### PR TITLE
store! after_save in mount.rb halting callback chain (state_machine compatability)

### DIFF
--- a/lib/carrierwave/mount.rb
+++ b/lib/carrierwave/mount.rb
@@ -344,12 +344,11 @@ module CarrierWave
       end
 
       def store!
-        unless uploader.blank?
-          if remove?
-            uploader.remove!
-          else
-            uploader.store!
-          end
+        return true if uploader.blank?
+        if remove?
+          uploader.remove!
+        else
+          uploader.store!
         end
       end
 


### PR DESCRIPTION
When encountering a blank uploader, carrierwave can halt other operations from finishing.  I encountered this issue while using state_machine and carrierwave together (rails 3.0.9, ruby 1.9.2, mongoid 2.1).

Unfortunately I was not able to reproduce the issue in carrierwave's specs.  When using "normal" callback definitions, the 'nil' returned by :store! did not halt the chain, or else I could not get the callback ordering correct so that the :store! method fired first.

Any thoughts on how that callback could be actually testes would be great, otherwise explicitly returning true for the result of that operation does not seem out of line, and all the current specs pass with the change.

Thanks,
Dave
