### PR TITLE
Reuse existing GridFS connection with specs and docs

### DIFF
--- a/lib/carrierwave/storage/grid_fs.rb
+++ b/lib/carrierwave/storage/grid_fs.rb
@@ -7,6 +7,34 @@ module CarrierWave
     ##
     # The GridFS store uses MongoDB's GridStore file storage system to store files
     #
+    # There are two ways of configuring the GridFS connection. Either you create a
+    # connection or you reuse an existing connection.
+    #
+    # Creating a connection looks something like this:
+    # 
+    #     CarrierWave.configure do |config|
+    #       config.storage = :grid_fs
+    #       config.grid_fs_host = "your-host.com"
+    #       config.grid_fs_port = "27017"
+    #       config.grid_fs_database = "your_dbs_app_name"
+    #       config.grid_fs_username = "user"
+    #       config.grid_fs_password = "verysecret"
+    #       config.grid_fs_access_url = "/images"
+    #     end
+    #
+    #   In the above example your documents url will look like:
+    #   
+    #      http://your-app.com/images/:document-identifier-here
+    #
+    # When you already have a Mongo connection object (for example through Mongoid)
+    # you can also reuse this connection:
+    #
+    #     CarrierWave.configure do |config|
+    #       config.storage = :grid_fs
+    #       config.grid_fs_connection = Mongoid.database
+    #       config.grid_fs_access_url = "/images"
+    #     end
+    #
     class GridFS < Abstract
 
       class File
@@ -53,7 +81,7 @@ module CarrierWave
       protected
 
         def database
-          @connection ||= begin
+          @connection ||= @uploader.grid_fs_connection || begin
             host = @uploader.grid_fs_host
             port = @uploader.grid_fs_port
             database = @uploader.grid_fs_database

--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -19,6 +19,7 @@ module CarrierWave
         add_config :cloud_files_api_key
         add_config :cloud_files_container
         add_config :cloud_files_cdn_host
+        add_config :grid_fs_connection
         add_config :grid_fs_database
         add_config :grid_fs_host
         add_config :grid_fs_port

--- a/spec/storage/grid_fs_spec.rb
+++ b/spec/storage/grid_fs_spec.rb
@@ -3,61 +3,40 @@
 require 'spec_helper'
 require 'mongo'
 
-describe CarrierWave::Storage::GridFS do
-
-  before do
-    @database = Mongo::Connection.new('localhost', 27017).db('carrierwave_test')
-    @uploader = mock('an uploader')
-    @uploader.stub!(:grid_fs_database).and_return("carrierwave_test")
-    @uploader.stub!(:grid_fs_host).and_return("localhost")
-    @uploader.stub!(:grid_fs_port).and_return(27017)
-    @uploader.stub!(:grid_fs_access_url).and_return(nil)
-    @uploader.stub!(:grid_fs_username).and_return(nil)
-    @uploader.stub!(:grid_fs_password).and_return(nil)
-    
-    @grid = Mongo::GridFileSystem.new(@database)
-
-    @storage = CarrierWave::Storage::GridFS.new(@uploader)
-    @file = stub_tempfile('test.jpg', 'application/xml')
-  end
-  
-  after do
-    @grid.delete('uploads/bar.txt')
-  end
-
+shared_examples_for "a GridFS connection" do
   describe '#store!' do
     before do
       @uploader.stub!(:store_path).and_return('uploads/bar.txt')
       @grid_fs_file = @storage.store!(@file)
     end
-    
+  
     it "should upload the file to gridfs" do
       @grid.open('uploads/bar.txt', 'r').data.should == 'this is stuff'
     end
-    
+  
     it "should not have a path" do
       @grid_fs_file.path.should be_nil
     end
-    
+  
     it "should not have a URL" do
       @grid_fs_file.url.should be_nil
     end
-    
+  
     it "should be deletable" do
       @grid_fs_file.delete
       lambda {@grid.open('uploads/bar.txt', 'r')}.should raise_error(Mongo::GridFileNotFound)
     end
-    
+  
     it "should store the content type on GridFS" do
       @grid_fs_file.content_type.should == 'application/xml'
     end
-    
+  
     it "should have a file length" do
       @grid_fs_file.file_length.should == 13
     end
-    
-  end
   
+  end
+
   describe '#retrieve!' do
     before do
       @grid.open('uploads/bar.txt', 'w') { |f| f.write "A test, 1234" }
@@ -68,24 +47,70 @@ describe CarrierWave::Storage::GridFS do
     it "should retrieve the file contents from gridfs" do
       @grid_fs_file.read.chomp.should == "A test, 1234"
     end
-    
+  
     it "should not have a path" do
       @grid_fs_file.path.should be_nil
     end
-    
+  
     it "should not have a URL unless set" do
       @grid_fs_file.url.should be_nil
     end
-    
+  
     it "should return a URL if configured" do
       @uploader.stub!(:grid_fs_access_url).and_return("/image/show")
       @grid_fs_file.url.should == "/image/show/uploads/bar.txt"
     end
-    
+  
     it "should be deletable" do
       @grid_fs_file.delete
       lambda {@grid.open('uploads/bar.txt', 'r')}.should raise_error(Mongo::GridFileNotFound)
     end
   end
+  
+end
 
+describe CarrierWave::Storage::GridFS do
+  
+  before do
+    @database = Mongo::Connection.new('localhost', 27017).db('carrierwave_test')
+
+    @uploader = mock('an uploader')
+    @uploader.stub!(:grid_fs_access_url).and_return(nil)
+  end
+
+  context "when reusing an existing connection manually" do
+    before do
+      @uploader.stub!(:grid_fs_connection).and_return(@database)
+      
+      @grid = Mongo::GridFileSystem.new(@database)
+
+      @storage = CarrierWave::Storage::GridFS.new(@uploader)
+      @file = stub_tempfile('test.jpg', 'application/xml')
+    end
+  
+    it_should_behave_like "a GridFS connection"
+  end
+
+  context "when setting a connection manually" do
+    before do
+      @uploader.stub!(:grid_fs_database).and_return("carrierwave_test")
+      @uploader.stub!(:grid_fs_host).and_return("localhost")
+      @uploader.stub!(:grid_fs_port).and_return(27017)
+      @uploader.stub!(:grid_fs_username).and_return(nil)
+      @uploader.stub!(:grid_fs_password).and_return(nil)
+      @uploader.stub!(:grid_fs_connection).and_return(nil)
+      
+      @grid = Mongo::GridFileSystem.new(@database)
+
+      @storage = CarrierWave::Storage::GridFS.new(@uploader)
+      @file = stub_tempfile('test.jpg', 'application/xml')
+    end
+  
+    it_should_behave_like "a GridFS connection"
+  end
+  
+  after do
+    @grid.delete('uploads/bar.txt')
+  end
+  
 end


### PR DESCRIPTION
See this previous [pull request](http://github.com/jnicklas/carrierwave/pull/118) for more info

It is the same patch, but with specs and documentation

Please let me know if I can improve things further

Thanks,

Jeroen
