### PR TITLE
Check for PADRINO_ROOT explicitly when setting CarrierWave.root

### DIFF
--- a/lib/carrierwave.rb
+++ b/lib/carrierwave.rb
@@ -95,7 +95,7 @@ elsif defined?(Rails)
   end
 
 elsif defined?(Sinatra)
-  if defined?(Padrino)
+  if defined?(Padrino) && defined?(PADRINO_ROOT)
     CarrierWave.root = File.join(PADRINO_ROOT, "public")
   else
 


### PR DESCRIPTION
As padrino components can be used as standalone components in a sinatra application (without defining `PADRINO_ROOT`), carrierwave should check that `PADRINO_ROOT` is defined explicitly, instead of assuming it is.
