### PR TITLE
Replace fog_host by fog_endpoint and asset_host config options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,9 +509,9 @@ CarrierWave.configure do |config|
     :region                 => 'eu-west-1'  # optional, defaults to 'us-east-1'
   }
   config.fog_directory  = 'name_of_directory'                     # required
-  config.fog_host       = 'https://assets.example.com'            # optional, defaults to nil
   config.fog_public     = false                                   # optional, defaults to true
   config.fog_attributes = {'Cache-Control'=>'max-age=315576000'}  # optional, defaults to {}
+  config.asset_host     = 'https://assets.example.com'            # optional, defaults to nil
 end
 ```
 
@@ -552,7 +552,7 @@ This is *highly* recommended, as without it every request requires a lookup
 of this information.
 
 ```ruby
-config.fog_host = "http://c000000.cdn.rackspacecloud.com"
+config.asset_host = "http://c000000.cdn.rackspacecloud.com"
 ```
 
 In your uploader, set the storage to :fog
@@ -599,13 +599,13 @@ end
 That's it! You can still use the `CarrierWave::Uploader#url` method to return
 the url to the file on Google.
 
-## Dynamic Fog Host
+## Dynamic Asset Host
 
-The `fog_host` config property can be assigned a proc (or anything that responds to `call`) for generating the host dynamically. The proc-compliant object gets an instance of the current `CarrierWave::Storage::Fog::File` as its only argument.
+The `asset_host` config property can be assigned a proc (or anything that responds to `call`) for generating the host dynamically. The proc-compliant object gets an instance of the current `CarrierWave::Storage::Fog::File` or `CarrierWave::SanitizedFile` as its only argument.
 
 ```ruby
 CarrierWave.configure do |config|
-  config.fog_host = proc do |file|
+  config.asset_host = proc do |file|
     identifier = # some logic
     "http://#{identifier}.cdn.rackspacecloud.com"
   end

--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -20,7 +20,6 @@ module CarrierWave
     # [:fog_directory]    specifies name of directory to store data in, assumed to already exist
     #
     # [:fog_attributes]                   (optional) additional attributes to set on files
-    # [:fog_host]                         (optional) non-default host to serve files from
     # [:fog_endpoint]                     (optional) non-default host to connect with
     # [:fog_public]                       (optional) public readability, defaults to true
     # [:fog_authenticated_url_expiration] (optional) time (in seconds) that authenticated urls
@@ -276,7 +275,7 @@ module CarrierWave
         # [NilClass] no public url available
         #
         def public_url
-          if host = @uploader.fog_host
+          if host = @uploader.asset_host
             if host.respond_to? :call
               "#{host.call(self)}/#{path}"
             else

--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -9,6 +9,7 @@ module CarrierWave
 
         add_config :root
         add_config :base_path
+        add_config :asset_host
         add_config :permissions
         add_config :directory_permissions
         add_config :storage_engines
@@ -25,7 +26,6 @@ module CarrierWave
         add_config :fog_attributes
         add_config :fog_credentials
         add_config :fog_directory
-        add_config :fog_host
         add_config :fog_endpoint
         add_config :fog_public
         add_config :fog_authenticated_url_expiration

--- a/lib/carrierwave/uploader/url.rb
+++ b/lib/carrierwave/uploader/url.rb
@@ -18,8 +18,18 @@ module CarrierWave
       def url(options = {})
         if file.respond_to?(:url) and not file.url.blank?
           file.method(:url).arity == 0 ? file.url : file.url(options)
-        elsif current_path
-          (base_path || "") + File.expand_path(current_path).gsub(File.expand_path(root), '')
+        elsif file.respond_to?(:path)
+          path = file.path.gsub(File.expand_path(root), '')
+
+          if host = asset_host
+            if host.respond_to? :call
+              "#{host.call(file)}#{path}"
+            else
+              "#{host}#{path}"
+            end
+          else
+            (base_path || "") + path
+          end
         end
       end
 

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -10,7 +10,6 @@ def fog_tests(fog_credentials)
             config.fog_attributes  = {}
             config.fog_credentials = fog_credentials
             config.fog_directory   = CARRIERWAVE_DIRECTORY
-            config.fog_host        = nil
             config.fog_endpoint    = nil
             config.fog_public      = true
           end
@@ -58,7 +57,7 @@ end
             @directory.files.get('uploads/test.jpg').content_type.should == 'image/jpeg'
           end
 
-          context "without fog_host" do
+          context "without asset_host" do
             it "should have a public_url" do
               unless fog_credentials[:provider] == 'Local'
                 @fog_file.public_url.should_not be_nil
@@ -72,29 +71,30 @@ end
             end
           end
 
-          context "with fog_host" do
-            context "when a fog_host is a proc" do
+          context "with asset_host" do
+            before { @uploader.stub(:asset_host).and_return(asset_host) }
 
-              let(:fog_host) { proc { "http://foo.bar" } }
-              before { @uploader.stub(:fog_host).and_return(fog_host) }
+            context "when a asset_host is a proc" do
+
+              let(:asset_host) { proc { "http://foo.bar" } }
 
               describe "args passed to proc" do
-                let(:fog_host) { proc { |storage| storage.should be_instance_of ::CarrierWave::Storage::Fog::File } }
+                let(:asset_host) { proc { |storage| storage.should be_instance_of ::CarrierWave::Storage::Fog::File } }
 
                 it "should be the uploader" do
                   @fog_file.public_url
                 end
               end
 
-              it "should have a fog_host rooted public_url" do
+              it "should have a asset_host rooted public_url" do
                 @fog_file.public_url.should == 'http://foo.bar/uploads/test.jpg'
               end
 
-              it "should have a fog_host rooted url" do
+              it "should have a asset_host rooted url" do
                 @fog_file.url.should == 'http://foo.bar/uploads/test.jpg'
               end
 
-              it "should always have the same fog_host rooted url" do
+              it "should always have the same asset_host rooted url" do
                 @fog_file.url.should == 'http://foo.bar/uploads/test.jpg'
                 @fog_file.url.should == 'http://foo.bar/uploads/test.jpg'
               end
@@ -105,20 +105,17 @@ end
             end
 
             context "when a string" do
-              let(:fog_host) { "http://foo.bar" }
+              let(:asset_host) { "http://foo.bar" }
 
-              it "should have a fog_host rooted public_url" do
-                @uploader.stub!(:fog_host).and_return(fog_host)
+              it "should have a asset_host rooted public_url" do
                 @fog_file.public_url.should == 'http://foo.bar/uploads/test.jpg'
               end
 
-              it "should have a fog_host rooted url" do
-                @uploader.stub!(:fog_host).and_return(fog_host)
+              it "should have a asset_host rooted url" do
                 @fog_file.url.should == 'http://foo.bar/uploads/test.jpg'
               end
 
-              it "should always have the same fog_host rooted url" do
-                @uploader.stub!(:fog_host).and_return(fog_host)
+              it "should always have the same asset_host rooted url" do
                 @fog_file.url.should == 'http://foo.bar/uploads/test.jpg'
                 @fog_file.url.should == 'http://foo.bar/uploads/test.jpg'
               end

--- a/spec/uploader/url_spec.rb
+++ b/spec/uploader/url_spec.rb
@@ -62,10 +62,29 @@ describe CarrierWave::Uploader do
       @uploader.url(:thumb, :mini).should == '/uploads/tmp/20071201-1234-345-2255/thumb_mini_test.jpg'
     end
 
-    it "should prepend the config option 'base_path', if set" do
+    it "should prepend the config option 'asset_host', if set and a string" do
+      MyCoolUploader.version(:thumb)
+      @uploader.class.configure do |config|
+        config.asset_host = "http://foo.bar"
+      end
+      @uploader.cache!(File.open(file_path('test.jpg')))
+      @uploader.url(:thumb).should == 'http://foo.bar/uploads/tmp/20071201-1234-345-2255/thumb_test.jpg'
+    end
+
+    it "should prepend the result of the config option 'asset_host', if set and a proc" do
+      MyCoolUploader.version(:thumb)
+      @uploader.class.configure do |config|
+        config.asset_host = proc { "http://foo.bar" }
+      end
+      @uploader.cache!(File.open(file_path('test.jpg')))
+      @uploader.url(:thumb).should == 'http://foo.bar/uploads/tmp/20071201-1234-345-2255/thumb_test.jpg'
+    end
+
+    it "should prepend the config option 'base_path', if set and 'asset_host' is not set" do
       MyCoolUploader.version(:thumb)
       @uploader.class.configure do |config|
         config.base_path = "/base_path"
+        config.asset_host = nil
       end
       @uploader.cache!(File.open(file_path('test.jpg')))
       @uploader.url(:thumb).should == '/base_path/uploads/tmp/20071201-1234-345-2255/thumb_test.jpg'


### PR DESCRIPTION
As discussed in #802.
- `fog_endpoint` defines the host Fog should connect with
- `asset_host` defines the host images should be served from

Previously, `fog_host` affected both when often you would want to change only one or the other.
