### PR TITLE
Fixed bug in MimeTypes integration when setting the content type through an instance variable.

### DIFF
--- a/lib/carrierwave/processing/mime_types.rb
+++ b/lib/carrierwave/processing/mime_types.rb
@@ -47,7 +47,7 @@ module CarrierWave
         if file.respond_to?(:content_type=)
           file.content_type = new_content_type
         else
-          file.set_instance_variable(:@content_type, new_content_type)
+          file.instance_variable_set(:@content_type, new_content_type)
         end
       end
     rescue ::MIME::InvalidContentType => e


### PR DESCRIPTION
Changed from "set_instance_variable" to using
Object#instance_variable_set to make it work.
