### PR TITLE
Decrease GridFS bloat by nuking versions

### DIFF
--- a/lib/carrierwave/storage/grid_fs.rb
+++ b/lib/carrierwave/storage/grid_fs.rb
@@ -61,7 +61,7 @@ module CarrierWave
         end
 
         def write(file)
-          grid.open(@uploader.store_path, 'w', :content_type => file.content_type) do |f|
+          grid.open(@uploader.store_path, 'w', :content_type => file.content_type, :delete_old => true) do |f|
             f.write(file.read)
           end
         end


### PR DESCRIPTION
Setting :delete_old on open for write call. This tells GridFS to nuke old versions of the same file, I was having problems with bloat on frequently updated files.
