### PR TITLE
added comment to uploader template for minimagick

### DIFF
--- a/lib/generators/templates/uploader.rb
+++ b/lib/generators/templates/uploader.rb
@@ -4,6 +4,7 @@ class <%= class_name %>Uploader < CarrierWave::Uploader::Base
 
   # Include RMagick or ImageScience support:
   # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
   # include CarrierWave::ImageScience
 
   # Choose what kind of storage to use for this uploader:


### PR DESCRIPTION
This commit certainly isn't necessary, although I found it interesting that the uploader file documented ImageScience and RMagick but not MiniMagick. It took me a long time before I realized it supported MiniMagick. The point of this commit is just for slightly more consistent docs, couldn't hurt right?
