### PR TITLE
Brackets [ ] in uri cause URI::InvalidURIError

### DIFF
--- a/lib/carrierwave/uploader/download.rb
+++ b/lib/carrierwave/uploader/download.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'open-uri'
+require 'cgi'
 
 module CarrierWave
   module Uploader
@@ -67,7 +68,7 @@ module CarrierWave
       # [url (String)] The URL where the remote file is stored
       #
       def process_uri(uri)
-        URI.parse(URI.escape(URI.unescape(uri)))
+        URI.parse( URI.encode( URI.escape(URI.unescape(uri)) , '[]') )
       end
 
     end # Download

--- a/spec/uploader/download_spec.rb
+++ b/spec/uploader/download_spec.rb
@@ -123,7 +123,7 @@ describe CarrierWave::Uploader::Download do
   end
 
   describe '#process_uri' do
-    let(:uri) { "http://www.example.com/test%20image.jpg" }
+    let(:uri) { "http://www.example.com/test%20image%5B2%5D.jpg" }
 
     it 'should unescape and then escape the given uri' do
       unescaped_uri = URI.unescape(uri)


### PR DESCRIPTION
When downloading a remote file that has brackets in it [ ], URI.parse raises an exception URI::InvalidURIError.
e.g http://www.example.com/test[2].jpg

This is because URI.escape does not escape the brackets.

This commit fixes the issue, although it's not the cleanest looking. 
