### PR TITLE
Fixed issue 282: Methods like @user.avatar? always return true when storage is AWS S3

### DIFF
--- a/lib/carrierwave/storage/s3.rb
+++ b/lib/carrierwave/storage/s3.rb
@@ -166,6 +166,12 @@ module CarrierWave
           end
         end
 
+        # when file not yet uploaded, size will be zero
+        def empty?
+          self.size.zero?
+        end
+        alias_method :blank?, :empty?
+
       private
 
         def use_ssl?


### PR DESCRIPTION
https://github.com/jnicklas/carrierwave/issues/282

Implemented the missing #empty?
