### PR TITLE
These files are no longer in the project, and thus should not be required

### DIFF
--- a/lib/carrierwave.rb
+++ b/lib/carrierwave.rb
@@ -108,6 +108,4 @@ elsif defined?(Sinatra)
 
 end
 
-require 'carrierwave/orm/datamapper' if defined?(DataMapper)
-require 'carrierwave/orm/sequel' if defined?(Sequel)
 require 'carrierwave/orm/mongoid' if defined?(Mongoid)


### PR DESCRIPTION
These files are no longer in the project, and thus should not be required here.  The Datamapper support is now in carrierwave-datamapper.  I have no clue what is up with Sequel
