### PR TITLE
CarrierWave::Storage::Fog::File.size changed 

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -225,7 +225,7 @@ module CarrierWave
         # [Integer] size of file body
         #
         def size
-          file.content_length
+          file.try(:content_length) || 0
         end
 
         ##

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -120,6 +120,17 @@ end
             @fog_file.delete
             @directory.files.head('uploads/test.jpg').should == nil
           end
+          
+          context "file does not exist" do
+            before do 
+              @uploader.stub!(:store_path).with('test.jpg').and_return('uploads/unexisting.jpg')              
+              @fog_file = @storage.retrieve!('test.jpg')
+            end
+            
+            it "should have zero size" do
+              @fog_file.size.should be_zero
+            end
+          end
         end
 
         describe 'fog_public' do


### PR DESCRIPTION
CarrierWave::Storage::Fog::File.size changed  to return zero size when file physically does not exist. 

So that I will not get strange error like this: 

> undefined method `content_length' for nil:NilClass
> carrierwave-789a8b952764/lib/carrierwave/storage/fog.rb:228:in`size'
