### PR TITLE
Fog aws storage

### DIFF
--- a/lib/carrierwave/storage/s3.rb
+++ b/lib/carrierwave/storage/s3.rb
@@ -199,7 +199,7 @@ module CarrierWave
       end
 
       def connection
-        @connection ||= Fog::AWS::S3.new(
+        @connection ||= Fog::AWS::Storage.new(
           :aws_access_key_id => uploader.s3_access_key_id,
           :aws_secret_access_key => uploader.s3_secret_access_key
         )


### PR DESCRIPTION
The Fog::AWS::S3 class throws a deprecation warning with fog 0.3.5 stating that Fog::AWS::Storage should be used instead.
