### PR TITLE
Don't ignore errors on Non-Production mode in Rails

### DIFF
--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -147,8 +147,8 @@ module CarrierWave
             config.store_dir = 'uploads'
             config.cache_dir = 'uploads/tmp'
             config.delete_tmp_file_after_storage = true
-            config.ignore_integrity_errors = true
-            config.ignore_processing_errors = true
+            config.ignore_processing_errors = config.ignore_integrity_errors =
+                (defined?(Rails) ? Rails.env.production? : true)
             config.validate_integrity = true
             config.validate_processing = true
             config.root = CarrierWave.root


### PR DESCRIPTION
Hi,

I recently got a new computer and had to re-setup my Rails environment. Due to ImageMagick not being in my ENV['PATH'], MiniMagick was throwing errors silently (as in, I got "Image failed to be processed" validation errors).

This was not helpful at all. After Googling the problem, I uninstalled the Homebrew version and installed from source only to find the same error. Uninstalled from source, reinstalled Homebrew, only to find the issue was a PATH issue all along (which I found after turning ignore errors off). I wasted a few hours over a very simple PATH change.

Therefore I am making this change to give more helpful error messages in non-production mode in Rails. I believe it will help others with the same issues, as I have followed a very default setup route on my new computer.

Thanks for the awesome Gem!
