### PR TITLE
Check to see if Rails::Railtie is defined over Rails

### DIFF
--- a/lib/carrierwave.rb
+++ b/lib/carrierwave.rb
@@ -86,7 +86,7 @@ if defined?(Merb)
     Dir.glob(File.join(Merb.load_paths[:uploaders])).each {|f| require f }
   end
 
-elsif defined?(Rails)
+elsif defined?(Rails::Railtie)
 
   module CarrierWave
     class Railtie < Rails::Railtie


### PR DESCRIPTION
Check to see if Rails::Railtie is defined over Rails, as in some situations, Rails::Railtie isn't available but Rails is, meaning big boo-boo
The use case for this is SimpleWorker, which I am attempting to integrate with CarrierWave (I'm the intern there at the moment)
