### PR TITLE
Fix bug in #remove_#{column} when filename is set explicitly

### DIFF
--- a/lib/carrierwave/mount.rb
+++ b/lib/carrierwave/mount.rb
@@ -296,11 +296,11 @@ module CarrierWave
       end
 
       def write_identifier
-        if remove?
-          record.write_uploader(serialization_column, '')
-        elsif not uploader.identifier.blank?
-          record.write_uploader(serialization_column, uploader.identifier)
-        end
+        return if record.frozen? || uploader.identifier.blank?
+
+        value = remove? ? '' : uploader.identifier
+
+        record.write_uploader(serialization_column, value)
       end
 
       def identifier

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -419,6 +419,20 @@ describe CarrierWave::ActiveRecord do
 
     describe '#destroy' do
 
+      it "should not raise an error with a custom filename" do
+        @uploader.class_eval do 
+          def filename 
+            "page.jpeg"
+          end
+        end
+
+        @event.image = stub_file('test.jpeg')
+        @event.save.should be_true
+        expect {
+          @event.destroy
+        }.to_not raise_error
+      end
+
       it "should do nothing when no file has been assigned" do
         @event.save.should be_true
         @event.destroy


### PR DESCRIPTION
Hi guys,

This patch fixes a bug introduced in 574e79c8c68317e85365c887094b09a0cc7a16b5 where removing a record fails if the uploader's filename is set explicitly.
