### PR TITLE
Rspec Upgrade

### DIFF
--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rails", ">= 3.2.0"
   s.add_development_dependency "cucumber", "~> 1.1.4"
   s.add_development_dependency "json"
-  s.add_development_dependency "rspec", "~> 2.10.0"
+  s.add_development_dependency "rspec", "~> 2.12.0"
   s.add_development_dependency "sham_rack"
   s.add_development_dependency "timecop"
   s.add_development_dependency "fog", ">= 1.3.1"

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -57,36 +57,36 @@ describe CarrierWave::ActiveRecord do
     describe '#image' do
 
       it "should return blank uploader when nothing has been assigned" do
-        @event.image.should be_blank
+        expect(@event.image).to be_blank
       end
 
       it "should return blank uploader when an empty string has been assigned" do
         @event[:image] = ''
         @event.save!
         @event.reload
-        @event.image.should be_blank
+        expect(@event.image).to be_blank
       end
 
       it "should retrieve a file from the storage if a value is stored in the database" do
         @event[:image] = 'test.jpeg'
         @event.save!
         @event.reload
-        @event.image.should be_an_instance_of(@uploader)
+        expect(@event.image).to be_an_instance_of(@uploader)
       end
 
       it "should set the path to the store dir" do
         @event[:image] = 'test.jpeg'
         @event.save!
         @event.reload
-        @event.image.current_path.should == public_path('uploads/test.jpeg')
+        expect(@event.image.current_path).to eq public_path('uploads/test.jpeg')
       end
 
       it "should return valid JSON when to_json is called when image is nil" do
-        @event[:image].should be_nil
+        expect(@event[:image]).to be_nil
         hash = JSON.parse(@event.to_json)["event#{$arclass}"]
-        hash.keys.should include("image")
-        hash["image"].keys.should include("url")
-        hash["image"]["url"].should be_nil
+        expect(hash.keys).to include("image")
+        expect(hash["image"].keys).to include("url")
+        expect(hash["image"]["url"]).to be_nil
       end
 
       it "should return valid JSON when to_json is called when image is present" do
@@ -94,7 +94,7 @@ describe CarrierWave::ActiveRecord do
         @event.save!
         @event.reload
 
-        JSON.parse(@event.to_json)["event#{$arclass}"]["image"].should == {"url" => "/uploads/test.jpeg"}
+        expect(JSON.parse(@event.to_json)["event#{$arclass}"]["image"]).to eq({"url" => "/uploads/test.jpeg"})
       end
 
       it "should return valid JSON when to_json is called on a collection containing uploader from a model" do
@@ -102,15 +102,15 @@ describe CarrierWave::ActiveRecord do
         @event.save!
         @event.reload
 
-        JSON.parse({:data => @event.image}.to_json).should == {"data"=>{"image"=>{"url"=>"/uploads/test.jpeg"}}}
+        expect(JSON.parse({:data => @event.image}.to_json)).to eq({"data"=>{"image"=>{"url"=>"/uploads/test.jpeg"}}})
       end
 
       it "should return valid XML when to_xml is called when image is nil" do
-        @event[:image].should be_nil
+        expect(@event[:image]).to be_nil
         hash = Hash.from_xml(@event.to_xml)["event#{$arclass}"]
-        hash.keys.should include("image")
-        hash["image"].keys.should include("url")
-        hash["image"]["url"].should be_nil
+        expect(hash.keys).to include("image")
+        expect(hash["image"].keys).to include("url")
+        expect(hash["image"]["url"]).to be_nil
       end
 
       it "should return valid XML when to_xml is called when image is present" do
@@ -118,7 +118,7 @@ describe CarrierWave::ActiveRecord do
         @event.save!
         @event.reload
 
-        Hash.from_xml(@event.to_xml)["event#{$arclass}"]["image"].should == {"url" => "/uploads/test.jpeg"}
+        expect(Hash.from_xml(@event.to_xml)["event#{$arclass}"]["image"]).to eq({"url" => "/uploads/test.jpeg"})
       end
 
       it "should respect options[:only] when passed to as_json for the serializable hash" do
@@ -126,7 +126,7 @@ describe CarrierWave::ActiveRecord do
         @event.save!
         @event.reload
 
