### PR TITLE
Remove redundant requires of sequel and datamapper

### DIFF
--- a/lib/carrierwave.rb
+++ b/lib/carrierwave.rb
@@ -108,6 +108,4 @@ elsif defined?(Sinatra)
 
 end
 
-require 'carrierwave/orm/datamapper' if defined?(DataMapper)
-require 'carrierwave/orm/sequel' if defined?(Sequel)
 require 'carrierwave/orm/mongoid' if defined?(Mongoid)


### PR DESCRIPTION
carrierwave/orm/(sequel|datamapper) no longer exist as those plugins
have been extracted to separate projects.

ps. I also sent an identical pull request to merge into 0.5-stable but seems like master is the current stable, right?
