### PR TITLE
Allow reprocessing remote files

### DIFF
--- a/lib/carrierwave/uploader/processing.rb
+++ b/lib/carrierwave/uploader/processing.rb
@@ -9,7 +9,6 @@ module CarrierWave
 
       included do
         after :cache, :process!
-        after :recreate_versions, :process!
       end
 
       module ClassMethods


### PR DESCRIPTION
This is a split of [this](https://github.com/jnicklas/carrierwave/pull/168) pull request.

Before, whenever `recreate_versions!` was called on a file stored on a cloud solution (S3, GridFS, etc.), the processing would fail because the processing attempted to read a file which wasn't hosted on the server it was running off of.

This fix entails instead processing a version where it is first read from the remote source into a StringIO and then processing occurs from that point.

I also removed the `recrate_versions` callback because the processing is already done once a `store!` is called. This method will also update the remote file if necessary.
