### PR TITLE
Fixing the README to show properly how to get an identifier for an uploaded file

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ u.avatar = File.open('somewhere')
 u.save!
 u.avatar.url # => '/url/to/file.png'
 u.avatar.current_path # => 'path/to/file.png'
-u.avatar_identifier # => 'file.png'
+u.avatar.identifier # => 'file.png'
 ```
 
 ### DataMapper, Mongoid, Sequel


### PR DESCRIPTION
An easy fix in the README. It should help the new users to do not try to get the identifier for an uploaded file in a wrong way.
