### PR TITLE
Added CarrierWave::MimeTypes processor for more advanced content-type guessing

### DIFF
--- a/lib/carrierwave.rb
+++ b/lib/carrierwave.rb
@@ -37,6 +37,7 @@ module CarrierWave
   autoload :RMagick, 'carrierwave/processing/rmagick'
   autoload :ImageScience, 'carrierwave/processing/image_science'
   autoload :MiniMagick, 'carrierwave/processing/mini_magick'
+  autoload :MimeTypes, 'carrierwave/processing/mime_types'
   autoload :VERSION, 'carrierwave/version'
 
   module Storage

--- a/lib/carrierwave/processing/mime_types.rb
+++ b/lib/carrierwave/processing/mime_types.rb
@@ -1,0 +1,58 @@
+require 'mime/types'
+
+module CarrierWave
+
+  ##
+  # This module simplifies the use of the mime-types gem to intelligently
+  # guess and set the content-type of a file. If you want to use this, you'll
+  # need to require this file:
+  #
+  #     require 'carrierwave/processing/mime_types'
+  #
+  # And then include it in your uploader:
+  #
+  #     class MyUploader < CarrierWave::Uploader::Base
+  #       include CarrierWave::MimeTypes
+  #     end
+  #
+  # You can now use the provided helper:
+  #
+  #     class MyUploader < CarrierWave::Uploader::Base
+  #       include Carrierwave::MimeTypes
+  #
+  #       process :set_content_type
+  #     end
+  #
+  module MimeTypes
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def set_content_type(override=false)
+        process :set_content_type => override
+      end
+    end
+
+    ##
+    # Changes the file content_type using the mime-types gem
+    #
+    # === Parameters
+    #
+    # [override (Boolean)] whether or not to override the file's content_type
+    #                      if it is already set and not a generic content-type,
+    #                      false by default
+    #
+    def set_content_type(override=false)
+      if override || file.content_type.blank? || file.content_type == 'application/octet-stream'
+        new_content_type = ::MIME::Types.type_for(file.original_filename).first.to_s
+        if file.respond_to?(:content_type=)
+          file.content_type = new_content_type
+        else
+          file.set_instance_variable(:@content_type, new_content_type)
+        end
+      end
+    rescue ::MIME::InvalidContentType => e
+      raise CarrierWave::ProcessingError.new("Failed to process file with MIME::Types, maybe not valid content-type? Original Error: #{e}")
+    end
+
+  end # MimeTypes
+end # CarrierWave

--- a/spec/processing/mime_types_spec.rb
+++ b/spec/processing/mime_types_spec.rb
@@ -1,0 +1,51 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe CarrierWave::MimeTypes do
+
+  before do
+    @klass = Class.new do
+      attr_accessor :content_type
+      include CarrierWave::MimeTypes
+    end
+    @instance = @klass.new
+    FileUtils.cp(file_path('landscape.jpg'), file_path('landscape_copy.jpg'))
+    @instance.stub(:original_filename).and_return file_path('landscape_copy.jpg')
+    @instance.stub(:file).and_return CarrierWave::SanitizedFile.new(file_path('landscape_copy.jpg'))
+    @file = @instance.file
+  end
+
+  after do
+    FileUtils.rm(file_path('landscape_copy.jpg'))
+  end
+
+  describe '#set_content_type' do
+
+    it "does not set content_type if already set" do
+      @instance.file.content_type = 'image/jpeg'
+      @instance.file.should_not_receive(:content_type=)
+      @instance.set_content_type
+    end
+
+    it "set content_type if content_type is nil" do
+      @instance.file.content_type = nil
+      @instance.file.should_receive(:content_type=).with('image/jpeg')
+      @instance.set_content_type
+    end
+
+    it "sets content_type if content_type is generic" do
+      @instance.file.content_type = 'application/octet-stream'
+      @instance.file.should_receive(:content_type=).with('image/jpeg')
+      @instance.set_content_type
+    end
+
+    it "sets content_type if override is true" do
+      @instance.file.content_type = 'image/jpeg'
+      @instance.file.should_receive(:content_type=).with('image/jpeg')
+      @instance.set_content_type(true)
+    end
+
+  end
+
+end


### PR DESCRIPTION
[As requested](https://github.com/jnicklas/carrierwave/pull/356#issuecomment-1404519), here's a new pull request with the commit from [pull 356](https://github.com/jnicklas/carrierwave/pull/356) that creates a new CarrierWave::MimeTypes file processor, complete with specs.

I'm still having problems getting jnicklas/carrierwave HEAD to work with my app (I'll submit a separate issue once I figure it out), so I haven't been able to do any real-world integration testing on this with my app yet.
