### PR TITLE
Fog storage leaks a file descriptor

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -243,6 +243,7 @@ module CarrierWave
             :key          => path,
             :public       => @uploader.fog_public
           }.merge(@uploader.fog_attributes))
+          fog_file.close if fog_file && !fog_file.closed?
           true
         end
 


### PR DESCRIPTION
This pull is more like a RFC than an actual fix.

When storing a file using fog, the method `CarrierWave::Storage::Fog::File#store` leaves a file descriptor open and can possibly exceed OS file descriptor count limit. (A valid use case is when you create a new version in an uploader and wants to generate it for all entries in your database. `#store` leaves 1 fd open for each version, including the original, and Linux, for example, limits open fd's to 1024, so you can quickly exceed that in a batch operation using `#recreate_versions!`)

Actually, it may be that `CarrierWave::SanitizedFile#to_file` is to blame, because it `File.open`'s and then delegates to the caller the responsibility to close the file. I know that behavior from C functions, but I'm not sure if it's the correct design here, because I lack the knowledge on CarrierWave and am left with unanswered questions: which entity should know the state of the `open()`'d file? It seems `SanitizedFile` can be initialized with a `File` object, and `#to_file` simply forwards it if that's the case, so, is it safe to `close()` it from outside? The current implementation makes it impossible to decide, since `#to_file` either returns `@file` if it's a `File` or a brand new object from `File.open`.
Since it seems `#to_file` was exclusively created to be used in `#store` (there's only a single occurrence of a `#to_file` call and it's inside `#store`), maybe it would be better to remove the whole `#to_file` method, pass only the path and the client opens and closes it?

In this fix, I chose the laziest approach and closed the file from outside.

Also, I didn't write any specs because I wasn't sure what was to be tested: the way it is now, `#to_file` throws the `open()`'d file and forgets. So it comes down to testing that there are zero open file descriptors after callers of `#to_file` are done, which sounds like implementing a james bond test like a kernel module. Or am I wrong?

If it matters, I pinned that `File.open` down using [rbtrace](https://github.com/tmm1/rbtrace) on a call to `#recreate_versions!` ([tracer used](https://gist.github.com/1784153) and the [output](https://gist.github.com/1784185) of it, interesting lines in the output: 1241-1271) and monitoring `/proc/<pid>/fd/*` (and a lot of code reading, of course).
