### PR TITLE
Add option for versions to fall back to the original "pre-processed" image

### DIFF
--- a/lib/carrierwave/uploader/versions.rb
+++ b/lib/carrierwave/uploader/versions.rb
@@ -29,7 +29,7 @@ module CarrierWave
         # [name (#to_sym)] name of the version
         # [&block (Proc)] a block to eval on this version of the uploader
         #
-        def version(name, &block)
+        def version(name, options = {}, &block)
           name = name.to_sym
           unless versions[name]
             versions[name] = Class.new(self)
@@ -41,6 +41,7 @@ module CarrierWave
               end
             RUBY
           end
+          versions[name].use_original_image! if options[:use_original_image]
           versions[name].class_eval(&block) if block
           versions[name]
         end
@@ -52,6 +53,22 @@ module CarrierWave
         #
         def versions
           @versions ||= {}
+        end
+
+        ##
+        # Tells this version to use the original image as a base for processing
+        # 
+        def use_original_image!
+          @use_original_image = true
+        end
+
+        ##
+        # === Returns
+        # 
+        # [Boolean] true if this version is supposed to fall back to the original image as a base for processing
+        # 
+        def use_original_image?
+          !!@use_original_image
         end
 
       end # ClassMethods
@@ -144,7 +161,7 @@ module CarrierWave
 
         versions.each do |name, v|
           v.send(:cache_id=, cache_id)
-          v.cache!(processed_parent)
+          v.cache!(v.class.use_original_image? ? new_file : processed_parent)
         end
       end
 

--- a/spec/uploader/versions_spec.rb
+++ b/spec/uploader/versions_spec.rb
@@ -127,6 +127,64 @@ describe CarrierWave::Uploader do
 
   end
 
+  context 'with use_original_image ' do
+
+    describe "#use_original_image?" do
+
+      before do
+        @uploader_class.class_eval {
+          include CarrierWave::MiniMagick
+
+          process :resize_to_fit => [200, 200]
+          version :untouched
+        }
+      end
+
+      it "should leave version image untouched when using use_original_image? returns true" do
+        @uploader.untouched.class.stub!(:use_original_image?).and_return(true)
+        @uploader.cache! File.open(file_path('portrait.jpg'))
+
+        @uploader.should have_dimensions(138,200)
+        @uploader.untouched.should have_dimensions(233,337)
+      end
+
+      it "should use resized version image use_original_image? returns false" do
+        @uploader.cache! File.open(file_path('portrait.jpg'))
+
+        @uploader.should have_dimensions(138,200)
+        @uploader.untouched.should have_dimensions(138,200)
+      end
+    end
+
+    describe "#use_original_image!" do
+
+      before do
+        @uploader_class.version :untouched do
+          use_original_image!
+        end
+      end
+
+      it "should tell the version class to use_original_image" do
+        @uploader.untouched.class.use_original_image?.should be_true
+      end
+
+      it "should not effect the base uploader" do
+        @uploader.untouched.class.use_original_image?.should be_true
+        @uploader_class.use_original_image?.should be_false
+      end
+    end
+
+    describe "use_original_image option on version method" do
+
+      it "should tell the version class to use_original_image" do
+        @uploader_class.version :untouched
+        @uploader.untouched.class.should_receive :use_original_image!
+        @uploader_class.version :untouched, :use_original_image => true
+      end
+
+    end
+  end
+
   describe 'with a version' do
     before do
       @uploader_class.version(:thumb)


### PR DESCRIPTION
Add option for versions to fall back to the original "pre-processed" image as a starting point for their processing.

  Usage:

```
class FooUploader < CarrierWave::Uploader::Base

  version :untouched do
    use_original_image!
    # Other processing...
  end

  # or

  version :untouched, :use_original_image => true
end
```
