### PR TITLE
Generate a nicer validation error message by turning the extension white list into a sentence.

### DIFF
--- a/lib/carrierwave/uploader/extension_whitelist.rb
+++ b/lib/carrierwave/uploader/extension_whitelist.rb
@@ -40,7 +40,7 @@ module CarrierWave
       def check_whitelist!(new_file)
         extension = new_file.extension.to_s
         if extension_white_list and not extension_white_list.detect { |item| extension =~ /\A#{item}\z/i }
-          raise CarrierWave::IntegrityError, I18n.translate(:"errors.messages.extension_white_list_error", :extension => new_file.extension.inspect, :allowed_types => extension_white_list.to_sentence)
+          raise CarrierWave::IntegrityError, I18n.translate(:"errors.messages.extension_white_list_error", :extension => new_file.extension.inspect, :allowed_types => extension_white_list.join(", "))
         end
       end
 


### PR DESCRIPTION
I monkey-patched this change in my Rails project and I think carrierwave might benefit from it as well. It might break tests as I haven't checked out carrierwave (yay for githubs editor). If you find it acceptable, then I can do the rest of the work of making sure tests pass, checking whether the white list actually responds to to_sentence, etc.
