### PR TITLE
Mini magick fix for uploader tests

### DIFF
--- a/lib/carrierwave/test/matchers.rb
+++ b/lib/carrierwave/test/matchers.rb
@@ -111,10 +111,10 @@ module CarrierWave
 
       class ImageLoader # :nodoc:
         def self.load_image(filename)
-          if defined? MiniMagick
+          if defined? ::MiniMagick
             MiniMagickWrapper.new(filename)
           else
-            unless defined? Magick
+            unless defined? ::Magick
               begin
                 require 'rmagick'
               rescue LoadError


### PR DESCRIPTION
Hey guys. 
I'm updating an application to Rails 2.3.9 and took the opportunity to update some other gems, then I got this error with CarrierWave 0.4.10 in uploader tests only:

```
NameError in 'PhotoUploader should resize 'large' version to fit within 200x250 pixels'
uninitialized constant MiniMagick
```

This fixes the issue by checking if MiniMagick is defined at the top level. I also checked the master branch, it's already modified there, so I've also changed the ::Magick constant.
Please let me know if you need anything else, thanks.
