### PR TITLE
add query options for s3 to support response headers overwriting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source :rubygems
-
+gem "fog", :git => "git://github.com/fog/fog.git"
 gemspec

--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -133,12 +133,16 @@ module CarrierWave
         #   or
         # [NilClass] no authenticated url available
         #
-        def authenticated_url
+        def authenticated_url(options = {})
           if ['AWS', 'Google'].include?(@uploader.fog_credentials[:provider])
             # avoid a get by using local references
             local_directory = connection.directories.new(:key => @uploader.fog_directory)
             local_file = local_directory.files.new(:key => path)
-            local_file.url(::Fog::Time.now + @uploader.fog_authenticated_url_expiration)
+            if @uploader.fog_credentials[:provider] == "AWS"
+              local_file.url(::Fog::Time.now + @uploader.fog_authenticated_url_expiration, options)
+            else
+              local_file.url(::Fog::Time.now + @uploader.fog_authenticated_url_expiration)
+            end
           else
             nil
           end
@@ -277,9 +281,9 @@ module CarrierWave
         #   or
         # [NilClass] no url available
         #
-        def url
+        def url(options = {})
           if !@uploader.fog_public
-            authenticated_url
+            authenticated_url(options)
           else
             public_url
           end

--- a/lib/carrierwave/storage/s3.rb
+++ b/lib/carrierwave/storage/s3.rb
@@ -114,9 +114,9 @@ module CarrierWave
         #
         # [String] file's url
         #
-        def url
+        def url(options = {})
           if access_policy == :authenticated_read
-            authenticated_url
+            authenticated_url(options)
           else
             public_url
           end
@@ -131,8 +131,8 @@ module CarrierWave
           end
         end
 
-        def authenticated_url
-          connection.get_object_https_url(bucket, path, Time.now + authentication_timeout)
+        def authenticated_url(options = {})
+          connection.get_object_https_url(bucket, path, Time.now + authentication_timeout, options)
         end
 
         def store(file)

--- a/lib/carrierwave/uploader/url.rb
+++ b/lib/carrierwave/uploader/url.rb
@@ -7,13 +7,17 @@ module CarrierWave
       include CarrierWave::Uploader::Configuration
 
       ##
+      # === Parameters
+      #
+      # [Hash] optional, the query params (only AWS)
+      #
       # === Returns
       #
       # [String] the location where this file is accessible via a url
       #
-      def url
+      def url(options = {})
         if file.respond_to?(:url) and not file.url.blank?
-          file.url
+          file.url(options)
         elsif current_path
           (base_path || "") + File.expand_path(current_path).gsub(File.expand_path(root), '')
         end

--- a/lib/carrierwave/uploader/versions.rb
+++ b/lib/carrierwave/uploader/versions.rb
@@ -140,28 +140,38 @@ module CarrierWave
       ##
       # When given a version name as a parameter, will return the url for that version
       # This also works with nested versions.
+      # When given a query hash as a parameter, will return the url with signature that contains query params
+      # Query hash only works with AWS (S3 storage).
       #
       # === Example
       #
       #     my_uploader.url                 # => /path/to/my/uploader.gif
       #     my_uploader.url(:thumb)         # => /path/to/my/thumb_uploader.gif
       #     my_uploader.url(:thumb, :small) # => /path/to/my/thumb_small_uploader.gif
+      #     my_uploader.url(:query => {"response-content-disposition" => "attachment"}) 
+      #     # => https://s3.amazonaws.com/carrierwave1323435530private/uploads/private.txt?AWSAccessKeyId=AKIAJXXVLMTYDJBPG5UA&Signature=wRqaa49WOpEWfuzWejpDyRcINN4%3D&Expires=1323436551
+      #     my_uploader.url(:version, :sub_version, :query => {"response-content-disposition" => "attachment"}) 
+      #     # => https://s3.amazonaws.com/carrierwave1323435530private/uploads/version_subversion_private.txt?AWSAccessKeyId=AKIAJXXVLMTYDJBPG5UA&Signature=wRqaa49WOpEWfuzWejpDyRcINN4%3D&Expires=1323436551
       #
       # === Parameters
       #
       # [*args (Symbol)] any number of versions
+      # OR
+      # [Hash] query params
       #
       # === Returns
       #
       # [String] the location where this file is accessible via a url
       #
       def url(*args)
-        if(args.first)
-          raise ArgumentError, "Version #{args.first} doesn't exist!" if versions[args.first.to_sym].nil?
+        if (version = args.first) && version.respond_to?(:to_sym)
+          raise ArgumentError, "Version #{version} doesn't exist!" if versions[version.to_sym].nil?
           # recursively proxy to version
-          versions[args.first.to_sym].url(*args[1..-1])
+          versions[version.to_sym].url(*args[1..-1])
+        elsif args.first
+          super(args.first)
         else
-          super()
+          super
         end
       end
 

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -165,6 +165,13 @@ end
                 @fog_file.authenticated_url.should_not be_nil
               end
             end
+
+            it "should handle query params" do
+              if @provider == 'AWS' && !Fog.mocking?
+                headers = Excon.get(@fog_file.url(:query => {"response-content-disposition" => "attachment"})).headers
+                headers["Content-Disposition"].should == "attachment"
+              end
+            end
           end
         end
 

--- a/spec/uploader/url_spec.rb
+++ b/spec/uploader/url_spec.rb
@@ -27,6 +27,10 @@ describe CarrierWave::Uploader do
       lambda { @uploader.url(:thumb) }.should raise_error(ArgumentError)
     end
 
+    it "should not raise exception when hash specified as argument" do
+      lambda { @uploader.url({}) }.should_not raise_error
+    end
+
     it "should not raise ArgumentError when versions version exists" do
       @uploader_class.version(:thumb)
       lambda { @uploader.url(:thumb) }.should_not raise_error(ArgumentError)


### PR DESCRIPTION
As title says this commit lets you add query params to s3 urls, so you can override response headers.

Example:
my_uploader.url
my_uploader.url(:thumb)
my_uploader.url(:thumb, :small)
my_uploader.url(:query => {"response-content-disposition" => "attachment"})
my_uploader.url(:thumb, :small, :query => {"response-content-disposition" => "attachment"})
