### PR TITLE
Get headers of S3 files

### DIFF
--- a/lib/carrierwave/storage/s3.rb
+++ b/lib/carrierwave/storage/s3.rb
@@ -143,7 +143,7 @@ module CarrierWave
         end
 
         def size
-         	headers['content-length'].to_i
+           headers['Content-Length'].to_i
         end
 
         # Headers returned from file retrieval


### PR DESCRIPTION
Apparently the method isn't #head, but it's rather #head_object. Also, the name of the 'content-length' header is 'Content-Length'.

I don't have any automated tests, but it worked on my machine...
