### PR TITLE
add fog provider

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,18 +69,18 @@ GEM
       data_objects (= 0.10.2)
     erubis (2.6.6)
       abstract (>= 1.0.0)
-    excon (0.2.3)
+    excon (0.2.4)
     extlib (0.9.15)
-    fog (0.3.7)
+    fog (0.3.25)
       builder
-      excon (>= 0.2.3)
-      formatador (>= 0.0.15)
+      excon (>= 0.2.4)
+      formatador (>= 0.0.16)
       json
       mime-types
       net-ssh (~> 2.0.23)
       nokogiri (~> 1.4.3.1)
       ruby-hmac
-    formatador (0.0.15)
+    formatador (0.0.16)
     gherkin (2.1.5)
       trollop (~> 1.16.2)
     i18n (0.4.1)
@@ -151,7 +151,7 @@ DEPENDENCIES
   dm-migrations
   dm-sqlite-adapter
   dm-validations
-  fog (~> 0.3.7)
+  fog (~> 0.3.25)
   image_science
   json
   mini_magick (~> 2.3)

--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rails", ["~> 3.0.0"]
   s.add_development_dependency "rspec", ["~> 1.3.0"]
-  s.add_development_dependency "fog", ["~> 0.3.7"]
+  s.add_development_dependency "fog", ["~> 0.3.25"]
   s.add_development_dependency "cucumber"
   s.add_development_dependency "sqlite3-ruby"
   s.add_development_dependency "dm-core"

--- a/lib/carrierwave.rb
+++ b/lib/carrierwave.rb
@@ -35,6 +35,7 @@ module CarrierWave
   module Storage
     autoload :Abstract, 'carrierwave/storage/abstract'
     autoload :File, 'carrierwave/storage/file'
+    autoload :Fog, 'carrierwave/storage/fog'
     autoload :S3, 'carrierwave/storage/s3'
     autoload :GridFS, 'carrierwave/storage/grid_fs'
     autoload :RightS3, 'carrierwave/storage/right_s3'

--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -1,0 +1,139 @@
+# encoding: utf-8
+
+begin
+  require 'fog'
+rescue LoadError
+  raise "You don't have the 'fog' gem installed"
+end
+
+module CarrierWave
+  module Storage
+
+    class Fog < Abstract
+
+      ##
+      # Store a file
+      #
+      # === Parameters
+      #
+      # [file (CarrierWave::SanitizedFile)] the file to store
+      #
+      # === Returns
+      #
+      # [CarrierWave::Storage::Fog::File] the stored file
+      #
+      def store!(file)
+        f = CarrierWave::Storage::Fog::File.new(uploader, self, uploader.store_path)
+        f.store(file)
+        f
+      end
+
+      ##
+      # Retrieve a file
+      #
+      # === Parameters
+      #
+      # [identifier (String)] unique identifier for file
+      #
+      # === Returns
+      #
+      # [CarrierWave::Storage::Fog::File] the stored file
+      #
+      def retrieve!(identifier)
+        CarrierWave::Storage::Fog::File.new(uploader, self, uploader.store_path(identifier))
+      end
+
+      def connection
+        @connection ||= begin
+          params = case uploader.fog_provider
+          when 'AWS'
+            {
+              :aws_access_key_id      => uploader.fog_aws_access_key_id,
+              :aws_secret_access_key  => uploader.fog_aws_secret_access_key,
+              :region                 => uploader.fog_aws_region
+            }
+          when 'Google'
+            {
+              :google_storage_access_key_id     => uploader.fog_google_storage_access_key_id,
+              :google_storage_secret_access_key => uploader.fog_google_storage_secret_access_key
+            }
+          when 'Local'
+            {
+              :local_root => uploader.fog_local_root
+            }
+          when 'Rackspace'
+            {
+              :rackspace_username => uploader.fog_rackspace_username,
+              :rackspace_api_key  => uploader.fog_rackspace_api_key
+            }
+          end
+          ::Fog::Storage.new(params.merge!(:provider => uploader.fog_provider))
+        end
+      end
+
+      class File
+
+        attr_reader :path
+
+        def content_type
+          file.content_type
+        end
+
+        def delete
+          file.destroy
+        end
+
+        def initialize(uploader, base, path)
+          @uploader, @base, @path = uploader, base, path
+        end
+
+        def read
+          file.body
+        end
+
+        def size
+          file.content_length
+        end
+
+        def store(new_file)
+          @file = directory.files.create({
+            :body         => new_file.read,
+            :content_type => new_file.content_type,
+            :key          => path,
+            :public       => @uploader.fog_public
+          })
+        end
+
+        def public_url
+          if @uploader.fog_host
+            @uploader.fog_host << '/' << path
+          else
+            file.public_url
+          end
+        end
+
+      private
+
+        def connection
+          @base.connection
+        end
+
+        def directory
+          @directory ||= begin
+            connection.directories.get(@uploader.fog_directory) || connection.directories.create(
+              :key    => @uploader.fog_directory,
+              :public => @uploader.fog_public
+            )
+          end
+        end
+
+        def file
+          @file ||= directory.files.get(path)
+        end
+
+      end
+
+    end # Fog
+
+  end # Storage
+end # CarrierWave

