### PR TITLE
Fixed rdoc errors when bundling from github.

### DIFF
--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -13,10 +13,10 @@ Gem::Specification.new do |s|
   s.description = "Upload files in your Ruby applications, map them to a range of ORMs, store them on different backends."
   s.summary = "Ruby file upload library"
   s.email = ["jonas.nicklas@gmail.com"]
-  s.extra_rdoc_files = ["README.rdoc"]
-  s.files = Dir.glob("{bin,lib}/**/*") + %w(README.rdoc)
+  s.extra_rdoc_files = ["README.md"]
+  s.files = Dir.glob("{bin,lib}/**/*") + %w(README.md)
   s.homepage = %q{https://github.com/jnicklas/carrierwave}
-  s.rdoc_options = ["--main", "README.rdoc"]
+  s.rdoc_options = ["--main"]
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{carrierwave}
   s.rubygems_version = %q{1.3.5}


### PR DESCRIPTION
Since the README was converted to github-style markdown in [this commit](https://github.com/jnicklas/carrierwave/commit/0d2e9ee8706074059cb78f2f85232caf17327952), I can no longer compile the gem or install from github, as I get the following error from bundler:

```
carrierwave at [clipped] did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  ["README.rdoc"] are not files
```

So, I just removed the rdoc references to README.rdoc from the gemspec and it works again.
