### PR TITLE
fix naming error in BeNoTallerThan test matcher

### DIFF
--- a/lib/carrierwave/test/matchers.rb
+++ b/lib/carrierwave/test/matchers.rb
@@ -182,7 +182,7 @@ module CarrierWave
         end
       end
 
-      def be_no_height_than(height)
+      def be_no_taller_than(height)
         BeNoTallerThan.new(height)
       end
 


### PR DESCRIPTION
Fixes: NoMethodError: undefined method `no_taller_than?'
