### PR TITLE
Write over previously assigned file

### DIFF
--- a/lib/carrierwave/mount.rb
+++ b/lib/carrierwave/mount.rb
@@ -337,8 +337,10 @@ module CarrierWave
       end
 
       def remote_url=(url)
-        @remote_url = url
-        uploader.download!(url)
+        unless uploader.cached? && !option(:write_over_a_previously_assigned_file_when_retrieving_file_from_remote_url)
+          @remote_url = url
+          uploader.download!(url)
+        end
       end
 
       def store!

--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -38,6 +38,7 @@ module CarrierWave
         add_config :ensure_multipart_form
         add_config :delete_tmp_file_after_storage
         add_config :remove_previously_stored_files_after_update
+        add_config :write_over_a_previously_assigned_file_when_retrieving_file_from_remote_url
 
         # fog
         add_config :fog_attributes
@@ -152,6 +153,7 @@ module CarrierWave
             config.root = CarrierWave.root
             config.enable_processing = true
             config.ensure_multipart_form = true
+            config.write_over_a_previously_assigned_file_when_retrieving_file_from_remote_url = false
           end
         end
       end

--- a/spec/mount_spec.rb
+++ b/spec/mount_spec.rb
@@ -292,7 +292,14 @@ describe CarrierWave::Mount do
           @instance.image.current_path.should =~ /test.jpg$/
         end
 
-        it "should write over a previously assigned file" do
+        it "should not write over a previously assigned file" do
+          @instance.image = stub_file('portrait.jpg')
+          @instance.remote_image_url = 'http://www.example.com/test.jpg'
+          @instance.image.current_path.should =~ /portrait.jpg$/
+        end
+
+        it "should write over a previously assigned file if corresponding option is set to true" do
+          @uploader.stub!(:write_over_a_previously_assigned_file_when_retrieving_file_from_remote_url).and_return(true)
           @instance.image = stub_file('portrait.jpg')
           @instance.remote_image_url = 'http://www.example.com/test.jpg'
           @instance.image.current_path.should =~ /test.jpg$/


### PR DESCRIPTION
Hi,

This is a patch to allow writing over previously assigned file when retrieving file from remote url (see https://groups.google.com/forum/#!topic/carrierwave/IMs3kYOur1E/discussion). In the second commit I've added a configuration option to make this new behavior optional so that the default behavior does not change.
