### PR TITLE
RSpec matchers for asserting an image's width or height is less than a given amount

### DIFF
--- a/lib/carrierwave/test/matchers.rb
+++ b/lib/carrierwave/test/matchers.rb
@@ -126,6 +126,66 @@ module CarrierWave
         HaveDimensions.new(width, height)
       end
 
+      class BeNoWiderThan # :nodoc:
+        def initialize(width)
+          @width = width
+        end
+
+        def matches?(actual)
+          @actual = actual
+          # Satisfy expectation here. Return false or raise an error if it's not met.
+          image = ImageLoader.load_image(@actual.current_path)
+          @actual_width = image.width
+          @actual_width <= @width
+        end
+
+        def failure_message
+          "expected #{@actual.current_path.inspect} to be no wider than #{@width}, but it was #{@actual_width}."
+        end
+
+        def negative_failure_message
+          "expected #{@actual.current_path.inspect} not to be wider than #{@width}, but it is."
+        end
+
+        def description
+          "have a width less than or equal to #{@width}"
+        end
+      end
+
+      def be_no_wider_than(width)
+        BeNoWiderThan.new(width)
+      end
+
+      class BeNoTallerThan # :nodoc:
+        def initialize(height)
+          @height = height
+        end
+
+        def matches?(actual)
+          @actual = actual
+          # Satisfy expectation here. Return false or raise an error if it's not met.
+          image = ImageLoader.load_image(@actual.current_path)
+          @actual_height = image.height
+          @actual_height <= @height
+        end
+
+        def failure_message
+          "expected #{@actual.current_path.inspect} to be no taller than #{@height}, but it was #{@actual_height}."
+        end
+
+        def negative_failure_message
+          "expected #{@actual.current_path.inspect} not to be taller than #{@height}, but it is."
+        end
+
+        def description
+          "have a height less than or equal to #{@height}"
+        end
+      end
+
+      def be_no_height_than(height)
+        BeNoTallerThan.new(height)
+      end
+
       class ImageLoader # :nodoc:
         def self.load_image(filename)
           if defined? ::MiniMagick


### PR DESCRIPTION
I added 2 additional matchers - be_no_wider_than and be_no_taller_than - for asserting image widths and heights individually. This is my first pull request so please let me know if I've missed anything - thank you!
