### PR TITLE
Also use AWS S3 subdomain URL when directory name contains a period.

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -286,7 +286,7 @@ module CarrierWave
             case @uploader.fog_credentials[:provider]
             when 'AWS'
               # if directory is a valid subdomain, use that style for access
-              if @uploader.fog_directory.to_s =~ /^(?:[a-z]|\d(?!\d{0,2}(?:\d{1,3}){3}$))(?:[a-z0-9]|(?![\-])|\-(?![\.])){1,61}[a-z0-9]$/
+              if @uploader.fog_directory.to_s =~ /^(?:[a-z]|\d(?!\d{0,2}(?:\d{1,3}){3}$))(?:[a-z0-9\.]|(?![\-])|\-(?![\.])){1,61}[a-z0-9]$/
                 "https://#{@uploader.fog_directory}.s3.amazonaws.com/#{path}"
               else
                 # directory is not a valid subdomain, so use path style for access

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -61,6 +61,20 @@ end
                 @fog_file.url.should_not be_nil
               end
             end
+
+            it "should use a subdomain URL for AWS if the directory is a valid subdomain" do
+              if @provider == 'AWS'
+                @uploader.stub(:fog_directory).and_return('assets.site.com')
+                @fog_file.public_url.should include('https://assets.site.com.s3.amazonaws.com')
+              end
+            end
+
+            it "should not use a subdomain URL for AWS if the directory is not a valid subdomain" do
+              if @provider == 'AWS'
+                @uploader.stub(:fog_directory).and_return('SiteAssets')
+                @fog_file.public_url.should include('https://s3.amazonaws.com/SiteAssets')
+              end
+            end
           end
 
           context "with fog_host" do


### PR DESCRIPTION
See #285 for info about the difference between AWS subdomain URLs (`https://#{bucket_name}.s3.amazonaws.com`) and path URLs (`https://s3.amazonaws.com/#{bucket_name}`).

Currently, the subdomain URL is not being used for buckets with a name containing a period like `assets.example.com`, while Amazon is perfectly fine with this and while this is actually required for buckets outside of the US Standard zone.

This pull request modifies the regular expression to allow this.
