### PR TITLE
Fixed a typo in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ require 'carrierwave/processing/mime_types'
 class MyUploader < CarrierWave::Uploader::Base
   include CarrierWave::MimeTypes
 
-  processor :set_content_type
+  process :set_content_type
 end
 ```
 


### PR DESCRIPTION
The line `processor :set_content_type` should be `process :set_content_type`.
