### PR TITLE
Use attr_protected for #{column}_filename for Mongoid and ActiveRecord to protect from mass-assignment flaws

### DIFF
--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -21,6 +21,8 @@ module CarrierWave
 
       include CarrierWave::Validations::ActiveModel
 
+      attr_protected column.to_sym
+
       validates_integrity_of column if uploader_option(column.to_sym, :validate_integrity)
       validates_processing_of column if uploader_option(column.to_sym, :validate_processing)
 

--- a/lib/carrierwave/orm/mongoid.rb
+++ b/lib/carrierwave/orm/mongoid.rb
@@ -11,6 +11,7 @@ module CarrierWave
     def mount_uploader(column, uploader, options={}, &block)
       options[:mount_on] ||= "#{column}_filename"
       field options[:mount_on]
+      attr_protected options[:mount_on].to_sym
       
       super
       

--- a/spec/orm/mongoid_spec.rb
+++ b/spec/orm/mongoid_spec.rb
@@ -78,7 +78,8 @@ describe CarrierWave::Mongoid do
 
       before do
         mongo_user_klass = reset_mongo_class
-        @document = mongo_user_klass.new(:image_filename => "test.jpg")
+        @document = mongo_user_klass.new
+        @document.image_filename = "test.jpg"
         @document.save
         @doc = MongoUser.first
       end


### PR DESCRIPTION
Hi guys,

I was thinking it's good that you add attr_protected for column in database that stores path to file. Otherwise, yo can trick carrierwave to use any file on the disk (say /etc/passwd) with simple Firebug hack. I just tried it last night one of applications and it's really a security threat when you output then attachments with send_file for example.

Please have a look at this commit: e722e348c1ca0ae2f8a1bd8cbda0162340d5920f. I have added attr_protected form Mongoid and ActiveRecord only, as these are the two ORMs I use.

Best,
H.