-        @event.as_json(:only => [:foo])["event#{$arclass}"].should == {"foo" => nil}
+        expect(@event.as_json(:only => [:foo])["event#{$arclass}"]).to eq({"foo" => nil})
       end
 
       it "should respect options[:except] when passed to as_json for the serializable hash" do
@@ -134,7 +134,7 @@ describe CarrierWave::ActiveRecord do
         @event.save!
         @event.reload
 
-        @event.as_json(:except => [:id, :image, :foo])["event#{$arclass}"].should == {"textfile" => nil}
+        expect(@event.as_json(:except => [:id, :image, :foo])["event#{$arclass}"]).to eq({"textfile" => nil})
       end
     end
 
@@ -142,26 +142,26 @@ describe CarrierWave::ActiveRecord do
 
       it "should cache a file" do
         @event.image = stub_file('test.jpeg')
-        @event.image.should be_an_instance_of(@uploader)
+        expect(@event.image).to be_an_instance_of(@uploader)
       end
 
       it "should write nothing to the database, to prevent overriden filenames to fail because of unassigned attributes" do
-        @event[:image].should be_nil
+        expect(@event[:image]).to be_nil
       end
 
       it "should copy a file into into the cache directory" do
         @event.image = stub_file('test.jpeg')
-        @event.image.current_path.should =~ %r(^#{public_path('uploads/tmp')})
+        expect(@event.image.current_path).to match(%r(^#{public_path('uploads/tmp')}))
       end
 
       it "should do nothing when nil is assigned" do
         @event.image = nil
-        @event.image.should be_blank
+        expect(@event.image).to be_blank
       end
 
       it "should do nothing when an empty string is assigned" do
         @event.image = ''
-        @event.image.should be_blank
+        expect(@event.image).to be_blank
       end
 
       context 'when validating white list integrity' do
@@ -182,9 +182,9 @@ describe CarrierWave::ActiveRecord do
           }) do
             # Assigning image triggers check_whitelist! and thus should be inside change_locale_and_store_translations
             @event.image = stub_file('test.jpg')
-            @event.should_not be_valid
+            expect(@event).to_not be_valid
             @event.valid?
-            @event.errors[:image].should == ['Het opladen van "jpg" bestanden is niet toe gestaan. Geaccepteerde types: txt']
+            expect(@event.errors[:image]).to eq (['Het opladen van "jpg" bestanden is niet toe gestaan. Geaccepteerde types: txt'])
           end
         end
       end
@@ -207,9 +207,9 @@ describe CarrierWave::ActiveRecord do
           }) do
             # Assigning image triggers check_blacklist! and thus should be inside change_locale_and_store_translations
             @event.image = stub_file('test.jpg')
-            @event.should_not be_valid
+            expect(@event).to_not be_valid
             @event.valid?
-            @event.errors[:image].should == ['You are not allowed to upload "jpg" files, prohibited types: jpg']
+            expect(@event.errors[:image]).to eq(['You are not allowed to upload "jpg" files, prohibited types: jpg'])
           end
         end
       end
@@ -227,12 +227,12 @@ describe CarrierWave::ActiveRecord do
         end
 
         it "should make the record invalid when a processing error occurs" do
-          @event.should_not be_valid
+          expect(@event).to_not be_valid
         end
 
         it "should use I18n for processing errors without messages" do
           @event.valid?
-          @event.errors[:image].should == ['failed to be processed']
+          expect(@event.errors[:image]).to eq(['failed to be processed'])
 
           change_locale_and_store_translations(:pt, :activerecord => {
             :errors => {
@@ -241,8 +241,8 @@ describe CarrierWave::ActiveRecord do
               }
             }
           }) do
-            @event.should_not be_valid
-            @event.errors[:image].should == ['falha ao processar imagem.']
+            expect(@event).to_not be_valid
+            expect(@event.errors[:image]).to eq(['falha ao processar imagem.'])
           end
         end
       end
@@ -259,12 +259,12 @@ describe CarrierWave::ActiveRecord do
         end
 
         it "should make the record invalid when a processing error occurs" do
-          @event.should_not be_valid
+          expect(@event).to_not be_valid
         end
 
         it "should use the error's messages for processing errors with messages" do
           @event.valid?
-          @event.errors[:image].should == ['Ohh noez!']
+          expect(@event.errors[:image]).to eq(['Ohh noez!'])
 
           change_locale_and_store_translations(:pt, :activerecord => {
             :errors => {
@@ -273,8 +273,8 @@ describe CarrierWave::ActiveRecord do
               }
             }
           }) do
