### PR TITLE
Add :read option to manipulate!

### DIFF
--- a/spec/processing/rmagick_spec.rb
+++ b/spec/processing/rmagick_spec.rb
@@ -80,13 +80,23 @@ describe CarrierWave::RMagick do
       ::Magick::Image::Info.any_instance.should_receive(:quality=).with(50)
       ::Magick::Image::Info.any_instance.should_receive(:depth=).with(8)
       
-      @instance.manipulate! do |img, index, options|
+      @instance.manipulate! do |image, index, options| 
         options[:write] = {
           :quality => 50,
           :depth => 8
         }
-        img
+        image
       end
+    end
+
+    it 'should support passing read options to RMagick' do
+      ::Magick::Image::Info.any_instance.should_receive(:density=).with(10)
+      ::Magick::Image::Info.any_instance.should_receive(:size=).with("200x200")
+      
+      @instance.manipulate! :read => {
+          :density => 10,
+          :size => %{"200x200"}
+        }
     end
   end
 


### PR DESCRIPTION
Hi guys,

I added the ability to pass :read options to manipulate! in the RMagick processor. With this you can now do things that previously you could only do via command line. For example, 

`convert -density 300 image.ext new-image.ext`, 

can now be :

`manipulate! :read => { :density => 300 }`.
