### PR TITLE
Add Code Climate badge to CarrierWave

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This gem provides a simple and extremely flexible way to upload files from Ruby 
 It works well with Rack based web applications, such as Ruby on Rails.
 
 [![Build Status](https://secure.travis-ci.org/jnicklas/carrierwave.png)](http://travis-ci.org/jnicklas/carrierwave)
+[![Code Quality](https://codeclimate.com/badge.png)](https://codeclimate.com/github/jnicklas/carrierwave)
 
 ## Information
 


### PR DESCRIPTION
Hey Jonas,

This adds a link to Code Climate from the CarrierWave README, like I did for Capybara. Here's a link to the metrics:

https://codeclimate.com/github/jnicklas/carrierwave

I explained a bit more about what this is in a pull request on Capybara:

https://github.com/jnicklas/capybara/pull/741

Let me know if you have any questions.

Cheers,

-Bryan