-            @event.should_not be_valid
-            @event.errors[:image].should == ['Ohh noez!']
+            expect(@event).to_not be_valid
+            expect(@event.errors[:image]).to eq(['Ohh noez!'])
           end
         end
       end
@@ -283,41 +283,41 @@ describe CarrierWave::ActiveRecord do
     describe '#save' do
 
       it "should do nothing when no file has been assigned" do
-        @event.save.should be_true
-        @event.image.should be_blank
+        expect(@event.save).to be_true
+        expect(@event.image).to be_blank
       end
 
       it "should copy the file to the upload directory when a file has been assigned" do
         @event.image = stub_file('test.jpeg')
-        @event.save.should be_true
-        @event.image.should be_an_instance_of(@uploader)
-        @event.image.current_path.should == public_path('uploads/test.jpeg')
+        expect(@event.save).to be_true
+        expect(@event.image).to be_an_instance_of(@uploader)
+        expect(@event.image.current_path).to eq public_path('uploads/test.jpeg')
       end
 
       it "should do nothing when a validation fails" do
         @class.validate { |r| r.errors.add :textfile, "FAIL!" }
         @event.image = stub_file('test.jpeg')
-        @event.save.should be_false
-        @event.image.should be_an_instance_of(@uploader)
-        @event.image.current_path.should =~ /^#{public_path('uploads/tmp')}/
+        expect(@event.save).to be_false
+        expect(@event.image).to be_an_instance_of(@uploader)
+        expect(@event.image.current_path).to match(/^#{public_path('uploads/tmp')}/)
       end
 
       it "should assign the filename to the database" do
         @event.image = stub_file('test.jpeg')
-        @event.save.should be_true
+        expect(@event.save).to be_true
         @event.reload
-        @event[:image].should == 'test.jpeg'
-        @event.image_identifier.should == 'test.jpeg'
+        expect(@event[:image]).to eq('test.jpeg')
+        expect(@event.image_identifier).to eq('test.jpeg')
       end
 
       it "should preserve the image when nothing is assigned" do
         @event.image = stub_file('test.jpeg')
-        @event.save.should be_true
+        expect(@event.save).to be_true
         @event = @class.find(@event.id)
         @event.foo = "bar"
-        @event.save.should be_true
-        @event[:image].should == 'test.jpeg'
-        @event.image_identifier.should == 'test.jpeg'
+        expect(@event.save).to be_true
+        expect(@event[:image]).to eq('test.jpeg')
+        expect(@event.image_identifier).to eq('test.jpeg')
       end
 
       it "should remove the image if remove_image? returns true" do
@@ -326,21 +326,21 @@ describe CarrierWave::ActiveRecord do
         @event.remove_image = true
         @event.save!
         @event.reload
-        @event.image.should be_blank
-        @event[:image].should == ''
-        @event.image_identifier.should == ''
+        expect(@event.image).to be_blank
+        expect(@event[:image]).to eq('')
+        expect(@event.image_identifier).to eq('')
       end
 
       it "should mark image as changed when saving a new image" do
-        @event.image_changed?.should be_false
+        expect(@event.image_changed?).to be_false
         @event.image = stub_file("test.jpeg")
-        @event.image_changed?.should be_true
+        expect(@event.image_changed?).to be_true
         @event.save
         @event.reload
-        @event.image_changed?.should be_false
+        expect(@event.image_changed?).to be_false
         @event.image = stub_file("test.jpg")
-        @event.image_changed?.should be_true
-        @event.changed_for_autosave?.should be_true
+        expect(@event.image_changed?).to be_true
+        expect(@event.changed_for_autosave?).to be_true
       end
     end
 
@@ -352,7 +352,7 @@ describe CarrierWave::ActiveRecord do
       end
 
       it "should clear the serialization column" do
-        @event.attributes['image'].should be_blank
+        expect(@event.attributes['image']).to be_blank
       end
     end
 
@@ -360,12 +360,12 @@ describe CarrierWave::ActiveRecord do
 
       # FIXME ideally image_changed? and remote_image_url_changed? would return true
       it "should mark image as changed when setting remote_image_url" do
-        @event.image_changed?.should be_false
+        expect(@event.image_changed?).to be_false
         @event.remote_image_url = 'http://www.example.com/test.jpg'
-        @event.image_changed?.should be_true
+        expect(@event.image_changed?).to be_true
         @event.save
         @event.reload
-        @event.image_changed?.should be_false
+        expect(@event.image_changed?).to be_false
       end
 
       context 'when validating download' do
@@ -379,12 +379,12 @@ describe CarrierWave::ActiveRecord do
         end
 
         it "should make the record invalid when a download error occurs" do
-          @event.should_not be_valid
+          expect(@event).to_not be_valid
         end
 
         it "should use I18n for download errors without messages" do
           @event.valid?
-          @event.errors[:image].should == ['could not be downloaded']
+          expect(@event.errors[:image]).to eq(['could not be downloaded'])
 
           change_locale_and_store_translations(:pt, :activerecord => {
             :errors => {
@@ -393,8 +393,8 @@ describe CarrierWave::ActiveRecord do
               }
             }
           }) do
