### PR TITLE
Remove excessive container requests for Rackspace CloudFiles

### DIFF
--- a/lib/carrierwave/storage/cloud_files.rb
+++ b/lib/carrierwave/storage/cloud_files.rb
@@ -121,8 +121,12 @@ module CarrierWave
             if @cf_container
               @cf_container
             else
-              @cf_container = cf_connection.create_container(container)
-              @cf_container.make_public
+              begin
+                @cf_container = cf_connection.container(container)
+              rescue NoSuchContainerException
+                @cf_container = cf_connection.create_container(container)
+                @cf_container.make_public
+              end
               @cf_container
             end
           end


### PR DESCRIPTION
Currently the storage for cloudfiles attempts to create a container and make it public every request. I changed it to only create the container if the requested container does not exist.
