### PR TITLE
Update get_object_url to Fog 1.0 API

### DIFF
--- a/lib/carrierwave/storage/s3.rb
+++ b/lib/carrierwave/storage/s3.rb
@@ -132,7 +132,7 @@ module CarrierWave
         end
 
         def authenticated_url
-          connection.get_object_url(bucket, path, Time.now + authentication_timeout)
+          connection.get_object_https_url(bucket, path, Time.now + authentication_timeout)
         end
 
         def store(file)


### PR DESCRIPTION
Change get_object_url to get_object_https_url because get_object_url is deprecated in fog 1.0
