### PR TITLE
Fixed root path in uploader.rb in order to work correctly Rails 3.2.2

### DIFF
--- a/lib/carrierwave/uploader/url.rb
+++ b/lib/carrierwave/uploader/url.rb
@@ -19,7 +19,8 @@ module CarrierWave
         if file.respond_to?(:url) and not file.url.blank?
           file.method(:url).arity == 0 ? file.url : file.url(options)
         elsif current_path
-          (base_path || "") + File.expand_path(current_path).gsub(File.expand_path(CarrierWave.root), '')
+          root ||= CarrierWave.root
+          (base_path || "") + File.expand_path(current_path).gsub(File.expand_path(root), '')
         end
       end
 


### PR DESCRIPTION
Recently I upgrade Rails to 3.2.2 and got the error 

``` ruby
TypeError: can't convert nil into String
```

when I finish uploading and try to get the file path (job.app_url for example)

`root` seems to be nil, `CarrierWave.root` seems to work.
