### PR TITLE
Nested or double embedded Mongoid document raises exception on re-save

### DIFF
--- a/lib/carrierwave/orm/mongoid.rb
+++ b/lib/carrierwave/orm/mongoid.rb
@@ -53,7 +53,9 @@ module CarrierWave
 
         def find_previous_model_for_#{column}
           if self.embedded?
-            self._parent.reload.send(self.metadata.key).find(to_key.first)
+            ancestors       = [[ self.metadata.key, self._parent ]].tap { |x| x.unshift([ x.first.last.metadata.key, x.first.last._parent ]) while x.first.last.embedded? }
+            reloaded_parent = ancestors.first.last.reload
+            ancestors.inject(reloaded_parent) { |parent,(key,ancestor)| (parent.is_a?(Array) ? parent.find(ancestor.to_key.first) : parent).send(key) }.find(to_key.first)
           else
             self.class.find(to_key.first)
           end


### PR DESCRIPTION
potatosalad/carrierwave@575542a0ef1e50e96660d3af06604e476b614320 contains the fix and specs that test the problem, below is an example that causes the exception

``` ruby
class ExampleUploader < CarrierWave::Uploader::Base
  include CarrierWave::RMagick

  storage :file

  version :thumb do
    process :resize_to_fill => [200,200]
  end
end

class LevelOne
end
class LevelTwo
end
class LevelThree
end
class LevelFour
end

class LevelOne
  include Mongoid::Document

  embeds_one :level_two
end

class LevelTwo
  include Mongoid::Document

  embedded_in :level_one
  embeds_many :level_threes
end

class LevelThree
  include Mongoid::Document

  embedded_in :level_two
  embeds_many :level_fours
end

class LevelFour
  include Mongoid::Document

  embedded_in :level_three
  mount_uploader :image, ::ExampleUploader
end

level_one   = LevelOne.new
level_two   = LevelTwo.new
level_one.level_two = level_two
level_three = level_two.level_threes.build
level_four  = level_three.level_fours.build
level_four.image = open('http://www.google.com/logos/2011/fourth_of_july11-hp.jpg')
level_four.save

level_one   = LevelOne.last
level_two   = level_one.level_two
level_three = level_two.level_threes.last
level_four  = level_three.level_fours.last
level_four.image = open('http://www.google.com/logos/2011/fathersday11-hp.jpg')
level_four.save

# => raises "Mongoid::Errors::InvalidCollection: Access to the collection for LevelThree is not allowed since it is an embedded document, please access a collection from the root document."
```
