### PR TITLE
Missed #setup_modifications for dirty attributes(Mongoid) in upload assignment

### DIFF
--- a/lib/carrierwave/orm/mongoid.rb
+++ b/lib/carrierwave/orm/mongoid.rb
@@ -39,6 +39,7 @@ module CarrierWave
             value = value.duplicable? ? value.clone : value
           rescue TypeError, NoMethodError
           end
+          setup_modifications
           @modifications[column] = value
 
           super

--- a/spec/orm/mongoid_spec.rb
+++ b/spec/orm/mongoid_spec.rb
@@ -197,6 +197,13 @@ describe CarrierWave::Mongoid do
 
   describe "#save" do
 
+    it "after it was initialized with params" do
+      doc = reset_mongo_class.new(:image => stub_file('test.jpg'))
+      doc.save
+      doc.image.should be_an_instance_of(MongoUploader)
+      doc.image.current_path.should == public_path('uploads/test.jpg')
+    end
+
     before do
       mongo_user_klass = reset_mongo_class
       @doc = mongo_user_klass.new


### PR DESCRIPTION
We can't operate with @modifications before we didn't setup it. In Mongoid [#setup_modifications](http://rubydoc.info/github/mongoid/mongoid/master/Mongoid/Dirty:setup_modifications) is run after attributes were [assignment](http://rubydoc.info/github/mongoid/mongoid/master/Mongoid/Attributes/Processing#process-instance_method). Here is a workaround and spec.
I think it also refers to the #361 issue.
