### PR TITLE
work with active_model_serializers

### DIFF
--- a/lib/carrierwave/uploader/serialization.rb
+++ b/lib/carrierwave/uploader/serialization.rb
@@ -13,7 +13,7 @@ module CarrierWave
       end
 
       def as_json(options=nil)
-        Hash[mounted_as || "uploader", serializable_hash]
+        serializable_hash
       end
 
       def to_json

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -102,7 +102,7 @@ describe CarrierWave::ActiveRecord do
         @event.save!
         @event.reload
 
-        JSON.parse({:data => @event.image}.to_json).should == {"data"=>{"image"=>{"url"=>"/uploads/test.jpeg"}}}
+        JSON.parse({:data => @event.image}.to_json).should == {"data"=>{"url"=>"/uploads/test.jpeg"}}
       end
 
       it "should return valid XML when to_xml is called when image is nil" do

--- a/spec/uploader/url_spec.rb
+++ b/spec/uploader/url_spec.rb
@@ -92,24 +92,22 @@ describe CarrierWave::Uploader do
     it "should return a hash with a nil URL" do
       MyCoolUploader.version(:thumb)
       hash = JSON.parse(@uploader.to_json)
-      hash.keys.should
-      hash.keys.should include("uploader")
-      hash["uploader"].keys.should include("url")
-      hash["uploader"].keys.should include("thumb")
-      hash["uploader"]["url"].should be_nil
-      hash["uploader"]["thumb"].keys.should include("url")
-      hash["uploader"]["thumb"]["url"].should be_nil
+      hash.keys.should include("url")
+      hash.keys.should include("thumb")
+      hash["url"].should be_nil
+      hash["thumb"].keys.should include("url")
+      hash["thumb"]["url"].should be_nil
     end
 
     it "should return a hash including a cached URL" do
       @uploader.cache!(File.open(file_path("test.jpg")))
-      JSON.parse(@uploader.to_json).should == {"uploader" => {"url" => "/uploads/tmp/20071201-1234-345-2255/test.jpg"}}
+      JSON.parse(@uploader.to_json).should == {"url" => "/uploads/tmp/20071201-1234-345-2255/test.jpg"}
     end
 
     it "should return a hash including a cached URL of a version" do
       MyCoolUploader.version(:thumb)
       @uploader.cache!(File.open(file_path("test.jpg")))
-      hash = JSON.parse(@uploader.to_json)["uploader"]
+      hash = JSON.parse(@uploader.to_json)
       hash.keys.should include "thumb"
       hash["thumb"].should == {"url" => "/uploads/tmp/20071201-1234-345-2255/thumb_test.jpg"}
     end


### PR DESCRIPTION
Hi, I'm using active_model_serializers to serialize my models to json,
my serializer just like this:

``` ruby
class UserSerializer < ActiveModel::Serializer
  attributes :id, :username, :avatar # avatar is an uploader
end
```

and i expect the output should be:

``` json
{
  "user": {
    "id": 1,
    "username": "ayamomiji",
    "avatar": {
      "url": "/assets/avatar.jpeg",
      "thumb": {
        "url": "/assets/thumb-avatar.jpeg"
      }
    }
  }
}
```

but it was:

``` json
{
  "user": {
    "id": 1,
    "username": "ayamomiji",
    "avatar": {
      "avatar": {
        "url": "/assets/avatar.jpeg",
        "thumb": {
          "url": "/assets/thumb-avatar.jpeg"
        }
      }
    }
  }
}
```

it nested with an unnecessary key (avatar), so i just patch to remove it.
