### PR TITLE
Fix problem where resize_to_fill would remove the transparency of a png

### DIFF
--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -175,6 +175,7 @@ module CarrierWave
             cmd.resize "#{cols}x#{rows}"
           end
           cmd.gravity gravity
+          cmd.background "rgba(255,255,255,0.0)"
           cmd.extent "#{width}x#{height}" if cols != width || rows != height
         end
         img = yield(img) if block_given?


### PR DESCRIPTION
...and replace it with the default background color.

This happens when the -extent command crops the image.

From the http://www.imagemagick.org/Usage/crop/#extent :

> Note that "-extent" works by using the same 'overlay' technique that both the Border and Frame operators uses. As such by default using it with a image containing transparency will replace the transparency with the current "-background" color.
