### PR TITLE
Added support for Padrino Framework, I added ActiveRecord because Padrino

### DIFF
--- a/lib/carrierwave.rb
+++ b/lib/carrierwave.rb
@@ -100,6 +100,11 @@ elsif defined?(Sinatra)
 
   CarrierWave.root = Sinatra::Application.public
 
+elsif defined?(Padrino)
+
+  CarrierWave.root = Padrino.root('public')
+  require 'carrierwave/orm/activerecord' if defined?(ActiveRecord)
+
 end
 
 require 'carrierwave/orm/datamapper' if defined?(DataMapper)


### PR DESCRIPTION
Added support for Padrino Framework, I added ActiveRecord because Padrino is ORM Agnostic and can use also this other than DataMapper, MongoMapper, Mongoid, MongoMapper, Couchrest etc...
