### PR TITLE
S3 - use valid ssl hostname when ssl is enabled

### DIFF
--- a/lib/carrierwave/storage/s3.rb
+++ b/lib/carrierwave/storage/s3.rb
@@ -124,10 +124,14 @@ module CarrierWave
 
         def public_url
           scheme = use_ssl? ? 'https' : 'http'
-          if cnamed?
-            ["#{scheme}://#{bucket}", path].compact.join('/')
+          if use_ssl?
+            ["#{scheme}://s3.amazonaws.com", "#{bucket}", path].join("/")
           else
-            ["#{scheme}://#{bucket}.s3.amazonaws.com", path].compact.join('/')
+            if cnamed?
+              ["#{scheme}://#{bucket}", path].compact.join('/')
+            else
+              ["#{scheme}://#{bucket}.s3.amazonaws.com", path].compact.join('/')
+            end
           end
         end
 

--- a/spec/storage/s3_spec.rb
+++ b/spec/storage/s3_spec.rb
@@ -80,6 +80,14 @@ if ENV['REMOTE'] == 'true'
           @s3_file.url.should == 'http://foo.bar/uploads/bar.txt'
         end
       end
+      
+      context "with ssl enabled" do
+        it "should use the long form of the url with the path" do
+          @uploader.stub!(:s3_bucket).and_return('foo.bar')
+          @uploader.stub!(:s3_use_ssl).and_return(true)
+          @s3_file.url.should == 'https://s3.amazonaws.com/foo.bar/uploads/bar.txt'
+        end
+      end
 
       it "should be deletable" do
         @s3_file.delete


### PR DESCRIPTION
if you have ssl enabled, using a cname or even the subdomain style (bucketname.s3.amazonaws.com) will cause issues. Therefore, if use_ssl is set, use the valid s3.amazonaws.com domain.
