### PR TITLE
Clear the AR column from remove_#{column}! (Issue #401)

### DIFF
--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -43,6 +43,12 @@ module CarrierWave
           super
         end
 
+        def remove_#{column}!
+          super
+          _mounter(:#{column}).remove = true
+          _mounter(:#{column}).write_identifier
+        end
+
         def serializable_hash(options=nil)
           hash = {}
 

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -318,6 +318,18 @@ describe CarrierWave::ActiveRecord do
       end
     end
 
+    describe "remove_image!" do
+      before do
+        @event.image = stub_file('test.jpeg')
+        @event.save!
+        @event.remove_image!
+      end
+
+      it "should clear the serialization column" do
+        @event.attributes['image'].should be_blank
+      end
+    end
+
     describe "dirty tracking with remote_image_url" do
 
       # FIXME ideally image_changed? and remote_image_url_changed? would return true


### PR DESCRIPTION
Clear the serialization column by calling `remove=` and `write_identifier` on the mounter after the default behaviour has run. 

@bcardarella also included specs for the case where the serialization column is manually wiped by the user, but I'm not sure I agree that CW should handle this (except perhaps by raising an exception). 

See https://github.com/bcardarella/carrierwave-failure/blob/master/spec/carrierwave_spec.rb (line 35) and let me know what you think. 
