### PR TITLE
make storages File#url methods to work without any params

### DIFF
--- a/lib/carrierwave/uploader/url.rb
+++ b/lib/carrierwave/uploader/url.rb
@@ -17,7 +17,7 @@ module CarrierWave
       #
       def url(options = {})
         if file.respond_to?(:url) and not file.url.blank?
-          file.url(options)
+          file.method(:url).arity == 0 ? file.url : file.url(options)
         elsif current_path
           (base_path || "") + File.expand_path(current_path).gsub(File.expand_path(root), '')
         end

--- a/spec/uploader/url_spec.rb
+++ b/spec/uploader/url_spec.rb
@@ -31,6 +31,12 @@ describe CarrierWave::Uploader do
       lambda { @uploader.url({}) }.should_not raise_error
     end
 
+    it "should not raise ArgumentError when storage's File#url method doesn't get params" do
+      module StorageX; class File; def url; true; end; end; end
+      @uploader.stub!(:file).and_return(StorageX::File.new)
+      lambda { @uploader.url }.should_not raise_error
+    end
+
     it "should not raise ArgumentError when versions version exists" do
       @uploader_class.version(:thumb)
       lambda { @uploader.url(:thumb) }.should_not raise_error(ArgumentError)


### PR DESCRIPTION
Hi guys,

Please have a look at fix for storages with File#url methods not accepting params.

Related commit: [add query options for s3 to support response headers overwriting](https://github.com/jnicklas/carrierwave/commit/593907495e060ba3a128988fd686c3d97699a3e2#commitcomment-824154)

Best regards,
Mateusz
