### PR TITLE
Remove unnecessary rescues.

### DIFF
--- a/lib/carrierwave/mount.rb
+++ b/lib/carrierwave/mount.rb
@@ -21,15 +21,13 @@ module CarrierWave
     #
     def uploaders
       @uploaders ||= {}
-      @uploaders = superclass.uploaders.merge(@uploaders)
-    rescue NoMethodError
+      @uploaders = superclass.uploaders.merge(@uploaders) if superclass.respond_to?(:uploaders)
       @uploaders
     end
 
     def uploader_options
       @uploader_options ||= {}
-      @uploader_options = superclass.uploader_options.merge(@uploader_options)
-    rescue NoMethodError
+      @uploader_options = superclass.uploader_options.merge(@uploader_options) if superclass.respond_to?(:uploader_options)
       @uploader_options
     end
 


### PR DESCRIPTION
After running perftools.rb on a project at work, Carrierwave::Mount#uploader_options was at the top of the list. Converting these rescues to condition checks (namely uploader_options) shaved 10 seconds off a 40 second test suite. Now this method is gone from a perftools.rb run :)

No new failures in the carrierwave test suite, other than some known mongodb issue.

Thoughts?
