### PR TITLE
The uri should be first unescaped and then escaped

### DIFF
--- a/lib/carrierwave/uploader/download.rb
+++ b/lib/carrierwave/uploader/download.rb
@@ -67,7 +67,7 @@ module CarrierWave
       # [url (String)] The URL where the remote file is stored
       #
       def process_uri(uri)
-        URI.parse(URI.escape(uri))
+        URI.parse(URI.escape(URI.unescape(uri)))
       end
 
     end # Download

--- a/spec/uploader/download_spec.rb
+++ b/spec/uploader/download_spec.rb
@@ -121,4 +121,17 @@ describe CarrierWave::Uploader::Download do
       }.should raise_error(CarrierWave::DownloadError)
     end
   end
+
+  describe '#process_uri' do
+    let(:uri) { "http://www.example.com/test%20image.jpg" }
+
+    it 'should unescape and then escape the given uri' do
+      unescaped_uri = URI.unescape(uri)
+      @uploader.process_uri(unescaped_uri).should == @uploader.process_uri(uri)
+    end
+
+    it 'should parse the given uri' do
+      @uploader.process_uri(uri).should == URI.parse(uri)
+    end
+  end
 end


### PR DESCRIPTION
I use carrierwave on production without big problems, but I've just found out that using the remote address in order to download images doesn't work quite good.

The uri is escaped, and that's good, but it should be first unescaped, as it's probable that users put the already escaped url (as they copy it from the browser or somewhere else)

I've added a simple test to it in order to show the problem, which is: "http://domain.com/test img.jpg" works, but "http://domain.com/test%20img.jpg" doesn't as it was considered as "http://domain.com/test%2520img.jpg", which is not the same :)

Hope to see this in the next version of cw ;)
