### PR TITLE
S3 CNAME with SSL causes SSL cert errors

### DIFF
--- a/lib/carrierwave/storage/s3.rb
+++ b/lib/carrierwave/storage/s3.rb
@@ -124,7 +124,9 @@ module CarrierWave
 
         def public_url
           scheme = use_ssl? ? 'https' : 'http'
-          if cnamed?
+          if use_ssl?
+            ["#{scheme}://s3.amazonaws.com", bucket, path].compact.join('/')
+          elsif cnamed?
             ["#{scheme}://#{bucket}", path].compact.join('/')
           else
             ["#{scheme}://#{bucket}.s3.amazonaws.com", path].compact.join('/')

--- a/spec/storage/s3_spec.rb
+++ b/spec/storage/s3_spec.rb
@@ -66,18 +66,32 @@ if ENV['REMOTE'] == 'true'
       end
 
       context "without cnamed bucket" do
-        it "should have a Euro supported Amazon URL" do
+        it "should have a Euro supported Amazon URL for http" do
           @uploader.stub!(:s3_cnamed).and_return(false)
           @uploader.stub!(:s3_bucket).and_return('foo.bar')
           @s3_file.url.should == "http://foo.bar.s3.amazonaws.com/uploads/bar.txt"
         end
+
+        it "should return a Amazon URL without subdomain for https" do
+          @uploader.stub!(:s3_cnamed).and_return(true)
+          @uploader.stub!(:s3_bucket).and_return('foo.bar')
+          @uploader.stub!(:s3_use_ssl).and_return(true)
+          @s3_file.url.should == "https://s3.amazonaws.com/foo.bar/uploads/bar.txt"
+        end
       end
 
       context "with cnamed bucket" do
-        it "should have a CNAMED URL" do
+        it "should have a CNAMED URL for http" do
           @uploader.stub!(:s3_cnamed).and_return(true)
           @uploader.stub!(:s3_bucket).and_return('foo.bar')
           @s3_file.url.should == 'http://foo.bar/uploads/bar.txt'
+        end
+
+        it "should return a Amazon URL without subdomain for https" do
+          @uploader.stub!(:s3_cnamed).and_return(true)
+          @uploader.stub!(:s3_bucket).and_return('foo.bar')
+          @uploader.stub!(:s3_use_ssl).and_return(true)
+          @s3_file.url.should == "https://s3.amazonaws.com/foo.bar/uploads/bar.txt"
         end
       end
 


### PR DESCRIPTION
Currently the URLs in Carrierwave are broken when using S3 with CNAME and SSL options due to the SSL certificates not matching up with the domain. The URL Carrierwave returns for example (sorry for the length) https://uploads.cdn.placester.net/logos/4d49c138df093a0793000001/4d49c138df093a0793000001.gif or if you use the S3 subdomain format https://uploads.cdn.placester.net.s3.amazonaws.com/logos/4d49c138df093a0793000001/4d49c138df093a0793000001.gif. In at least the latest Safari, Firefox and Chrome versions they'll all appear broken unless you manually view the image and confirm that it's ok.

The small change I made was to make it so any calls to the S3 storage modules public_url will return the Amazon path URL rather than the subdomain or CNAME when SSL is enabled. Using the above URL example, it will return https://s3.amazonaws.com/uploads.cdn.placester.net/logos/4d49c138df093a0793000001/4d49c138df093a0793000001.gif which loads fine.
