### PR TITLE
Update README to reflect column identifier/filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ u.avatar = File.open('somewhere')
 u.save!
 u.avatar.url # => '/url/to/file.png'
 u.avatar.current_path # => 'path/to/file.png'
+u.avatar.identifier # => 'file.png'
 ```
 
 If using Mongoid, note that embedded documents files aren't saved when parent documents are saved.


### PR DESCRIPTION
Hi,

I wanted to display just the filename of the uploaded file and had to dig through the docs for the commit (0ac7af9a1bf458b344e23f75a861e88aa45b8485) that introduced a way to do so.

I've added the .identifier to what I think is the relevant section that would have helped me.

Thanks,
Kevin
