### PR TITLE
Support for Rackspace Cloud Files Temp URL

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -139,7 +139,7 @@ module CarrierWave
 
         ##
         # Return a temporary authenticated url to a private file, if available
-        # Only supported for AWS and Google providers
+        # Only supported for AWS, Rackspace and Google providers
         #
         # === Returns
         #
@@ -148,12 +148,14 @@ module CarrierWave
         # [NilClass] no authenticated url available
         #
         def authenticated_url(options = {})
-          if ['AWS', 'Google'].include?(@uploader.fog_credentials[:provider])
+          if ['AWS', 'Google', 'Rackspace'].include?(@uploader.fog_credentials[:provider])
             # avoid a get by using local references
             local_directory = connection.directories.new(:key => @uploader.fog_directory)
             local_file = local_directory.files.new(:key => path)
             if @uploader.fog_credentials[:provider] == "AWS"
               local_file.url(::Fog::Time.now + @uploader.fog_authenticated_url_expiration, options)
+            elsif @uploader.fog_credentials[:provider] == "Rackspace"
+              connection.get_object_https_url(@uploader.fog_directory, path, ::Fog::Time.now + @uploader.fog_authenticated_url_expiration)
             else
               local_file.url(::Fog::Time.now + @uploader.fog_authenticated_url_expiration)
             end

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -232,7 +232,7 @@ end
             end
 
             it "should have an authenticated_url" do
-              if ['AWS', 'Google'].include?(@provider)
+              if ['AWS', 'Rackspace', 'Google'].include?(@provider)
                 @fog_file.authenticated_url.should_not be_nil
               end
             end


### PR DESCRIPTION
Added support for serving files from Rackspace Cloud Files using authenticated URLs. 
