### PR TITLE
Add binary/octet-stream as generic mime type.

### DIFF
--- a/lib/carrierwave/processing/mime_types.rb
+++ b/lib/carrierwave/processing/mime_types.rb
@@ -32,6 +32,12 @@ module CarrierWave
       end
     end
 
+    GENERIC_CONTENT_TYPES = %w[application/octet-stream binary/octet-stream]
+
+    def generic_content_type?
+      GENERIC_CONTENT_TYPES.include? file.content_type
+    end
+
     ##
     # Changes the file content_type using the mime-types gem
     #
@@ -42,7 +48,7 @@ module CarrierWave
     #                      false by default
     #
     def set_content_type(override=false)
-      if override || file.content_type.blank? || file.content_type == 'application/octet-stream'
+      if override || file.content_type.blank? || generic_content_type?
         new_content_type = ::MIME::Types.type_for(file.original_filename).first.to_s
         if file.respond_to?(:content_type=)
           file.content_type = new_content_type

--- a/spec/processing/mime_types_spec.rb
+++ b/spec/processing/mime_types_spec.rb
@@ -34,10 +34,18 @@ describe CarrierWave::MimeTypes do
       @instance.set_content_type
     end
 
-    it "sets content_type if content_type is generic" do
-      @instance.file.content_type = 'application/octet-stream'
+    it "set content_type if content_type is empty" do
+      @instance.file.content_type = ''
       @instance.file.should_receive(:content_type=).with('image/jpeg')
       @instance.set_content_type
+    end
+
+    %w[ application/octet-stream binary/octet-stream ].each do |type|
+      it "sets content_type if content_type is generic (#{type})" do
+        @instance.file.content_type = type
+        @instance.file.should_receive(:content_type=).with('image/jpeg')
+        @instance.set_content_type
+      end
     end
 
     it "sets content_type if override is true" do


### PR DESCRIPTION
I refactored a bit of code in the MimeTypes module to add 'binary/octet-stream' as a generic mime type. This is [the default for files uploaded to S3](http://docs.amazonwebservices.com/AmazonS3/latest/API/RESTObjectPUT.html) and is something we're running into in an application I'm working on.

Thanks for all your hard work! :cake:
