### PR TITLE
Fix SanitizedFile#to_file on Windows (binary mode)

### DIFF
--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -228,7 +228,7 @@ module CarrierWave
     #
     def to_file
       return @file if @file.is_a?(File)
-      File.open(path) if exists?
+      File.open(path, "rb") if exists?
     end
 
     ##


### PR DESCRIPTION
Storage backends that use SanitizedFile#to_file (e.g. CarrierWave::Storage::Fog) break on Windows when trying to store binary files, due to the files being opened in text mode.

This patch fixes this issue.
