### PR TITLE
Add more sophisticated multi-page PDF support

### DIFF
--- a/lib/carrierwave/processing/rmagick.rb
+++ b/lib/carrierwave/processing/rmagick.rb
@@ -249,13 +249,14 @@ module CarrierWave
 
       frames = if image.size > 1
         list = ::Magick::ImageList.new
-        image.each do |frame|
-          list << (block_given? ? yield( frame ) : frame)
+        image.each_with_index do |frame, index|
+          processed_frame = block_given? ? yield( frame, index ) : frame
+          list << processed_frame if processed_frame
         end
         block_given? ? list : list.append(true)
       else
         frame = image.first
-        frame = yield( frame ) if block_given?
+        frame = yield( frame, 0 ) if block_given?
         frame
       end
 


### PR DESCRIPTION
Hi,

I needed a way to extract the cover of a PDF as a separate version. 

Unfortunately, the current multi-page PDF support in the RMagick processor lets you either generate all pages as separate images or one vertically-joined image. 

This patch allows you to accept an additional parameter, zero-indexed page number, from the `manipulate!` block. 

You can then write a custom processor like this:

``` ruby
def cover 
  manipulate! do |frame, index|
    frame if index.zero?
  end
end
```

Single page PDFs and regular images will receive `index = 0`, and existing processors can ignore the index parameter. This patch should also work for other multi-frame files, such as animated GIFs.
