### PR TITLE
improves interchangeability of :file and :fog storage mechanisms

### DIFF
--- a/lib/carrierwave/storage/file.rb
+++ b/lib/carrierwave/storage/file.rb
@@ -22,7 +22,7 @@ module CarrierWave
       # [CarrierWave::SanitizedFile] a sanitized file
       #
       def store!(file)
-        path = ::File.expand_path(uploader.store_path, uploader.root)
+        path = ::File.expand_path(::File.join(uploader.file_directory, uploader.store_path), uploader.root)
         file.copy_to(path, uploader.permissions)
       end
 
@@ -38,7 +38,7 @@ module CarrierWave
       # [CarrierWave::SanitizedFile] a sanitized file
       #
       def retrieve!(identifier)
-        path = ::File.expand_path(uploader.store_path(identifier), uploader.root)
+        path = ::File.expand_path(::File.join(uploader.file_directory, uploader.store_path(identifier)), uploader.root)
         CarrierWave::SanitizedFile.new(path)
       end
 

--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -39,6 +39,9 @@ module CarrierWave
         add_config :delete_tmp_file_after_storage
         add_config :remove_previously_stored_files_after_update
 
+        # file
+        add_config :file_directory
+
         # fog
         add_config :fog_attributes
         add_config :fog_credentials
@@ -137,6 +140,7 @@ module CarrierWave
             config.grid_fs_database = 'carrierwave'
             config.grid_fs_host = 'localhost'
             config.grid_fs_port = 27017
+            config.file_directory = '.'
             config.fog_attributes = {}
             config.fog_credentials = {}
             config.fog_public = true

--- a/spec/storage/file_spec.rb
+++ b/spec/storage/file_spec.rb
@@ -1,0 +1,40 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe CarrierWave::Storage::File do
+  
+  let(:klass) { Class.new(CarrierWave::Uploader::Base) }
+  subject { klass.new }
+  
+  after do
+    FileUtils.rm_rf(public_path)
+  end
+
+  context "when configuration is left at default" do
+    
+    it "should generate a correct url" do
+      subject.store! File.open(file_path("test.jpg"))
+      subject.current_path.should == "#{klass.root}#{subject.url}"
+    end
+    
+  end
+  
+  context "when config.file_directory has been set" do
+    
+    before { klass.file_directory = "system" }
+    
+    it "should store the file in ./public/system" do
+      subject.store! File.open(file_path("test.jpg"))
+      subject.current_path.should =~ /\/public\/system\/uploads\/test.jpg$/
+    end
+    
+    it "should generate a correct url" do
+      subject.store! File.open(file_path("test.jpg"))
+      subject.url.should == "/system/uploads/test.jpg"
+    end
+    
+  end
+  
+
+end


### PR DESCRIPTION
With regards to the discussion started here:
http://groups.google.com/group/carrierwave/browse_thread/thread/7cd699b9d97222c9

This change improves the interchangeability of File and Fog storage providers by allowing the File storage mechanism to target a subdirectory of CarrierWave.root, which for practical purposes and compatibility should probably always be Rails.public_path.

This change would allow, for example, the Fog storage mechanism to be used in production while the File storage mechanism can be used in development.
