### PR TITLE
CarrierWave.root instead of root (which was nil)

### DIFF
--- a/lib/carrierwave/uploader/url.rb
+++ b/lib/carrierwave/uploader/url.rb
@@ -13,7 +13,7 @@ module CarrierWave
         if file.respond_to?(:url) and not file.url.blank?
           file.url
         elsif current_path
-          File.expand_path(current_path).gsub(File.expand_path(root), '')
+          File.expand_path(current_path).gsub(File.expand_path(CarrierWave.root), '')
         end
       end
 


### PR DESCRIPTION
Hi!

The "root" variable was nil when accessed from CarrierWave::Uploader::Url::url (in ruby ruby 1.8.7 ). So i had to write the full "CarrierWave.root" for it to work (on my Sinatra project).

I tested my patch on ruby 1.9.2 and all the tests are still passing. But on ruby 1.8.7 i get this error when running the tests: https://gist.github.com/848390 . So i can't seem to test on my side, but feel free tu pull if on your side the tests are still passing.
Let me know if there's something wrong with my fix.

Thanks for CarrierWave :)

Julien