--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -32,6 +32,20 @@ module CarrierWave
         add_config :ensure_multipart_form
         add_config :delete_tmp_file_after_storage
 
+        # fog
+        add_config :fog_directory
+        add_config :fog_host
+        add_config :fog_provider
+        add_config :fog_public
+        add_config :fog_aws_access_key_id
+        add_config :fog_aws_secret_access_key
+        add_config :fog_aws_region
+        add_config :fog_google_storage_access_key_id
+        add_config :fog_google_storage_secret_access_key
+        add_config :fog_local_root
+        add_config :fog_rackspace_username
+        add_config :fog_rackspace_api_key
+
         # Mounting
         add_config :ignore_integrity_errors
         add_config :ignore_processing_errors
@@ -43,6 +57,7 @@ module CarrierWave
           config.permissions = 0644
           config.storage_engines = {
             :file => "CarrierWave::Storage::File",
+            :fog => "CarrierWave::Storage::Fog",
             :s3 => "CarrierWave::Storage::S3",
             :grid_fs => "CarrierWave::Storage::GridFS",
             :right_s3 => "CarrierWave::Storage::RightS3",

--- a/spec/storage/fog_spec.rb
+++ b/spec/storage/fog_spec.rb
@@ -1,0 +1,142 @@
+# encoding: utf-8
+
+require 'spec_helper'
+require 'open-uri'
+
+require 'fog'
+
+if ENV['FOG_MOCK'] == 'true'
+  Fog.mock!
+end
+
+if ENV['PROVIDER']
+  describe CarrierWave::Storage::Fog do
+    describe ENV['PROVIDER'] do
+      before do
+        @bucket = ENV['CARRIERWAVE_TEST_BUCKET']
+        @uploader = mock('an uploader')
+        @uploader.stub!(:fog_directory).and_return(@bucket)
+        @uploader.stub!(:fog_host).and_return(nil)
+        @uploader.stub!(:fog_public).and_return(true)
+        @uploader.stub!(:fog_provider).and_return(ENV['PROVIDER'])
+        case ENV['PROVIDER']
+        when 'AWS'
+          @uploader.stub!(:fog_aws_access_key_id).and_return(ENV['S3_ACCESS_KEY_ID'])
+          @uploader.stub!(:fog_aws_secret_access_key).and_return(ENV['S3_SECRET_ACCESS_KEY'])
+          @uploader.stub!(:fog_aws_region).and_return(ENV['S3_REGION'] || 'us-east-1')
+        when 'Google'
+          @uploader.stub!(:fog_google_storage_access_key_id).and_return(ENV['GOOGLE_STORAGE_ACCESS_KEY_ID'])
+          @uploader.stub!(:fog_google_storage_secret_access_key).and_return(ENV['GOOGLE_STORAGE_SECRET_ACCESS_KEY'])
+        when 'Local'
+          @uploader.stub!(:fog_local_root).and_return(ENV['LOCAL_ROOT'])
+        when 'Rackspace'
+          @uploader.stub!(:fog_rackspace_username).and_return(ENV['RACKSPACE_USERNAME'])
+          @uploader.stub!(:fog_rackspace_api_key).and_return(ENV['RACKSPACE_API_KEY'])
+        end
+        @uploader.stub!(:store_path).and_return('uploads/bar.txt')
+
+        @storage = CarrierWave::Storage::Fog.new(@uploader)
+        @directory = @storage.connection.directories.new(:key => @bucket)
+        @file = CarrierWave::SanitizedFile.new(file_path('test.jpg'))
+      end
+
+      describe '#store!' do
+        before do
+          @uploader.stub!(:store_path).and_return('uploads/bar.txt')
+          @fog_file = @storage.store!(@file)
+        end
+
+        it "should upload the file" do
+          @directory.files.get('uploads/bar.txt').body.should == 'this is stuff'
+        end
+
+        it "should have a path" do
+          @fog_file.path.should == 'uploads/bar.txt'
+        end
+
+        context "without fog_host" do
+          it "should have a public_url" do
+            pending if ENV['PROVIDER'] == 'Local'
+            @fog_file.public_url.should_not be_nil
+          end
+        end
+
+        context "with fog_host" do
+          it "should have a fog_host rooted url" do
+            @uploader.stub!(:fog_host).and_return('http://foo.bar')
+            @fog_file.public_url.should == 'http://foo.bar/uploads/bar.txt'
+          end
+        end
+
+        it "should return filesize" do
+          @fog_file.size.should == 13
+        end
+
+        it "should be deletable" do
+          @fog_file.delete
+          @directory.files.head('uploads/bar.txt').should == nil
+        end
+      end
+
+      describe '#retrieve!' do
+        before do
+          @directory.files.create(:key => 'uploads/bar.txt', :body => 'A test, 1234', :public => true)
+          @uploader.stub!(:store_path).with('bar.txt').and_return('uploads/bar.txt')
+          @fog_file = @storage.retrieve!('bar.txt')
+        end
+
+        it "should retrieve the file contents" do
+          @fog_file.read.chomp.should == "A test, 1234"
+        end
+
+        it "should have a path" do
+          @fog_file.path.should == 'uploads/bar.txt'
+        end
+
+        it "should have a public url" do
+          pending if ENV['PROVIDER'] == 'Local'
+          @fog_file.public_url.should_not be_nil
+        end
+
+        it "should return filesize" do
+          @fog_file.size.should == 12
+        end
+
+        it "should be deletable" do
+          @fog_file.delete
+          @directory.files.head('uploads/bar.txt').should == nil
+        end
+      end
+
+      describe 'fog_public' do
+        after do
+          @directory.files.get('uploads/bar.txt').destroy
+          @directory.destroy
+        end
+
+        context "true" do
+          before do
+            @fog_file = @storage.store!(@file)
+          end
+
+          it "should be available at public URL" do
+            pending if ENV['PROVIDER'] == 'Local'
+            open(@fog_file.public_url).read.should == 'this is stuff'
+          end
+        end
+
+        context "false" do
+          before do
+            @uploader.stub!(:fog_public).and_return(false)
+            @fog_file = @storage.store!(@file)
+          end
+
+          it "should not be available at public URL" do
+            pending if ENV['PROVIDER'] == 'Local'
+            @fog_file.public_url.should be_nil
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
First off, thanks for using fog for your s3 stuff, I was happy to hear that it was working well for you!

As a thank you and to help out I wanted to help out and give back a more thorough fog using example.

So this provides a separate for storage option.  Depending on which credentials you pass in it should be fully functional as AWS S3, Google Storage, Local (stores things in a specified directory) or Rackspace Files.  I did some work in fog to try and make it as transparent as possible and hopefully you'll see the advantages of having a single workflow for all the services.

A couple other possible benefits are that fog is being actively developed and supported, so you should be able to get more providers when they get added for close to free.

It also opens up the possibility of your end users (and your tests for that matter) to use fogs mocks for some or all of the testing.  These can be enabled with Fog.mock! and simulate the usage of things in memory.  Note that a couple acl related things are not yet mocked and neither is Rackspace Files (but missing stuff is getting filled in all the time).

If you wanted to it could follow the pattern set by the right_s3 storage option and add deprecation warnings for old providers and replace them with this single provider. I think that is what I would do, but I have a vested interest ;) so I thought I would just provide you with the options and let you guys decide how to proceed.

If you have any questions or concerns just let me know and I'll try to get them sorted out.

Thanks!
wes
