### PR TITLE
Support for non-Amazon S3 storage solutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,15 +505,16 @@ You can also pass in additional options, as documented fully in lib/carrierwave/
 ```ruby
 CarrierWave.configure do |config|
   config.fog_credentials = {
-    :provider               => 'AWS',       # required
-    :aws_access_key_id      => 'xxx',       # required
-    :aws_secret_access_key  => 'yyy',       # required
-    :region                 => 'eu-west-1'  # optional, defaults to 'us-east-1'
+    :provider               => 'AWS',                        # required
+    :aws_access_key_id      => 'xxx',                        # required
+    :aws_secret_access_key  => 'yyy',                        # required
+    :region                 => 'eu-west-1'                   # optional, defaults to 'us-east-1'
+    :hosts                  => 's3.example.com'              # optional, defaults to nil
+    :endpoint               => 'https://s3.example.com:8080' # optional, defaults to nil
   }
   config.fog_directory  = 'name_of_directory'                     # required
   config.fog_public     = false                                   # optional, defaults to true
   config.fog_attributes = {'Cache-Control'=>'max-age=315576000'}  # optional, defaults to {}
-  config.asset_host     = 'https://assets.example.com'            # optional, defaults to nil
 end
 ```
 

--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -20,7 +20,8 @@ module CarrierWave
     # [:fog_directory]    specifies name of directory to store data in, assumed to already exist
     #
     # [:fog_attributes]                   (optional) additional attributes to set on files
-    # [:fog_endpoint]                     (optional) non-default host to connect with
+    # [:fog_endpoint] (deprecated!)       (optional) non-default host to connect with
+    #                                     To set non-default host use :host or :endpoint in :fog_credentials instead
     # [:fog_public]                       (optional) public readability, defaults to true
     # [:fog_authenticated_url_expiration] (optional) time (in seconds) that authenticated urls
     #   will be valid, when fog_public is false and provider is AWS or Google, defaults to 600


### PR DESCRIPTION
Replacement for: https://github.com/jnicklas/carrierwave/pull/896
