### PR TITLE
Replace aws with fog

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,14 +40,6 @@ GEM
     addressable (2.2.0)
     arel (1.0.1)
       activesupport (~> 3.0.0)
-    aws (2.3.20)
-      http_connection
-      uuidtools
-      xml-simple
-    aws-s3 (0.6.2)
-      builder
-      mime-types
-      xml-simple
     bson (1.0.4)
     bson_ext (1.0.4)
     builder (2.1.2)
@@ -77,10 +69,20 @@ GEM
       data_objects (= 0.10.2)
     erubis (2.6.6)
       abstract (>= 1.0.0)
+    excon (0.2.0)
     extlib (0.9.15)
+    fog (0.2.30)
+      builder
+      excon (>= 0.2.0)
+      formatador (>= 0.0.15)
+      json
+      mime-types
+      net-ssh
+      nokogiri (>= 1.4.3.1)
+      ruby-hmac
+    formatador (0.0.15)
     gherkin (2.1.5)
       trollop (~> 1.16.2)
-    http_connection (1.3.0)
     i18n (0.4.1)
     image_science (1.2.1)
     json (1.4.6)
@@ -100,6 +102,8 @@ GEM
       mongo (= 1.0.7)
       tzinfo (~> 0.3.22)
       will_paginate (~> 3.0.pre)
+    net-ssh (2.0.23)
+    nokogiri (1.4.3.1)
     polyglot (0.3.1)
     rack (1.2.1)
     rack-mount (0.6.13)
@@ -122,6 +126,7 @@ GEM
     rake (0.8.7)
     rmagick (2.13.1)
     rspec (1.3.0)
+    ruby-hmac (0.4.0)
     sequel (3.14.0)
     sqlite3-ruby (1.3.1)
     subexec (0.0.4)
@@ -132,9 +137,7 @@ GEM
       polyglot (>= 0.3.1)
     trollop (1.16.2)
     tzinfo (0.3.23)
-    uuidtools (2.1.1)
     will_paginate (3.0.pre2)
-    xml-simple (1.0.12)
 
 PLATFORMS
   ruby
@@ -142,8 +145,6 @@ PLATFORMS
 DEPENDENCIES
   RubyInline
   activesupport (~> 3.0.0)
-  aws
-  aws-s3
   bson_ext
   carrierwave!
   cucumber
@@ -151,6 +152,7 @@ DEPENDENCIES
   dm-migrations
   dm-sqlite-adapter
   dm-validations
+  fog (~> 0.2.30)
   image_science
   json
   mini_magick (~> 2.1)

--- a/README.rdoc
+++ b/README.rdoc
@@ -320,10 +320,10 @@ CarrierWave comes with some RSpec matchers which you may find useful:
 
 == Using Amazon S3
 
