### PR TITLE
Fixes #root race condition

### DIFF
--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -106,7 +106,8 @@ module CarrierWave
             end
 
             def #{name}
-              self.class.#{name}
+              value = self.class.#{name}
+              value.instance_of?(Proc) ? value.call : value
             end
           RUBY
         end
@@ -149,7 +150,7 @@ module CarrierWave
             config.ignore_processing_errors = true
             config.validate_integrity = true
             config.validate_processing = true
-            config.root = CarrierWave.root
+            config.root = lambda { CarrierWave.root }
             config.enable_processing = true
             config.ensure_multipart_form = true
           end

--- a/spec/uploader/paths_spec.rb
+++ b/spec/uploader/paths_spec.rb
@@ -5,18 +5,29 @@ require 'spec_helper'
 describe CarrierWave::Uploader do
 
   before do
+    @root = CarrierWave.root
+    CarrierWave.root = nil
     @uploader_class = Class.new(CarrierWave::Uploader::Base)
     @uploader = @uploader_class.new
   end
 
   after do
     FileUtils.rm_rf(public_path)
+    CarrierWave.root = @root
   end
 
   describe '#root' do
+
     it "should default to the config option" do
       @uploader.root.should == public_path
     end
+    
+    it "should default to the current value of CarrierWave.root" do
+      @uploader.root.should be_nil
+      CarrierWave.root = public_path
+      @uploader.root.should == public_path
+    end
+    
   end
-
+  
 end


### PR DESCRIPTION
When CarrierWave is loaded, the Configuration module is loaded prior to setting CarrierWave.root. At the time the configuration 'defaults' are established, CarrierWave.root is nil, causing Uploader instances to initially carry a #root value of nil, unless config.root is explicitly configured either globally or on the Uploader instance.

This condition was also difficult to test for (and in fact an existing test for this was hiding the error). During test setup, in 'spec_helper.rb', a value is explicitly set for CarrierWave.root _before_ any of the modules (including Configuration) are loaded. This causes the test in 'paths_spec.rb' to give false positives.

In normal operation, the Configuration module loads before CarrierWave.root is set, near the end of carrierwave.rb.

Rather than re-order the initialization process and module loading, I changed the Configuration module to accept Proc values for configuration values. This has the added bonus of allowing configuration values to be dynamically evaluated at runtime, rather than at startup.

I have set the default value of config.root as a Proc to resolve the race condition.

Additionally, I have corrected the 'paths_spec.rb' unit test to ensure the existing test fails, exposing the error, and a new test has been added to ensure that the Proc execution resolves correctly on the uploader instance.
