### PR TITLE
Version type.

### DIFF
--- a/lib/carrierwave/uploader/versions.rb
+++ b/lib/carrierwave/uploader/versions.rb
@@ -27,9 +27,9 @@ module CarrierWave
         self.version_names = []
 
         attr_accessor :parent_cache_id
-        attr_accessor :create_version_type
+        attr_accessor :create_type
 
-        before :create_versions, :assign_create_version_type
+        before :create_versions, :assign_create_type
 
         after :cache, :assign_parent_cache_id
         after :cache, :cache_versions!
@@ -37,7 +37,7 @@ module CarrierWave
         after :remove, :remove_versions!
         after :retrieve_from_cache, :retrieve_versions_from_cache!
         after :retrieve_from_store, :retrieve_versions_from_store!
-        after :create_versions, :assign_nil_to_create_version_type
+        after :create_versions, :assign_nil_to_create_type
       end
 
       module ClassMethods
@@ -222,10 +222,10 @@ module CarrierWave
         end
       end
 
-      def recursively_set_create_version_type_to_versions
+      def recursively_set_create_type_to_versions
         versions.each do |name, uploader|
-          uploader.create_version_type = @create_version_type
-          uploader.recursively_set_create_version_type_to_versions
+          uploader.create_type = @create_type
+          uploader.recursively_set_create_type_to_versions
         end
       end
 
@@ -245,8 +245,8 @@ module CarrierWave
 
       def type_condition(name, uploader)
         type = self.class.versions[name][:options][:type]
-        if uploader.create_version_type.present?
-          (uploader.create_version_type.include? type) || (uploader.create_version_type.include? :all)
+        if uploader.create_type.present?
+          (uploader.create_type.include? type) || (uploader.create_type.include? :all)
         else
           type.blank?
         end
@@ -289,13 +289,13 @@ module CarrierWave
         versions.each { |name, v| v.retrieve_from_store!(identifier) }
       end
 
-      def assign_create_version_type(*args)
-        @create_version_type = args.compact
-        recursively_set_create_version_type_to_versions
+      def assign_create_type(*args)
+        @create_type = args.compact
+        recursively_set_create_type_to_versions
       end
 
-      def assign_nil_to_create_version_type(*args)
-        assign_create_version_type(nil)
+      def assign_nil_to_create_type(*args)
+        assign_create_type(nil)
       end
 
     end # Versions

--- a/spec/uploader/versions_spec.rb
+++ b/spec/uploader/versions_spec.rb
@@ -293,35 +293,35 @@ describe CarrierWave::Uploader do
         @uploader.thumb.store_path.should == 'uploads/thumb_test.jpg'
       end
 
-      it "should process version with type included to instance variable @create_version_type" do
+      it "should process version with type included to instance variable @create_type" do
         @uploader_class.version(:thumb)[:options][:type] = :delayed
-        @uploader.thumb.instance_variable_set('@create_version_type', [:delayed])
+        @uploader.thumb.instance_variable_set('@create_type', [:delayed])
         @uploader.store!(@file)
         @uploader.thumb.should be_present
       end
 
-      it "should process versions without type if @create_version_type is not set" do
+      it "should process versions without type if @create_type is not set" do
         @uploader_class.version(:thumb)[:options][:type].should be_nil
-        @uploader.thumb.instance_variable_get('@create_version_type').should be_nil
+        @uploader.thumb.instance_variable_get('@create_type').should be_nil
         @uploader.store!(@file)
         @uploader.thumb.should be_present
       end
 
-      it "should process all versions if the @create_version_type set to [:all]" do
+      it "should process all versions if the @create_type set to [:all]" do
         @uploader_class.version(:preview)[:options][:type] = :my_version
         @uploader_class.version(:thumb)[:options][:type].should be_nil
-        @uploader.thumb.instance_variable_set('@create_version_type', [:all])
-        @uploader.preview.instance_variable_set('@create_version_type', [:all])
+        @uploader.thumb.instance_variable_set('@create_type', [:all])
+        @uploader.preview.instance_variable_set('@create_type', [:all])
         @uploader.store!(@file)
         @uploader.thumb.should be_present
         @uploader.preview.should be_present
       end
 
-      it "should process versions with types included in @create_version_type" do
+      it "should process versions with types included in @create_type" do
         @uploader_class.version(:preview)[:options][:type] = :my_version
         @uploader_class.version(:thumb)[:options][:type]= :delayed
-        @uploader.thumb.instance_variable_set('@create_version_type', [:my_version, :delayed])
-        @uploader.preview.instance_variable_set('@create_version_type', [:my_version, :delayed])
+        @uploader.thumb.instance_variable_set('@create_type', [:my_version, :delayed])
+        @uploader.preview.instance_variable_set('@create_type', [:my_version, :delayed])
         @uploader.store!(@file)
         @uploader.thumb.should be_present
         @uploader.preview.should be_present
@@ -589,7 +589,7 @@ describe CarrierWave::Uploader do
           File.exists?(@uploader.preview.big.path).should == true
         end
 
-        it "should assign nil to create_version_type variable" do
+        it "should assign nil to create_type variable" do
           @uploader_class.class_eval {
             version :preview, :type => :delayed do
               version :middle, :type => :my_type
@@ -598,9 +598,9 @@ describe CarrierWave::Uploader do
           }
           @uploader.store!(@file)
           @uploader.create_versions!(:all)
-          @uploader.preview.create_version_type.should be_blank
-          @uploader.preview.middle.create_version_type.should be_blank
-          @uploader.preview.big.create_version_type.should be_blank
+          @uploader.preview.create_type.should be_blank
+          @uploader.preview.middle.create_type.should be_blank
+          @uploader.preview.big.create_type.should be_blank
         end
 
       end


### PR DESCRIPTION
Allows to set versions type and processing it later. Main purpose is to create versions in background with resque or delay_job.
Example:
       We have uploader with version `:preview` that have type `:delayed`:

``` ruby
  class MyUploader < CarrierWave::Uploader::Base

    version :thumb do
      process :scale => [200, 200]
    end

    version :preview, :type => :delayed do
      process :scale => [200, 200]
    end

  end
```

When file is cached version :preview will not be created. And we can create it later:

``` ruby
instance.create_versions!(:delayed)
```

also we can create all version for this uploader by passing :all to the method:

``` ruby
instance.create_versions!(:all)
```

and we can create few versions by passing multiple version types to the method:

``` ruby
instance.create_versions!(:delayed, :other_version)
```

Having different versions we can create versions by priorities.