-            @event.should_not be_valid
-            @event.errors[:image].should == ['não pode ser descarregado']
+            expect(@event).to_not be_valid
+            expect(@event.errors[:image]).to eq(['não pode ser descarregado'])
           end
         end
       end
@@ -410,16 +410,16 @@ describe CarrierWave::ActiveRecord do
 
       it "should include the other columns" do
         ["id", "foo"].each do |key|
-          @event.serializable_hash.should have_key(key)
+          expect(@event.serializable_hash).to have_key(key)
         end
       end
 
       it "should take an option to exclude the image column" do
-        @event.serializable_hash(:except => :image).should_not have_key("image")
+        expect(@event.serializable_hash(:except => :image)).to_not have_key("image")
       end
 
       it "should take an option to only include the image column" do
-        @event.serializable_hash(:only => :image).should have_key("image")
+        expect(@event.serializable_hash(:only => :image)).to have_key("image")
       end
 
       context "with multiple uploaders" do
@@ -433,14 +433,14 @@ describe CarrierWave::ActiveRecord do
         end
 
         it "serializes the correct values" do
-          @event.serializable_hash["image"]["url"].should match(/old\.jpeg$/)
-          @event.serializable_hash["textfile"]["url"].should match(/old\.txt$/)
+          expect(@event.serializable_hash["image"]["url"]).to match(/old\.jpeg$/)
+          expect(@event.serializable_hash["textfile"]["url"]).to match(/old\.txt$/)
         end
 
         it "should have JSON for each uploader" do
           parsed = JSON.parse(@event.to_json)
-          parsed["event#{$arclass}"]["image"]["url"].should match(/old\.jpeg$/)
-          parsed["event#{$arclass}"]["textfile"]["url"].should match(/old\.txt$/)
+          expect(parsed["event#{$arclass}"]["image"]["url"]).to match(/old\.jpeg$/)
+          expect(parsed["event#{$arclass}"]["textfile"]["url"]).to match(/old\.txt$/)
         end
       end
     end
@@ -455,24 +455,24 @@ describe CarrierWave::ActiveRecord do
         end
 
         @event.image = stub_file('test.jpeg')
-        @event.save.should be_true
+        expect(@event.save).to be_true
         expect {
           @event.destroy
         }.to_not raise_error
       end
 
       it "should do nothing when no file has been assigned" do
-        @event.save.should be_true
+        expect(@event.save).to be_true
         @event.destroy
       end
 
       it "should remove the file from the filesystem" do
         @event.image = stub_file('test.jpeg')
-        @event.save.should be_true
-        @event.image.should be_an_instance_of(@uploader)
-        @event.image.current_path.should == public_path('uploads/test.jpeg')
+        expect(@event.save).to be_true
+        expect(@event.image).to be_an_instance_of(@uploader)
+        expect(@event.image.current_path).to eq public_path('uploads/test.jpeg')
         @event.destroy
-        File.exist?(public_path('uploads/test.jpeg')).should be_false
+        expect(File.exist?(public_path('uploads/test.jpeg'))).to be_false
       end
 
     end
@@ -492,16 +492,16 @@ describe CarrierWave::ActiveRecord do
 
         it "should copy the file to the upload directory when a file has been assigned" do
           @event.image = stub_file('test.jpeg')
-          @event.save.should be_true
-          @event.image.should be_an_instance_of(@uploader)
-          @event.image.current_path.should == public_path('uploads/jonas.jpeg')
+          expect(@event.save).to be_true
+          expect(@event.image).to be_an_instance_of(@uploader)
+          expect(@event.image.current_path).to eq(public_path('uploads/jonas.jpeg'))
         end
 
         it "should assign an overridden filename to the database" do
           @event.image = stub_file('test.jpeg')
