### PR TITLE
changing check to inverse on head response if nil?

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -227,6 +227,17 @@ module CarrierWave
         def size
           file.content_length
         end
+        
+        ##
+        # Checks if file exists
+        #
+        # === Returns
+        #
+        # [Boolean] true if it exists or false
+        
+        def exists?
+          head.nil? == false
+        end
 
         ##
         # Write file to service
@@ -334,6 +345,17 @@ module CarrierWave
         #
         def file
           @file ||= directory.files.get(path)
+        end
+        
+        ##
+        # lookup file head
+        #
+        # === Returns
+        #
+        # [Fog::#{provider}::File] file data wrapper, body is retrieved on demand
+        #        
+        def head 
+          directory.files.head(path)
         end
 
       end


### PR DESCRIPTION
http://fog.io/1.1.2/rdoc/Fog/Storage/AWS/Files.html
# File lib/fog/aws/models/storage/files.rb, line 91

def head(key, options = {})
  requires :directory
  data = connection.head_object(directory.key, key, options)
  file_data = data.headers.merge({
    :key => key
  })
  normalise_headers(file_data)
  new(file_data)
rescue Excon::Errors::NotFound
  nil
end
