### PR TITLE
Links to DataMapper and Sequel projects in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -94,6 +94,13 @@ If using Mongoid, note that embedded documents files aren't saved when parent do
 You must explicitly call save on embedded documents in order to save their attached files.
 You can read more about this {here}[https://github.com/jnicklas/carrierwave/issues#issue/81]
 
+== DataMapper, Sequel
+
+Other ORM support has been extracted into separate gems. Learn more:
+
+* {DataMapper}[https://github.com/jnicklas/carrierwave-datamapper]
+* {Sequel}[https://github.com/jnicklas/carrierwave-sequel]
+
 == Changing the storage directory
 
 In order to change where uploaded files are put, just override the +store_dir+


### PR DESCRIPTION
Hey I just added info about other ORMS to README.

BTW - why did you extract only DM and Sequel and left AR and Mongoid in the main repo?