-          @event.save.should be_true
+          expect(@event.save).to be_true
           @event.reload
-          @event[:image].should == 'jonas.jpeg'
+          expect(@event[:image]).to eq('jonas.jpeg')
         end
 
       end
@@ -517,11 +517,11 @@ describe CarrierWave::ActiveRecord do
 
       it "should be valid if a file has been cached" do
         @event.image = stub_file('test.jpeg')
-        @event.should be_valid
+        expect(@event).to be_valid
       end
 
       it "should not be valid if a file has not been cached" do
-        @event.should_not be_valid
+        expect(@event).to_not be_valid
       end
 
     end
@@ -535,12 +535,12 @@ describe CarrierWave::ActiveRecord do
 
       it "should be valid if a file has been cached that matches the size criteria" do
         @event.image = stub_file('test.jpeg')
-        @event.should be_valid
+        expect(@event).to be_valid
       end
 
       it "should not be valid if a file has been cached that does not match the size criteria" do
         @event.image = stub_file('bork.txt')
-        @event.should_not be_valid
+        expect(@event).to_not be_valid
       end
 
     end
@@ -566,8 +566,8 @@ describe CarrierWave::ActiveRecord do
         @event.avatar = stub_file('test.jpeg')
         @event.save
         @event.reload
-        @event.avatar.should be_an_instance_of(@uploader)
-        @event.image.should == 'test.jpeg'
+        expect(@event.avatar).to be_an_instance_of(@uploader)
+        expect(@event.image).to eq('test.jpeg')
       end
 
     end
@@ -585,8 +585,8 @@ describe CarrierWave::ActiveRecord do
       @class.mount_uploader(:image, @uploader)
       @event = @class.new
       @event.image = stub_file('old.jpeg')
-      @event.save.should be_true
-      File.exists?(public_path('uploads/old.jpeg')).should be_true
+      expect(@event.save).to be_true
+      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_true
     end
 
     after do
@@ -596,30 +596,30 @@ describe CarrierWave::ActiveRecord do
     describe 'normally' do
       it "should remove old file if old file had a different path" do
         @event.image = stub_file('new.jpeg')
-        @event.save.should be_true
-        File.exists?(public_path('uploads/new.jpeg')).should be_true
-        File.exists?(public_path('uploads/old.jpeg')).should be_false
+        expect(@event.save).to be_true
+        expect(File.exists?(public_path('uploads/new.jpeg'))).to be_true
+        expect(File.exists?(public_path('uploads/old.jpeg'))).to be_false
       end
 
       it "should not remove old file if old file had a different path but config is false" do
         @uploader.stub!(:remove_previously_stored_files_after_update).and_return(false)
         @event.image = stub_file('new.jpeg')
-        @event.save.should be_true
-        File.exists?(public_path('uploads/new.jpeg')).should be_true
-        File.exists?(public_path('uploads/old.jpeg')).should be_true
+        expect(@event.save).to be_true
+        expect(File.exists?(public_path('uploads/new.jpeg'))).to be_true
+        expect(File.exists?(public_path('uploads/old.jpeg'))).to be_true
       end
 
       it "should not remove file if old file had the same path" do
         @event.image = stub_file('old.jpeg')
-        @event.save.should be_true
-        File.exists?(public_path('uploads/old.jpeg')).should be_true
+        expect(@event.save).to be_true
+        expect(File.exists?(public_path('uploads/old.jpeg'))).to be_true
       end
 
       it "should not remove file if validations fail on save" do
         @class.validate { |r| r.errors.add :textfile, "FAIL!" }
         @event.image = stub_file('new.jpeg')
-        @event.save.should be_false
-        File.exists?(public_path('uploads/old.jpeg')).should be_true
+        expect(@event.save).to be_false
+        expect(File.exists?(public_path('uploads/old.jpeg'))).to be_true
       end
     end
 
@@ -632,24 +632,24 @@ describe CarrierWave::ActiveRecord do
         end
 
         @event.image = stub_file('old.jpeg')
