### PR TITLE
original_filename of remote uploads should be calculated from final (possibly redirected) URL.

### DIFF
--- a/lib/carrierwave/uploader/download.rb
+++ b/lib/carrierwave/uploader/download.rb
@@ -17,7 +17,7 @@ module CarrierWave
         end
 
         def original_filename
-          File.basename(@uri.path)
+          File.basename(file.base_uri.path)
         end
 
         def respond_to?(*args)


### PR DESCRIPTION
Hello,

The info is in the commit message, but in short:

I ran into an issue getting images from the Facebook Graph API, wherein if the remote URL didn't have an extension on it, the extension whitelisting would complain in Carrierwave. I've changed it to use the file (possible redirected) URL to calculate #original_filename, which has fixed the problem.

All tests (except Mongo, for some reason?) pass on my local machine. The Mongo tests failed on a clean history as well, so I'm assuming I haven't bunged it up.
