### PR TITLE
Fix gemspec compatibility with old rubygems

### DIFF
--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "mysql2"
   s.add_development_dependency "rails", ">= 3.2.0"
-  s.add_development_dependency "cucumber", "1.1.4"
+  s.add_development_dependency "cucumber", "= 1.1.4"
   s.add_development_dependency "json"
   s.add_development_dependency "rspec", "~> 2.0"
   s.add_development_dependency "sham_rack"


### PR DESCRIPTION
Old rubygems versions (eg. 1.3.7) without this fix
https://github.com/rubygems/rubygems/commit/a2498af
don't like version numbers without a prefix.
As the gemspec specifies to be dependent on rubygems
1.3.5 we should fix this.
Also see https://github.com/rubygems/rubygems/pull/121
for discussion.

This should fix gh-674.
