### PR TITLE
Compressed tarballs extensions

### DIFF
--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -303,7 +303,7 @@ module CarrierWave
     def split_extension(filename)
       # regular expressions to try for identifying extensions
       extension_matchers = [
-        /\A(.+)\.(tar\.gz)\z/, # matches "something.tar.gz"
+        /\A(.+)\.(tar\.([glx]?z|bz2))\z/, # matches "something.tar.gz"
         /\A(.+)\.([^\.]+)\z/ # matches "something.jpg"
       ]
 

--- a/spec/sanitized_file_spec.rb
+++ b/spec/sanitized_file_spec.rb
@@ -68,9 +68,11 @@ describe CarrierWave::SanitizedFile do
   end
 
   describe '#extension' do
-    it "should return the extension for complicated extensions" do
-      @sanitized_file = CarrierWave::SanitizedFile.new(file_path('complex.filename.tar.gz'))
-      @sanitized_file.extension.should == "tar.gz"
+    %w[gz bz2 z lz xz].each do |ext|
+      it "should return the extension for complicated extensions (tar.#{ext})" do
+        @sanitized_file = CarrierWave::SanitizedFile.new(file_path("complex.filename.tar.#{ext}"))
+        @sanitized_file.extension.should == "tar.#{ext}"
+      end
     end
 
     it "should return the extension for real-world user file names" do


### PR DESCRIPTION
The following are listed in Wikipedia:
- tar.gz
- tar.bz2
- tar.z
- tar.lx
- tar.xz