-Older versions of CarrierWave used the +aws-s3+ and +right_aws+ libraries. The Aws[http://github.com/appoxy/aws]
-is now used meaning european buckets are supported out the box. Ensure you have it installed:
+Older versions of CarrierWave used the +aws+, +aws-s3+, and/or +right_aws+ libraries.
+Now fog[http://github.com/geemus/fog] is now used instead. Ensure you have it installed:
 
-    gem install aws
+    gem install fog
 
 You'll need to configure a bucket, access id and secret key like this:
 

--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rails", ["~> 3.0.0"]
   s.add_development_dependency "rspec", ["~> 1.3.0"]
-  s.add_development_dependency "aws"
+  s.add_development_dependency "fog", ["~> 0.2.30"]
   s.add_development_dependency "cucumber"
   s.add_development_dependency "sqlite3-ruby"
   s.add_development_dependency "dm-core"
@@ -40,7 +40,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "mini_magick", ["~> 2.1"]
   s.add_development_dependency "mongoid", ["= 2.0.0.beta.17"]
   s.add_development_dependency "bson_ext"
-  s.add_development_dependency "aws-s3"
   s.add_development_dependency "timecop"
   s.add_development_dependency "json"
 end

--- a/lib/carrierwave/storage/right_s3.rb
+++ b/lib/carrierwave/storage/right_s3.rb
@@ -1,3 +1,1 @@
-
-raise "The right_aws library is no longer supported. Please install the updated 'aws' library with support for Ruby 1.9 and euro buckets"
-
+raise "The right_aws library is no longer supported. Please install the 'fog' gem instead."

--- a/lib/carrierwave/storage/s3.rb
+++ b/lib/carrierwave/storage/s3.rb
@@ -1,28 +1,22 @@
 # encoding: utf-8
 begin
-  require 'aws'
+  require 'fog'
 rescue LoadError
-  raise "You don't have the 'aws' gem installed. 'aws-s3' and 'right_aws' are no longer supported."
+  raise "You don't have the 'fog' gem installed. The 'aws', 'aws-s3' and 'right_aws' gems are no longer supported."
 end
-
-require 'active_support/inflector'
 
 module CarrierWave
   module Storage
 
     ##
-    # Uploads things to Amazon S3 webservices using the "aws" library (aws gem). 
-    # In order for CarrierWave to connect to Amazon S3, you'll need to specify an access key id, secret key
-    # and bucket
+    # Uploads things to Amazon S3 using the "fog" gem.
+    # You'll need to specify the access_key_id, secret_access_key and bucket.
     #
     #     CarrierWave.configure do |config|
     #       config.s3_access_key_id = "xxxxxx"
     #       config.s3_secret_access_key = "xxxxxx"
     #       config.s3_bucket = "my_bucket_name"
     #     end
-    #
-    # The AWS::S3Interface is used directly as opposed to the normal AWS::S3::Bucket et.al. classes.
-    # This gives much improved performance and avoids unnecessary requests.
     #
     # You can set the access policy for the uploaded files:
     #
@@ -53,7 +47,7 @@ module CarrierWave
     #     end
     #
     # Now the resulting url will be
-    #     
+    #
     #     http://bucketname.domain.tld/path/to/file
     #
     # instead of
@@ -89,16 +83,16 @@ module CarrierWave
         # [String] contents of the file
         #
         def read
-          result = connection.get(bucket, @path)
-          @headers = result[:headers]
-          result[:object]
+          result = connection.get_object(bucket, @path)
+          @headers = result.headers
+          result.body
         end
 
         ##
         # Remove the file from Amazon S3
         #
         def delete
-          connection.delete(bucket, @path)
+          connection.delete_object(bucket, @path)
         end
 
         ##
@@ -118,10 +112,10 @@ module CarrierWave
 
         def store(file)
           content_type ||= file.content_type # this might cause problems if content type changes between read and upload (unlikely)
-          connection.put(bucket, @path, file.read,
+          connection.put_object(bucket, @path, file.read,
             {
               'x-amz-acl' => access_policy,
-              'content-type' => content_type
+              'Content-Type' => content_type
             }.merge(@uploader.s3_headers)
           )
         end
@@ -129,7 +123,7 @@ module CarrierWave
         # The Amazon S3 Access policy ready to send in storage request headers.
         def access_policy
           return @access_policy unless @access_policy.blank?
-          if @uploader.s3_access_policy.blank? 
+          if @uploader.s3_access_policy.blank?
             if !@uploader.s3_access.blank?
               @access_policy = @uploader.s3_access.to_s.gsub(/_/, '-')
             else
@@ -141,20 +135,20 @@ module CarrierWave
         end
 
         def content_type
-          headers["content-type"]
+          headers["Content-Type"]
         end
 
         def content_type=(type)
-          headers["content-type"] = type
+          headers["Content-Type"] = type
         end
 
         # Headers returned from file retrieval
         def headers
           @headers ||= {}
         end
- 
+
       private
-    
+
         def bucket
           @uploader.s3_bucket
         end
@@ -174,7 +168,7 @@ module CarrierWave
       #
       # === Returns
       #
-      # [CarrierWave::Storage::RightS3::File] the stored file
+      # [CarrierWave::Storage::S3::File] the stored file
       #
       def store!(file)
         f = CarrierWave::Storage::S3::File.new(uploader, self, uploader.store_path)
@@ -190,16 +184,16 @@ module CarrierWave
       #
       # === Returns
       #
-      # [CarrierWave::Storage::RightS3::File] the stored file
+      # [CarrierWave::Storage::S3::File] the stored file
       #
       def retrieve!(identifier)
         CarrierWave::Storage::S3::File.new(uploader, self, uploader.store_path(identifier))
       end
 
       def connection
-        @connection ||= Aws::S3Interface.new(
-          uploader.s3_access_key_id, uploader.s3_secret_access_key,
-          :multi_thread => uploader.s3_multi_thread
+        @connection ||= Fog::AWS::S3.new(
+          :aws_access_key_id => uploader.s3_access_key_id,
+          :aws_secret_access_key => uploader.s3_secret_access_key
         )
       end
 

--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -8,14 +8,13 @@ module CarrierWave
         add_config :root
         add_config :permissions
         add_config :storage_engines
-        add_config :s3_access # for old aws/s3
-        add_config :s3_access_policy # for aws
+        add_config :s3_access # for old s3 support
+        add_config :s3_access_policy # for new s3 support
         add_config :s3_bucket
         add_config :s3_access_key_id
         add_config :s3_secret_access_key
         add_config :s3_cnamed
         add_config :s3_headers
-        add_config :s3_multi_thread
         add_config :cloud_files_username
         add_config :cloud_files_api_key
         add_config :cloud_files_container
@@ -48,10 +47,7 @@ module CarrierWave
             :cloud_files => "CarrierWave::Storage::CloudFiles"
           }
           config.storage = :file
-          #config.s3_access = :public_read
-          #config.s3_access_policy = 'public-read' # Now set in library
           config.s3_headers = {}
-          config.s3_multi_thread = true
           config.grid_fs_database = 'carrierwave'
           config.grid_fs_host = 'localhost'
           config.grid_fs_port = 27017


### PR DESCRIPTION
As discussed in this thread:

http://github.com/jnicklas/carrierwave/issues#issue/101

...this is an attempt to switch out the aws gem in favor of the fog gem.

I'm not 100% sure how we'd like to go about further testing and/or benchmarks. Sam, did you have any ideas about that, or would you like me to give something a shot on my own?

If we decide to go ahead with fog I'd be happy to investigate using that for the Cloudfiles support as well. I think it supports that, too.

Note that fog introduces some other gem dependencies, as you'll see if you run "bundle install" and I'm not sure if you guys will be comfortable with that. 

Also, as discussed in this issue:

http://github.com/jnicklas/carrierwave/issues/closed#issue/103

...I'm having trouble running all of the tests. I was able to get things going well enough to run the S3 tests, though, and I don't think I've broken anything else. It's tough to be sure, though. I also tested with a sample Rails app that I have locally, and things seem to be working. Are you guys having trouble with the tests? In any case, can you run them if you decide to pull this change, just to make sure I'm in the green. 

Finally, I'm having trouble with the "url upload" support, but I'm not sure if that's related to this change. I think this issue is about that:

http://github.com/jnicklas/carrierwave/issues#issue/98

Anyway - sorry for the long pull request! ;)

Let me know how I might be able to help from here. Thanks!
