### PR TITLE
Change public_url regex to not break ssl on AWS buckets with "." names

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -253,7 +253,7 @@ module CarrierWave
             case @uploader.fog_credentials[:provider]
             when 'AWS'
               # if directory is a valid subdomain, use that style for access
-              if @uploader.fog_directory.to_s =~ /^(?:[a-z]|\d(?!\d{0,2}(?:\.\d{1,3}){3}$))(?:[a-z0-9]|\.(?![\.\-])|\-(?![\.])){1,61}[a-z0-9]$/
+              if @uploader.fog_directory.to_s =~ /^(?:[a-z]|\d(?!\d{0,2}(?:\d{1,3}){3}$))(?:[a-z0-9]|(?![\-])|\-(?![\.])){1,61}[a-z0-9]$/
                 "https://#{@uploader.fog_directory}.s3.amazonaws.com/#{path}"
               else
                 # directory is not a valid subdomain, so use path style for access


### PR DESCRIPTION
Currently, if the bucket has any dots in the name the AWS wildcard ssl certificate will be invalid, since it only works for the first level of subdomains off amazonaws.com. This commit changes the regex to drop down to the s3.amazonaws.com/bucket urls for bucket names with containing "."s.
