### PR TITLE
Reuse existing GridFS connection

### DIFF
--- a/lib/carrierwave/storage/grid_fs.rb
+++ b/lib/carrierwave/storage/grid_fs.rb
@@ -53,7 +53,7 @@ module CarrierWave
       protected
 
         def database
-          @connection ||= begin
+          @connection ||= @uploader.grid_fs_connection || begin
             host = @uploader.grid_fs_host
             port = @uploader.grid_fs_port
             database = @uploader.grid_fs_database

--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -20,6 +20,7 @@ module CarrierWave
         add_config :cloud_files_api_key
         add_config :cloud_files_container
         add_config :cloud_files_cdn_host
+        add_config :grid_fs_connection
         add_config :grid_fs_database
         add_config :grid_fs_host
         add_config :grid_fs_port


### PR DESCRIPTION
Hi Jonas,

Here is a small feature addition which you already replied on in [the past](http://github.com/jeroenvandijk/carrierwave/commit/54dbde7713db186824dec3a95d26b91e56103c8a#comments).  This doesn't break the API as the previous one you already commented on. It would be nice if you could merge it in.

Thanks in advance,
Jeroen

Ps I think my previous pull request got lost in your inbox. With the new github interface I thought to give it another try
