### PR TITLE
Fix JSON output for Mongoid models.

### DIFF
--- a/lib/carrierwave/orm/mongoid.rb
+++ b/lib/carrierwave/orm/mongoid.rb
@@ -10,7 +10,7 @@ module CarrierWave
     # See +CarrierWave::Mount#mount_uploader+ for documentation
     #
     def mount_uploader(column, uploader=nil, options={}, &block)
-      options[:mount_on] ||= "#{column}_filename"
+      options[:mount_on] ||= column
       field options[:mount_on]
 
       super

--- a/spec/orm/mongoid_spec.rb
+++ b/spec/orm/mongoid_spec.rb
@@ -78,7 +78,8 @@ describe CarrierWave::Mongoid do
 
       before do
         mongo_user_klass = reset_mongo_class
-        @document = mongo_user_klass.new(:image_filename => "test.jpg")
+        @document = mongo_user_klass.new
+        @document[:image] = "test.jpg"
         @document.save
         @doc = MongoUser.first
       end
@@ -128,7 +129,7 @@ describe CarrierWave::Mongoid do
       end
 
       it "should write nothing to the database, to prevent overriden filenames to fail because of unassigned attributes" do
-        @doc.image_filename.should be_nil
+        @doc[:image].should be_nil
       end
 
       it "should copy a file into into the cache directory" do
@@ -224,7 +225,7 @@ describe CarrierWave::Mongoid do
       it "saves the filename in the database" do
         @doc.image = stub_file('test.jpg')
         @doc.save
-        @doc.image_filename.should == 'test.jpg'
+        @doc[:image].should == 'test.jpg'
       end
 
       context "when remove_image? is true" do
@@ -236,7 +237,7 @@ describe CarrierWave::Mongoid do
           @doc.save
           @doc.reload
           @doc.image.should be_blank
-          @doc.image_filename.should == ''
+          @doc[:image].should == ''
         end
 
       end


### PR DESCRIPTION
The default behavior for ActiveRecord the mount and the column name be identical. This is good, since it results in the uploader being included in to_json/as_json calls. E.g.:

> ruby-1.9.2-p180 :001 > u = User.first
>   User Load (0.3ms)  SELECT "users".\* FROM "users" LIMIT 1
>  => #<User id: 1, name: "Testy McTesterson", avatar: "plans.jpg", created_at: "2011-05-23 21:35:58", updated_at: "2011-05-23 21:35:58"> 
> ruby-1.9.2-p180 :002 > u.avatar
>  => /uploads/user/avatar/1/plans.jpg 
> ruby-1.9.2-p180 :003 > puts u.to_json
> {"avatar":{"url":"/uploads/user/avatar/1/plans.jpg"},"created_at":"2011-05-23T21:35:58Z","id":1,"name":"Testy McTesterson","updated_at":"2011-05-23T21:35:58Z"}

Mongoid currently appends "_filename" to the column name by default. This breaks JSON output. E.g.:

> ruby-1.9.2-p180 :001 > u = User.find '4ddae268e779891dc2000003'
>  => #<User _id: 4ddae268e779891dc2000003, created_at: 2011-05-23 22:40:41 UTC, updated_at: 2011-05-23 22:40:41 UTC, deleted_at: nil, name: "aoeuaoeu", photo_filename: "dogpipe.jpg"> 
> ruby-1.9.2-p180 :002 > u.photo
>  => /u/unsubscribe/photo/4ddae268e779891dc2000003/dogpipe.jpg 
> ruby-1.9.2-p180 :003 > puts u.to_json
> {"_id":"4ddae268e779891dc2000003","created_at":"2011-05-23T15:40:41-07:00","name":"aoeuaoeu","photo_filename":"dogpipe.jpg","updated_at":"2011-05-23T15:40:41-07:00"}

Since "photo" is not in the field list, it doesn't get included in the JSON output by default. There are obvious ways to work around this... but I think this is a better default, and in any case, the two ORMs should have matching behavior.

What do you think?
