### PR TITLE
adding head method and exists to check if file exists

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -227,6 +227,17 @@ module CarrierWave
         def size
           file.content_length
         end
+        
+        ##
+        # Checks if file exists
+        #
+        # === Returns
+        #
+        # [Boolean] true if it exists or false
+        
+        def exists?
+          head.nil?
+        end
 
         ##
         # Write file to service
@@ -334,6 +345,17 @@ module CarrierWave
         #
         def file
           @file ||= directory.files.get(path)
+        end
+        
+        ##
+        # lookup file head
+        #
+        # === Returns
+        #
+        # [Fog::#{provider}::File] file data wrapper, body is retrieved on demand
+        #        
+        def head 
+          directory.files.head(path)
         end
 
       end


### PR DESCRIPTION
now using the head method instead of get, looks like it provides the same support across providers.  i'm not storing the head response in an instance variable, as i think it should be a live request.
