### PR TITLE
Fixes #137 (ignore case in extension_white_list) and add support for Regexp's

### DIFF
--- a/lib/carrierwave/uploader/extension_whitelist.rb
+++ b/lib/carrierwave/uploader/extension_whitelist.rb
@@ -11,11 +11,15 @@ module CarrierWave
 
       ##
       # Override this method in your uploader to provide a white list of extensions which
-      # are allowed to be uploaded.
+      # are allowed to be uploaded. Compares the file's extension case insensitive.
+      # Furthermore, not only strings but Regexp are allowed as well.
+      #
+      # When using a Regexp in the white list, `\A` and `\z` are automatically added to
+      # the Regexp expression, also case insensitive.
       #
       # === Returns
       #
-      # [NilClass, Array[String]] a white list of extensions which are allowed to be uploaded
+      # [NilClass, Array[String,Regexp]] a white list of extensions which are allowed to be uploaded
       #
       # === Examples
       #
@@ -23,12 +27,19 @@ module CarrierWave
       #       %w(jpg jpeg gif png)
       #     end
       #
+      # Basically the same, but using a Regexp:
+      #
+      #     def extension_white_list
+      #       [/jpe?g/, 'gif', 'png']
+      #     end
+      #
       def extension_white_list; end
 
     private
 
       def check_whitelist!(new_file)
-        if extension_white_list and not extension_white_list.include?(new_file.extension.to_s)
+        ext = new_file.extension.to_s.downcase # downcase not really necessary, already done in SanitizedFile#sanitize, but well
+        if extension_white_list and not extension_white_list.find { |check| check.respond_to?(:to_str) ? check.to_str.downcase == ext : ext =~ /\A#{check}\z/i }
           raise CarrierWave::IntegrityError, "You are not allowed to upload #{new_file.extension.inspect} files, allowed types: #{extension_white_list.inspect}"
         end
       end

--- a/spec/fixtures/case.JPG
+++ b/spec/fixtures/case.JPG
@@ -1,0 +1,1 @@
+this is stuff

--- a/spec/uploader/extension_whitelist_spec.rb
+++ b/spec/uploader/extension_whitelist_spec.rb
@@ -39,6 +39,27 @@ describe CarrierWave::Uploader do
         @uploader.cache!(File.open(file_path('test.jpg')))
       }.should raise_error(CarrierWave::IntegrityError)
     end
+    
+    it "should compare white list in a case insensitive manner" do
+      @uploader.stub!(:extension_white_list).and_return(%w(jpg gif png))
+      running {
+        @uploader.cache!(File.open(file_path('case.JPG')))
+      }.should_not raise_error(CarrierWave::IntegrityError)
+    end
+    
+    it "should ignore case of extensions provided by white list" do
+      @uploader.stub!(:extension_white_list).and_return(%w(JPG GIF PNG))
+      running {
+        @uploader.cache!(File.open(file_path('test.jpg')))
+      }.should_not raise_error(CarrierWave::IntegrityError)
+    end    
+    
+    it "should accept and check regular expressions" do
+      @uploader.stub!(:extension_white_list).and_return([/jpe?g/, 'gif', 'png'])
+      running {
+        @uploader.cache!(File.open(file_path('test.jpeg')))
+      }.should_not raise_error(CarrierWave::IntegrityError)      
+    end    
   end
 
 end


### PR DESCRIPTION
Even though #137 appears to probably be already solved by that downcase on https://github.com/jnicklas/carrierwave/blob/master/lib/carrierwave/sanitized_file.rb#L254, but the changed check now also ensures that mappings are downcased and such - and it adds specs for it.

Also I've added support for regular expressions in the whitelist, might come in handy here and there (with tests as well...)
