### PR TITLE
Allow conditionals to accept blocks

### DIFF
--- a/lib/carrierwave/uploader/processing.rb
+++ b/lib/carrierwave/uploader/processing.rb
@@ -79,7 +79,9 @@ module CarrierWave
       def process!(new_file=nil)
         if enable_processing
           self.class.processors.each do |method, args, condition|
-            next if condition && !self.send(condition, new_file)
+            if(condition)
+              next if !(condition.respond_to?(:call) ? condition.call(self, :args => args, :method => method, :file => new_file) : self.send(condition, new_file))
+            end
             self.send(method, *args)
           end
         end

--- a/lib/carrierwave/uploader/versions.rb
+++ b/lib/carrierwave/uploader/versions.rb
@@ -191,7 +191,15 @@ module CarrierWave
       def active_versions
         versions.select do |name, uploader|
           condition = self.class.versions[name][:options][:if]
-          not condition or send(condition, file)
+          if(condition)
+            if(condition.respond_to?(:call))
+              condition.call(self, :version => name, :file => false)
+            else
+              send(condition, file)
+            end
+          else
+            true
+          end
         end
       end
 

--- a/spec/uploader/processing_spec.rb
+++ b/spec/uploader/processing_spec.rb
@@ -65,6 +65,24 @@ describe CarrierWave::Uploader do
       @uploader.process!("test.jpg")
     end
 
+    it "should call the processor if the condition block returns true" do
+      @uploader_class.process :resize => [200, 300], :if => lambda{|record, args| record.true?(args[:file])}
+      @uploader_class.process :fancy, :if => :true?
+      @uploader.should_receive(:true?).with("test.jpg").twice.and_return(true)
+      @uploader.should_receive(:resize).with(200, 300)
+      @uploader.should_receive(:fancy).with()
+      @uploader.process!("test.jpg")
+    end
+
+    it "should not call the processor if the condition block returns false" do
+      @uploader_class.process :resize => [200, 300], :if => lambda{|record, args| record.false?(args[:file])}
+      @uploader_class.process :fancy, :if => :false?
+      @uploader.should_receive(:false?).with("test.jpg").twice.and_return(false)
+      @uploader.should_not_receive(:resize)
+      @uploader.should_not_receive(:fancy)
+      @uploader.process!("test.jpg")
+    end
+
     context "with 'enable_processing' set to false" do
       it "should not do any processing" do
         @uploader_class.enable_processing = false

--- a/spec/uploader/versions_spec.rb
+++ b/spec/uploader/versions_spec.rb
@@ -278,19 +278,35 @@ describe CarrierWave::Uploader do
         @uploader.store!(@file)
         @uploader.thumb.should be_present
         @uploader.preview.should be_blank
-       end
+      end
 
-       it "should not cache file twice when store! called with a file" do
-         @uploader_class.process :banana
-         @uploader.thumb.class.process :banana
+      it "should process conditional version if the condition block returns true" do
+        @uploader_class.version(:preview)[:options][:if] = lambda{|record, args| record.true?(args[:file])}
+        @uploader.should_receive(:true?).at_least(:once).and_return(true)
+        @uploader.store!(@file)
+        @uploader.thumb.should be_present
+        @uploader.preview.should be_present
+      end
 
-         @uploader.should_receive(:banana).at_least(:once).at_most(:once).and_return(true)
-         @uploader.thumb.should_receive(:banana).at_least(:once).at_most(:once).and_return(true)
+      it "should not process conditional versions if the condition block returns false" do
+        @uploader_class.version(:preview)[:options][:if] = lambda{|record, args| record.false?(args[:file])}
+        @uploader.should_receive(:false?).at_least(:once).and_return(false)
+        @uploader.store!(@file)
+        @uploader.thumb.should be_present
+        @uploader.preview.should be_blank
+      end
 
-         @uploader.store!(@file)
-         @uploader.store_path.should == 'uploads/test.jpg'
-         @uploader.thumb.store_path.should == 'uploads/thumb_test.jpg'
-       end
+      it "should not cache file twice when store! called with a file" do
+        @uploader_class.process :banana
+        @uploader.thumb.class.process :banana
+
+        @uploader.should_receive(:banana).at_least(:once).at_most(:once).and_return(true)
+        @uploader.thumb.should_receive(:banana).at_least(:once).at_most(:once).and_return(true)
+
+        @uploader.store!(@file)
+        @uploader.store_path.should == 'uploads/test.jpg'
+        @uploader.thumb.store_path.should == 'uploads/thumb_test.jpg'
+      end
     end
 
     describe '#recreate_versions!' do


### PR DESCRIPTION
Modification to allow conditionals to accept blocks as well as method name symbols. This allows a bit more flexibility in defining the allowed conditions for a version to be applied.
