### PR TITLE
JRuby sqlite3 support

### DIFF
--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -25,7 +25,12 @@ Gem::Specification.new do |s|
   s.add_dependency("activesupport", ["~> 3.0"])
 
   s.add_development_dependency "rails", ["~> 3.0"]
-  s.add_development_dependency "sqlite3"
+  if defined?(JRUBY_VERSION)
+    s.add_development_dependency "activerecord-jdbc-adapter"
+    s.add_development_dependency "jdbc-sqlite3"
+  else
+    s.add_development_dependency "sqlite3"
+  end
 
   s.add_development_dependency "cucumber"
   s.add_development_dependency "json"

--- a/features/support/activerecord.rb
+++ b/features/support/activerecord.rb
@@ -1,8 +1,10 @@
 # encoding: utf-8
 
-# not sure why we need to do this
-require 'sqlite3/sqlite3_native'
-require 'sqlite3'
+unless defined?(JRUBY_VERSION)
+  # not sure why we need to do this
+  require 'sqlite3/sqlite3_native'
+  require 'sqlite3'
+end
 
 require 'active_record'
 require 'carrierwave/mount'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,9 +12,11 @@ require 'timecop'
 require 'open-uri'
 require 'sham_rack'
 
-# not sure why we need to do this
-require 'sqlite3/sqlite3_native'
-require 'sqlite3'
+unless defined?(JRUBY_VERSION)
+  # not sure why we need to do this
+  require 'sqlite3/sqlite3_native'
+  require 'sqlite3'
+end
 
 require 'fog'
 require 'storage/fog_helper'


### PR DESCRIPTION
Native sqlite3 looks to have outbound memory access issue and it causes
JVM to SEGV. C-ext version doesn't scale well with multi-threads on
JRuby so use jdbc-sqlite3 gem instead of native sqlite3 gem.
