### PR TITLE
Fog store does not follow other storage semantics on store!

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -226,6 +226,7 @@ module CarrierWave
         # [Boolean] true on success or raises error
         def store(new_file)
           fog_file = new_file.to_file
+          delete if self.exists?
           @content_type ||= new_file.content_type
           @file = directory.files.create({
             :body         => fog_file ? fog_file : new_file.read,
@@ -283,6 +284,17 @@ module CarrierWave
           else
             public_url
           end
+        end
+
+        ##
+        # Return if the remote file exists
+        #
+        # === Returns
+        #
+        # [Boolean] true if the file exists
+        #
+        def exists?
+          !file.nil?
         end
 
       private


### PR DESCRIPTION
Hi,

I've done two small changes.  I've created an exists? method and modified store to overwrite a file if it already exists.  This is to because when you call store! with CarrierWave::Storage::File::store! it will overwrite the file but when you use CarrierWave::Storage::Fog::store! it calls HTTP POST - rather than PUT which throws an error if it already exists.

I could not work out how the fog testing framework works.  If you could explain what needs to be done to fog_credentials and how the mocking framework works I'd be happy to add tests to this.
