### PR TITLE
Fix for #422 and may be #386 (only for store! yet).

### DIFF
--- a/lib/carrierwave/uploader/store.rb
+++ b/lib/carrierwave/uploader/store.rb
@@ -53,7 +53,7 @@ module CarrierWave
       # [new_file (File, IOString, Tempfile)] any kind of file object
       #
       def store!(new_file=nil)
-        cache!(new_file) if new_file
+        cache!(new_file) if new_file && ((@cache_id != parent_cache_id) || @cache_id.nil?)
         if @file and @cache_id
           with_callbacks(:store, new_file) do
             new_file = storage.store!(@file)

--- a/lib/carrierwave/uploader/versions.rb
+++ b/lib/carrierwave/uploader/versions.rb
@@ -26,11 +26,14 @@ module CarrierWave
         self.versions = {}
         self.version_names = []
 
+        attr_accessor :parent_cache_id
+
+        after :cache, :assign_parent_cache_id
         after :cache, :cache_versions!
         after :store, :store_versions!
         after :remove, :remove_versions!
         after :retrieve_from_cache, :retrieve_versions_from_cache!
-        after :retrieve_from_store, :retrieve_versions_from_store!
+        after :retrieve_from_store, :retrieve_versions_from_store!        
       end
 
       module ClassMethods
@@ -179,6 +182,11 @@ module CarrierWave
       end
 
     private
+      def assign_parent_cache_id(file)
+        active_versions.each do |name, uploader|
+          uploader.parent_cache_id = @cache_id
+        end
+      end
 
       def active_versions
         versions.select do |name, uploader|

--- a/spec/uploader/versions_spec.rb
+++ b/spec/uploader/versions_spec.rb
@@ -287,7 +287,10 @@ describe CarrierWave::Uploader do
          @uploader.should_receive(:banana).at_least(:once).at_most(:once).and_return(true)
          @uploader.thumb.should_receive(:banana).at_least(:once).at_most(:once).and_return(true)
          
+#         puts '-------'
          @uploader.store!(@file)
+#         puts '-------'
+                  
          @uploader.store_path.should == 'uploads/test.jpg'
          @uploader.thumb.store_path.should == 'uploads/thumb_test.jpg'
        end


### PR DESCRIPTION
Added parent_cache_name accessor to uploader. This accessor is assigned after cache!. Version with new file passed is cached only if it's cache_id not equals parent's cache_id. In other words, child version is cached only if parent file cache has changed.
