### PR TITLE
A little change on the clean_cached_files! method

### DIFF
--- a/lib/carrierwave/uploader/cache.rb
+++ b/lib/carrierwave/uploader/cache.rb
@@ -41,11 +41,11 @@ module CarrierWave
         # This only works as long as you haven't done anything funky with your cache_dir.
         # It's recommended that you keep cache files in one place only.
         #
-        def clean_cached_files!
+        def clean_cached_files!(seconds=60*60*24)
           Dir.glob(File.expand_path(File.join(cache_dir, '*'), CarrierWave.root)).each do |dir|
             time = dir.scan(/(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})/).first.map { |t| t.to_i }
             time = Time.utc(*time)
-            if time < (Time.now.utc - (60*60*24))
+            if time < (Time.now.utc - seconds)
               FileUtils.rm_rf(dir)
             end
           end

--- a/spec/uploader/cache_spec.rb
+++ b/spec/uploader/cache_spec.rb
@@ -23,11 +23,18 @@ describe CarrierWave::Uploader do
 
     after { FileUtils.rm_rf(@cache_dir) }
 
-    it "should clear all files older than 24 hours in the default cache directory" do
+    it "should clear all files older than, by defaul, 24 hours in the default cache directory" do
       Timecop.freeze(Time.utc(2007, 12, 6, 10, 12)) do
         @uploader_class.clean_cached_files!
       end
       Dir.glob("#{@cache_dir}/*").should have(1).element
+    end
+
+    it "should permit to set since how many seconds delete the cached files" do
+      Timecop.freeze(Time.utc(2007, 12, 6, 10, 12)) do
+        @uploader_class.clean_cached_files!(60*60*24*4)
+      end
+      Dir.glob("#{@cache_dir}/*").should have(2).element
     end
 
     it "should be aliased on the CarrierWave module" do


### PR DESCRIPTION
This is a useful method, but it would be even better with the ability to set since how many seconds delete the folders. 24 hours could be ok in most cases, but with a lot uploads the risk is to reach the 32k file system limit (ext3) before them. I kept 24 hours the default one so nothing should break.
