### PR TITLE
shows users how to remove generated uploader and associated

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ describe MyUploader do
 
   after do
     MyUploader.enable_processing = false
+    @uploader.remove!
   end
 
   context 'the thumb version' do


### PR DESCRIPTION
small change to readme file may be useful for users seeking how to remove uploaders (and the associated files)  created in the uploader specs
