### PR TITLE
add descriptions for matchers called without a string

### DIFF
--- a/lib/carrierwave/test/matchers.rb
+++ b/lib/carrierwave/test/matchers.rb
@@ -13,15 +13,22 @@ module CarrierWave
         def initialize(expected)
           @expected = expected
         end
+
         def matches?(actual)
           @actual = actual
           FileUtils.identical?(@actual, @expected)
         end
+
         def failure_message
           "expected #{@actual.inspect} to be identical to #{@expected.inspect}"
         end
+
         def negative_failure_message
           "expected #{@actual.inspect} to not be identical to #{@expected.inspect}"
+        end
+
+        def description
+          "be identical to #{@expected.inspect}"
         end
       end
 
@@ -46,6 +53,10 @@ module CarrierWave
 
         def negative_failure_message
           "expected #{@actual.inspect} not to have permissions #{@expected.to_s(8)}, but it did"
+        end
+
+        def description
+          "have permissions #{@expected.to_s(8)}"
         end
       end
 
@@ -75,6 +86,9 @@ module CarrierWave
           "expected #{@actual.current_path.inspect} to be larger than #{@width} by #{@height}, but it wasn't."
         end
 
+        def description
+          "be no larger than #{@width} by #{@height}"
+        end
       end
 
       def be_no_larger_than(width, height)
@@ -103,6 +117,9 @@ module CarrierWave
           "expected #{@actual.current_path.inspect} not to have an exact size of #{@width} by #{@height}, but it did."
         end
 
+        def description
+          "have an exact size of #{@width} by #{@height}"
+        end
       end
 
       def have_dimensions(width, height)


### PR DESCRIPTION
Prettier output in case a matcher is called without a string, such as:

```
specify { @uploader.should be_no_larger_than(800, 600) }
```
