### PR TITLE
add gravity option to resize_to_fill

### DIFF
--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -158,7 +158,7 @@ module CarrierWave
     #
     # [width (Integer)] the width to scale the image to
     # [height (Integer)] the height to scale the image to
-    # [gravity (String)] the current gravity suggestion (default: Center; options: NorthWest, North, NorthEast, West, Center, East, SouthWest, South, SouthEast)
+    # [gravity (String)] the current gravity suggestion (default: 'Center'; options: 'NorthWest', 'North', 'NorthEast', 'West', 'Center', 'East', 'SouthWest', 'South', 'SouthEast')
     #
     # === Yields
     #


### PR DESCRIPTION
It looks like the gravity option for resize_to_fill was missing from the ClassMethods. For instance, setting up a version like this:

``` ruby
version :large do
  resize_to_fill(600, 600, 'North')
end
```

would result in a "wrong number of arguments" error. I couldn't find a set of tests which used the public ClassMethods, but all existing tests still passed after this addition. Let me know if there's anything I should change/try.