-        @event.foo = "test"
-        @event.save.should be_true
-        File.exists?(public_path('uploads/test.jpeg')).should be_true
-        @event.image.read.should == "this is stuff"
+        @event.foo = 'test'
+        expect(@event.save).to be_true
+        expect(File.exists?(public_path('uploads/test.jpeg'))).to be_true
+        expect(@event.image.read).to eq('this is stuff')
       end
 
       it "should not remove file if old file had the same dynamic path" do
         @event.image = stub_file('test.jpeg')
-        @event.save.should be_true
-        File.exists?(public_path('uploads/test.jpeg')).should be_true
+        expect(@event.save).to be_true
+        expect(File.exists?(public_path('uploads/test.jpeg'))).to be_true
       end
 
       it "should remove old file if old file had a different dynamic path" do
         @event.foo = "new"
         @event.image = stub_file('test.jpeg')
-        @event.save.should be_true
-        File.exists?(public_path('uploads/new.jpeg')).should be_true
-        File.exists?(public_path('uploads/test.jpeg')).should be_false
+        expect(@event.save).to be_true
+        expect(File.exists?(public_path('uploads/new.jpeg'))).to be_true
+        expect(File.exists?(public_path('uploads/test.jpeg'))).to be_false
       end
     end
   end
@@ -667,9 +667,9 @@ describe CarrierWave::ActiveRecord do
       @class.mount_uploader(:image, @uploader)
       @event = @class.new
       @event.image = stub_file('old.jpeg')
-      @event.save.should be_true
-      File.exists?(public_path('uploads/old.jpeg')).should be_true
-      File.exists?(public_path('uploads/thumb_old.jpeg')).should be_true
+      expect(@event.save).to be_true
+      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_true
+      expect(File.exists?(public_path('uploads/thumb_old.jpeg'))).to be_true
     end
 
     after do
@@ -678,18 +678,18 @@ describe CarrierWave::ActiveRecord do
 
     it "should remove old file if old file had a different path" do
       @event.image = stub_file('new.jpeg')
-      @event.save.should be_true
-      File.exists?(public_path('uploads/new.jpeg')).should be_true
-      File.exists?(public_path('uploads/thumb_new.jpeg')).should be_true
-      File.exists?(public_path('uploads/old.jpeg')).should be_false
-      File.exists?(public_path('uploads/thumb_old.jpeg')).should be_false
+      expect(@event.save).to be_true
+      expect(File.exists?(public_path('uploads/new.jpeg'))).to be_true
+      expect(File.exists?(public_path('uploads/thumb_new.jpeg'))).to be_true
+      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_false
+      expect(File.exists?(public_path('uploads/thumb_old.jpeg'))).to be_false
     end
 
     it "should not remove file if old file had the same path" do
       @event.image = stub_file('old.jpeg')
-      @event.save.should be_true
-      File.exists?(public_path('uploads/old.jpeg')).should be_true
-      File.exists?(public_path('uploads/thumb_old.jpeg')).should be_true
+      expect(@event.save).to be_true
+      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_true
+      expect(File.exists?(public_path('uploads/thumb_old.jpeg'))).to be_true
     end
   end
 
@@ -708,9 +708,9 @@ describe CarrierWave::ActiveRecord do
       @event = @class.new
       @event.image = stub_file('old.jpeg')
       @event.textfile = stub_file('old.txt')
-      @event.save.should be_true
-      File.exists?(public_path('uploads/old.jpeg')).should be_true
-      File.exists?(public_path('uploads/old.txt')).should be_true
+      expect(@event.save).to be_true
+      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_true
+      expect(File.exists?(public_path('uploads/old.txt'))).to be_true
     end
 
     after do
@@ -720,28 +720,28 @@ describe CarrierWave::ActiveRecord do
     it "should remove old file1 and file2 if old file1 and file2 had a different paths" do
       @event.image = stub_file('new.jpeg')
       @event.textfile = stub_file('new.txt')
-      @event.save.should be_true
-      File.exists?(public_path('uploads/new.jpeg')).should be_true
-      File.exists?(public_path('uploads/old.jpeg')).should be_false
-      File.exists?(public_path('uploads/new.txt')).should be_true
-      File.exists?(public_path('uploads/old.txt')).should be_false
+      expect(@event.save).to be_true
+      expect(File.exists?(public_path('uploads/new.jpeg'))).to be_true
+      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_false
+      expect(File.exists?(public_path('uploads/new.txt'))).to be_true
+      expect(File.exists?(public_path('uploads/old.txt'))).to be_false
     end
 
     it "should remove old file1 but not file2 if old file1 had a different path but old file2 has the same path" do
       @event.image = stub_file('new.jpeg')
       @event.textfile = stub_file('old.txt')
