### PR TITLE
resize_and_pad pads with black, not white

### DIFF
--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -206,7 +206,7 @@ module CarrierWave
         img.combine_options do |cmd|
           cmd.thumbnail "#{width}x#{height}>"
           if background == :transparent
-            cmd.background "rgba(0, 0, 0, 0.0)"
+            cmd.background "rgba(255, 255, 255, 0.0)"
           else
             cmd.background background
           end

--- a/spec/processing/mini_magick_spec.rb
+++ b/spec/processing/mini_magick_spec.rb
@@ -48,6 +48,15 @@ describe CarrierWave::MiniMagick do
       @instance.resize_and_pad(1000, 1000)
       @instance.should have_dimensions(1000, 1000)
     end
+
+    it "should pad with white" do
+      @instance.resize_and_pad(200, 200)
+      image = ::MiniMagick::Image.open(@instance.current_path)
+      x, y = 0, 0
+      color = image.run_command("convert", "#{image.escaped_path}[1x1+#{x}+#{y}]", "-depth 8", "txt:").split("\n")[1]
+      color.should include('#FFFFFF')
+    end
+
   end
 
   describe '#resize_to_fit' do


### PR DESCRIPTION
When using resize_and_pad on a .jpeg image without specifying the background color, or when specifying :transparent, the padding is black instead of white.
