### PR TITLE
Add :write option to manipulate!. Issue #711.

### DIFF
--- a/spec/processing/rmagick_spec.rb
+++ b/spec/processing/rmagick_spec.rb
@@ -73,6 +73,23 @@ describe CarrierWave::RMagick do
     end
   end
 
+  describe "#manipulate!" do
+    it 'should support passing write options to RMagick' do
+      image = ::Magick::Image.read(file_path('landscape_copy.jpg'))
+      ::Magick::Image.stub(:read => image)
+      ::Magick::Image::Info.any_instance.should_receive(:quality=).with(50)
+      ::Magick::Image::Info.any_instance.should_receive(:depth=).with(8)
+      
+      @instance.manipulate! do |img, index, options|
+        options[:write] = {
+          :quality => 50,
+          :depth => 8
+        }
+        img
+      end
+    end
+  end
+
   describe "test errors" do
     context "invalid image file" do
       before do


### PR DESCRIPTION
Options for the RMagick `#write` call can now be added to the options under the `:write` key. Since the `#write` call takes a block containing assignments, these options are translated to a lambda. 

Also, the options argument is now yielded to the block, allowing it to be updated based on the image object (eg. change interlace option only if necessary). 

Example: 

```
manipulate! do |img, index, options|
  options[:write] = {
    :quality => 50,
    :depth => 8
  }
  img
end
```

is translated to

```
image.write do |img|
  self.quality = 50
  self.depth = 8
end
```

By the way I apologize for the ugly stubbing in the spec. I didn't see how else to test this without factoring out `::Magick` from `CW::RMagick`. 
