### PR TITLE
Paperclip compatibility fix

### DIFF
--- a/lib/carrierwave/compatibility/paperclip.rb
+++ b/lib/carrierwave/compatibility/paperclip.rb
@@ -77,17 +77,17 @@ module CarrierWave
       end
 
       def mappings
-        {
-          :rails_root   => lambda{|u, f| Rails.root },
-          :rails_env    => lambda{|u, f| Rails.env },
-          :class        => lambda{|u, f| u.model.class.name.underscore.pluralize},
-          :id           => lambda{|u, f| u.model.id },
-          :id_partition => lambda{|u, f| ("%09d" % u.model.id).scan(/\d{3}/).join("/")},
-          :attachment   => lambda{|u, f| u.mounted_as.to_s.downcase.pluralize },
-          :style        => lambda{|u, f| u.paperclip_style },
-          :basename     => lambda{|u, f| f.gsub(/#{File.extname(f)}$/, "") },
-          :extension    => lambda{|u, f| File.extname(f).gsub(/^\.+/, "")}
-        }
+        [
+          [:rails_root   , lambda{|u, f| Rails.root }],
+          [:rails_env    , lambda{|u, f| Rails.env }],
+          [:class        , lambda{|u, f| u.model.class.name.underscore.pluralize}],
+          [:id_partition , lambda{|u, f| ("%09d" % u.model.id).scan(/\d{3}/).join("/")}],
+          [:id           , lambda{|u, f| u.model.id }],
+          [:attachment   , lambda{|u, f| u.mounted_as.to_s.downcase.pluralize }],
+          [:style        , lambda{|u, f| u.paperclip_style }],
+          [:basename     , lambda{|u, f| f.gsub(/#{File.extname(f)}$/, "") }],
+          [:extension    , lambda{|u, f| File.extname(f).gsub(/^\.+/, "")}]
+        ]
       end
 
     end # Paperclip

--- a/spec/compatibility/paperclip_spec.rb
+++ b/spec/compatibility/paperclip_spec.rb
@@ -42,6 +42,11 @@ describe CarrierWave::Compatibility::Paperclip do
       @uploader.stub!(:paperclip_path).and_return("/foo/:id/bar")
       @uploader.store_path("monkey.png").should == "/foo/23/bar"
     end
+
+    it "should interpolate the id partition" do
+      @uploader.stub!(:paperclip_path).and_return("/foo/:id_partition/bar")
+      @uploader.store_path("monkey.png").should == "/foo/000/000/023/bar"
+    end
   end
 
 end


### PR DESCRIPTION
Hi,

working with the 0.4-stable branch in Rails 2.3.9 and ree-1.8.7 (production environment),  I noticed that depending on how ruby sorted the mappings hash, the :id_partition was correctly interpolated or not. If the :id interpolation comes before the :id_partition interpolation, whooops! :) We should ensure this doesn't happen.

I've replaced the mappings hash by an array containing arrays with the symbol and its interpolation and implemented a very simple example to test this case.

Hope it helps,

Mari.
