### PR TITLE
#serializable_hash broken with no options

### DIFF
--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -45,8 +45,12 @@ module CarrierWave
 
         def serializable_hash(options=nil)
           hash = {}
+
+          except = options && options[:except] && Array.wrap(options[:except]).map(&:to_s)
+          only   = options && options[:only]   && Array.wrap(options[:only]).map(&:to_s)
+
           self.class.uploaders.each do |column, uploader|
-            if (!options[:only] && !options[:except]) || (options[:only] && options[:only].include?(column)) || (options[:except] && !options[:except].include?(column))
+            if (!only && !except) || (only && only.include?(column.to_s)) || (except && !except.include?(column.to_s))
               hash[column.to_s] = _mounter(:#{column}).uploader.serializable_hash
             end
           end

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -332,6 +332,28 @@ describe CarrierWave::ActiveRecord do
 
     end
 
+    describe "#serializable_hash" do
+
+      it "should include the image with url" do
+        @event.image = stub_file("test.jpg")
+        @event.serializable_hash["image"].should have_key("url")
+      end
+
+      it "should include the other columns" do
+        ["id", "foo"].each do |key|
+          @event.serializable_hash.should have_key(key)
+        end
+      end
+
+      it "should take an option to exclude the image column" do
+        @event.serializable_hash(:except => :image).should_not have_key("image")
+      end
+
+      it "should take an option to only include the image column" do
+        @event.serializable_hash(:only => :image).should have_key("image")
+      end
+    end
+
     describe '#destroy' do
 
       it "should do nothing when no file has been assigned" do


### PR DESCRIPTION
This fixes a bug I hit using Tire
which also makes use of #serializable_hash

Specifically the current implementation breaks if we call
`record.serializable_hash`

I have also rewritten the method to function more like ActiveRecord's implementation.

Namely it now uses Array.wrap
and changes everything to strings.
