### PR TITLE
Escape plusses for the download!

### DIFF
--- a/lib/carrierwave/uploader/download.rb
+++ b/lib/carrierwave/uploader/download.rb
@@ -67,7 +67,7 @@ module CarrierWave
       # [url (String)] The URL where the remote file is stored
       #
       def process_uri(uri)
-        URI.parse(URI.escape(URI.unescape(uri)).gsub("[", "%5B").gsub("]", "%5D"))
+        URI.parse(URI.escape(URI.unescape(uri)).gsub("[", "%5B").gsub("]", "%5D").gsub("+", "%2B"))
       end
 
     end # Download

--- a/spec/uploader/download_spec.rb
+++ b/spec/uploader/download_spec.rb
@@ -22,6 +22,7 @@ describe CarrierWave::Uploader::Download do
       sham_rack_app.register_resource('/test.jpg', File.read(file_path('test.jpg')), 'image/jpg')
       sham_rack_app.register_resource('/test%20with%20spaces/test.jpg', File.read(file_path('test.jpg')), 'image/jpg')
       sham_rack_app.register_resource('/test-with-brackets/test-%5B4%5D.jpg', File.read(file_path('test.jpg')), 'image/jpg')
+      sham_rack_app.register_resource('/test-with-params/test.jpg?param=foo%2Bbar', File.read(file_path('test.jpg')), 'image/jpg')
 
       ShamRack.at("www.redirect.com") do |env|
         [301, {'Content-Type'=>'text/html', 'Location'=>"http://www.example.com/test.jpg"}, ['Redirecting']]
@@ -88,6 +89,11 @@ describe CarrierWave::Uploader::Download do
     it "should accept brackets in the url" do
       @uploader.download!('http://www.example.com/test-with-brackets/test-[4].jpg')
       @uploader.url.should == '/uploads/tmp/20071201-1234-345-2255/test-_5B4_5D.jpg'
+    end
+
+    it "should escape plusses in the url params" do
+      @uploader.download!('http://www.example.com/test-with-params/test.jpg?param=foo+bar')
+      @uploader.url.should == '/uploads/tmp/20071201-1234-345-2255/test.jpg'
     end
 
     it "should follow redirects" do


### PR DESCRIPTION
If there's a plus in, say, an S3 signed request generated by fog, and it gets unescaped, you'll get a 403 when you try and hit it.

I was getting similar symptoms to #294 whenever my signed requests to S3 had a plus in them - this fixes that. I'd like to make sure it doesn't break urls for folks if there's a plus in the non-params.

Another possibility (and one that I'm actually doing on my side of things) is to get smarter about how params are handled in a remote_url. I'm having to explicitly strip off params in [my fork of carrierwave_direct](https://github.com/adrianpike/carrierwave_direct/blob/c73c79344444a65f7adffa034b8696d8fa5c36e0/lib/carrierwave_direct/uploader.rb#L94), otherwise my generated versions have the params included in their name. This is on my list of things to investigate post-launch, whether this is cw-direct or cw's responsibility.

Thanks!
