### PR TITLE
DataMapper fixes

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -76,6 +76,12 @@ Add a string column to the model you want to mount the uploader on:
 
     add_column :users, :avatar, :string
 
+If you are using DataMapper you just add
+
+    property :avatar, String, :auto_validate => false
+
+to your model. Then proceed as stated below.
+
 Open your model file and mount the uploader:
 
     class User


### PR DESCRIPTION
Added something to make life easier for folks using DataMapper.
Since DataMapper does not use migrations (or you can opt not to) you have to add

property :filename, String, :auto_validate => false

to your model file. (If you mount the uploader to :filename).

Without that nothing works and you get a weird No method error for .loaded? for Nil:Nilclass due to validations.

Regards

Kristoffer
