### PR TITLE
Problem with recreate_version and Fog

### DIFF
--- a/lib/carrierwave/uploader/cache.rb
+++ b/lib/carrierwave/uploader/cache.rb
@@ -70,7 +70,13 @@ module CarrierWave
       # require the file to be stored on the local filesystem.
       #
       def cache_stored_file!
-        sanitized = SanitizedFile.new :tempfile => StringIO.new(file.read),
+        _content = file.read
+        if _content.is_a?(File) # could be if storage is Fog
+          _tempfile = _content.read
+        else
+          _tempfile = StringIO.new(_content)          
+        end
+        sanitized = SanitizedFile.new :tempfile => _tempfile,
           :filename => File.basename(path), :content_type => file.content_type
 
         cache! sanitized


### PR DESCRIPTION
in cache_stored_file! file.read sometimes returns returns a File object.

This seems to happen when you upload a new file, which is cached  between form displays, then save the model, and then a recreate_version! is executed in an after_save. 

I use this to create custom crops in my versions.

It seems like an ugly fix, but I don't really know how to solve it in a better way. Here's some debugging output that might give some clues.

```
(rdb:1) self
  <Fog::Storage::AWS::File
    key="uploads/development/video/screenshot/1/image.jpg",
    cache_control="max-age=315576000",
    content_disposition=nil,
    content_encoding=nil,
    content_length=170769,
    content_md5=nil,
    content_type=nil,
    etag="6bad799a542968e7bfd883c6c550e784",
    expires=nil,
    last_modified=nil,
    metadata={},
    owner=nil,
    storage_class=nil
  >
```

```
(rdb:1) attributes
{:body=>#<File:/blabla/uploads/development/tmp/20111222-1210-4994-6806/bla.jpg>, :content_type=>nil, :key=>"uploads/development/video/screenshot/1/image.jpg", :cache_control=>"max-age=315576000", "x-amz-id-2"=>"XXXXX", "x-amz-request-id"=>"XXXXXX", "Date"=>"Thu, 22 Dec 2011 11:10:49 GMT", :etag=>"6bad799a542968e7bfd883c6c550e784", :content_length=>170769, "Server"=>"AmazonS3"}
```

```
(rdb:1) body
#<File:/blabla/uploads/development/tmp/20111222-1210-4994-6806/bla.jpg>
```
