### PR TITLE
Fix nested versioning processing

### DIFF
--- a/lib/carrierwave/uploader/versions.rb
+++ b/lib/carrierwave/uploader/versions.rb
@@ -130,9 +130,15 @@ module CarrierWave
       end
 
       def cache_versions!(new_file)
+        # We might have processed the new_file argument after the callbacks were
+        # initialized, so get the actual file based off of the current state of
+        # our file
+        processed_parent = SanitizedFile.new :tempfile => self.file,
+          :filename => new_file.original_filename
+
         versions.each do |name, v|
           v.send(:cache_id=, cache_id)
-          v.cache!(new_file)
+          v.cache!(processed_parent)
         end
       end
 

--- a/spec/uploader/versions_spec.rb
+++ b/spec/uploader/versions_spec.rb
@@ -98,6 +98,31 @@ describe CarrierWave::Uploader do
         @uploader.thumb.micro.version_name.should == :thumb_micro
       end
 
+      it "should process nested versions" do
+        @uploader_class.class_eval {
+          include CarrierWave::MiniMagick
+
+          version :rotated do
+            process :rotate
+
+            version :boxed do
+              process :resize_to_fit => [200, 200]
+            end
+          end
+
+          def rotate
+            manipulate! do |img|
+              img.rotate 90
+              img
+            end
+          end
+        }
+        @uploader.cache! File.open(file_path('portrait.jpg'))
+
+        @uploader.should have_dimensions(233, 337)
+        @uploader.rotated.should have_dimensions(337, 233)
+        @uploader.rotated.boxed.should have_dimensions(200, 138)
+      end
     end
 
   end


### PR DESCRIPTION
See the commit for the most details, but this is a split of [this](https://github.com/jnicklas/carrierwave/pull/168) pull request.

The gist of the issue, however, is that nested versions don't inherit from the processing which occurred in the parent because the callback is called with an argument for a file which is stale by that point. I got around this by wrapping it in a SanitizedFile pointing to our parent's processed version and then going from there.
