### PR TITLE
Force the Proxy#current_path 's encoding to UTF-8

### DIFF
--- a/lib/carrierwave/uploader/proxy.rb
+++ b/lib/carrierwave/uploader/proxy.rb
@@ -18,8 +18,9 @@ module CarrierWave
       #
       # [String] the path where the file is currently located.
       #
+      # NOTICE: force encoding to utf-8
       def current_path
-        file.path if file.respond_to?(:path)
+        file.path.encode('UTF-8') if file.respond_to?(:path)
       end
 
       alias_method :path, :current_path


### PR DESCRIPTION
Hi, there
   I'm using carrierwave in my app, it's pretty nice. But when I try to upload files which path contains some Chinese, it rails `mini_magick_processing_error`. Then I tried the `uploader#store!` method and passed a file which opened using `UTF-8`, but still got the same error. When I digged deepper, I found the `current_path` was the reason to cause the problem. So I forced it to `UTF-8` and it worked. 
   And when read upload file out, say `picture.url`, still suffered with the encoding issue. I'm tried not offend the source code, so I did this and it worked:

``` ruby
class PictureUploader < CarrierWave::Uploader::Base
  alias old_url url
  def url
     old_url.force_encoding('UTF-8')
  end
end
```

   I don't know whether I'm doing the right way or not, so please take a look. 
