### PR TITLE
Leave URI Sanitization to the user

### DIFF
--- a/lib/carrierwave/uploader/download.rb
+++ b/lib/carrierwave/uploader/download.rb
@@ -67,7 +67,7 @@ module CarrierWave
       # [url (String)] The URL where the remote file is stored
       #
       def process_uri(uri)
-        URI.parse(URI.escape(URI.unescape(uri)))
+        URI.parse(uri)
       end
 
     end # Download

--- a/spec/uploader/download_spec.rb
+++ b/spec/uploader/download_spec.rb
@@ -79,9 +79,10 @@ describe CarrierWave::Uploader::Download do
       }.should raise_error(CarrierWave::DownloadError)
     end
 
-    it "should accept spaces in the url" do
-      @uploader.download!('http://www.example.com/test with spaces/test.jpg')
-      @uploader.url.should == '/uploads/tmp/20071201-1234-345-2255/test.jpg'
+    it "should not accept invalid URIs" do
+      lambda {
+        @uploader.download!('http://www.example.com/test with spaces/test.jpg')
+      }.should raise_error URI::InvalidURIError
     end
 
     it "should follow redirects" do
@@ -124,11 +125,6 @@ describe CarrierWave::Uploader::Download do
 
   describe '#process_uri' do
     let(:uri) { "http://www.example.com/test%20image.jpg" }
-
-    it 'should unescape and then escape the given uri' do
-      unescaped_uri = URI.unescape(uri)
-      @uploader.process_uri(unescaped_uri).should == @uploader.process_uri(uri)
-    end
 
     it 'should parse the given uri' do
       @uploader.process_uri(uri).should == URI.parse(uri)


### PR DESCRIPTION
Square bracket uris cannot be used to upload an image via carrierwave. This is because of a bug in ruby whose fix has been rejected.

I believe that a reasonable approach is to delegate the duty of sanitizing URIs to the user (i.e. developer using the library). That way they can use whatever practice they are comfortable with to sanitize URIs.

In my case that caused this patch, I have a list of URIs from a trusted source and I am doing a bulk import. Carrierwave is incredibly good at this, except for URIs with brackets in them.

This patch passes all tests because it changes the expectations of the library, as seen in the diff.

If an invalid URI is passed to carrierwave, URI will raise a URI::InvalidURIError, which is tested for in the specs. This will easily alert the developer to the cause of the problem.

Thanks!
xoxo @ngauthier
