### PR TITLE
Add config.base_url, use it as prefix in Uploader#url.

### DIFF
--- a/lib/carrierwave.rb
+++ b/lib/carrierwave.rb
@@ -15,7 +15,7 @@ require 'active_support/memoizable'
 module CarrierWave
 
   class << self
-    attr_accessor :root, :base_url
+    attr_accessor :root, :base_path
 
     def configure(&block)
       CarrierWave::Uploader::Base.configure(&block)
@@ -92,7 +92,7 @@ elsif defined?(Rails)
     class Railtie < Rails::Railtie
       initializer "carrierwave.setup_paths" do
         CarrierWave.root = Rails.root.join(Rails.public_path).to_s
-        CarrierWave.base_url = ENV['RAILS_RELATIVE_URL_ROOT']
+        CarrierWave.base_path = ENV['RAILS_RELATIVE_URL_ROOT']
       end
 
       initializer "carrierwave.active_record" do

--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -8,7 +8,7 @@ module CarrierWave
         class_attribute :_storage, :instance_writer => false
 
         add_config :root
-        add_config :base_url
+        add_config :base_path
         add_config :permissions
         add_config :storage_engines
         add_config :s3_access_policy
@@ -151,7 +151,7 @@ module CarrierWave
             config.validate_integrity = true
             config.validate_processing = true
             config.root = CarrierWave.root
-            config.base_url = CarrierWave.base_url
+            config.base_path = CarrierWave.base_path
             config.enable_processing = true
             config.ensure_multipart_form = true
           end

--- a/lib/carrierwave/uploader/url.rb
+++ b/lib/carrierwave/uploader/url.rb
@@ -15,7 +15,7 @@ module CarrierWave
         if file.respond_to?(:url) and not file.url.blank?
           file.url
         elsif current_path
-          (base_url || "") + File.expand_path(current_path).gsub(File.expand_path(root), '')
+          (base_path || "") + File.expand_path(current_path).gsub(File.expand_path(root), '')
         end
       end
 

--- a/spec/uploader/url_spec.rb
+++ b/spec/uploader/url_spec.rb
@@ -51,13 +51,13 @@ describe CarrierWave::Uploader do
       @uploader.url(:thumb, :mini).should == '/uploads/tmp/20071201-1234-345-2255/thumb_mini_test.jpg'
     end
 
-    it "should prepend the config option 'base_url', if set" do
+    it "should prepend the config option 'base_path', if set" do
       @uploader_class.version(:thumb)
       @uploader.class.configure do |config|
-        config.base_url = "/base_url"
+        config.base_path = "/base_path"
       end
       @uploader.cache!(File.open(file_path('test.jpg')))
-      @uploader.url(:thumb).should == '/base_url/uploads/tmp/20071201-1234-345-2255/thumb_test.jpg'
+      @uploader.url(:thumb).should == '/base_path/uploads/tmp/20071201-1234-345-2255/thumb_test.jpg'
     end
 
     it "should return file#url if available" do


### PR DESCRIPTION
This patch adds a config option named "base_url" that is used as prefix in Uploader#url (if file#url is not present).

If using Rails, "base_url" defaults to ENV['RAILS_RELATIVE_URL_ROOT'], so CarrierWave's local file storage now plays nicely with Rails apps deployed to subdirectories.