-      @event.save.should be_true
-      File.exists?(public_path('uploads/new.jpeg')).should be_true
-      File.exists?(public_path('uploads/old.jpeg')).should be_false
-      File.exists?(public_path('uploads/old.txt')).should be_true
+      expect(@event.save).to be_true
+      expect(File.exists?(public_path('uploads/new.jpeg'))).to be_true
+      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_false
+      expect(File.exists?(public_path('uploads/old.txt'))).to be_true
     end
 
     it "should not remove file1 or file2 if file1 and file2 have the same paths" do
       @event.image = stub_file('old.jpeg')
       @event.textfile = stub_file('old.txt')
-      @event.save.should be_true
-      File.exists?(public_path('uploads/old.jpeg')).should be_true
-      File.exists?(public_path('uploads/old.txt')).should be_true
+      expect(@event.save).to be_true
+      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_true
+      expect(File.exists?(public_path('uploads/old.txt'))).to be_true
     end
   end
 
@@ -757,8 +757,8 @@ describe CarrierWave::ActiveRecord do
       @class.mount_uploader(:avatar, @uploader, :mount_on => :image)
       @event = @class.new
       @event.avatar = stub_file('old.jpeg')
-      @event.save.should be_true
-      File.exists?(public_path('uploads/old.jpeg')).should be_true
+      expect(@event.save).to be_true
+      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_true
     end
 
     after do
@@ -767,15 +767,15 @@ describe CarrierWave::ActiveRecord do
 
     it "should remove old file if old file had a different path" do
       @event.avatar = stub_file('new.jpeg')
-      @event.save.should be_true
-      File.exists?(public_path('uploads/new.jpeg')).should be_true
-      File.exists?(public_path('uploads/old.jpeg')).should be_false
+      expect(@event.save).to be_true
+      expect(File.exists?(public_path('uploads/new.jpeg'))).to be_true
+      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_false
     end
 
     it "should not remove file if old file had the same path" do
       @event.avatar = stub_file('old.jpeg')
-      @event.save.should be_true
-      File.exists?(public_path('uploads/old.jpeg')).should be_true
+      expect(@event.save).to be_true
+      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_true
     end
   end
 end

--- a/spec/uploader/cache_spec.rb
+++ b/spec/uploader/cache_spec.rb
@@ -178,6 +178,10 @@ describe CarrierWave::Uploader do
 
         it "should use move_to() during cache!()" do
           CarrierWave::SanitizedFile.any_instance.should_receive(:move_to).with(@cached_path, 0777, 0777)
+          @uploader.cache!(@tmpfile)
+        end
+
+        it "should not use copy_to() during cache!()" do
           CarrierWave::SanitizedFile.any_instance.should_not_receive(:copy_to)
           @uploader.cache!(@tmpfile)
         end
@@ -198,6 +202,10 @@ describe CarrierWave::Uploader do
 
         it "should use copy_to() during cache!()" do
           CarrierWave::SanitizedFile.any_instance.should_receive(:copy_to).with(@cached_path, 0777, 0777)
+          @uploader.cache!(@tmpfile)
+        end
+
+        it "should not use move_to() during cache!()" do
           CarrierWave::SanitizedFile.any_instance.should_not_receive(:move_to)
           @uploader.cache!(@tmpfile)
         end

--- a/spec/uploader/store_spec.rb
+++ b/spec/uploader/store_spec.rb
@@ -101,7 +101,7 @@ describe CarrierWave::Uploader do
 
       it "should not delete the old file" do
         @uploader.cache!(@file)
-        @uploader.file.should_not_receive(:delete).and_return(true)
+        @uploader.file.should_not_receive(:delete)
         @uploader.store!
       end
 


### PR DESCRIPTION
Upgraded to rspec 2.12 . Noticed the specs were running much faster. I've changed the orm specs to the new expectation syntax. 
should_not_receive followed by and_return has been deprecated, so I've removed it. https://github.com/rspec/rspec-mocks/issues/134
As per https://github.com/rspec/rspec-mocks/issues/164 , any_instance.should_not_receive hasn't been implemented correctly and is ambiguous. So I've commented it out. 
