### PR TITLE
Added google storage credentials reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,10 @@ gem "fog", "~> 1.3.1"
 You'll need to configure a directory (also known as a bucket), access key id and secret access key in the initializer.
 For the sake of performance it is assumed that the directory already exists, so please create it if need be.
 
+Sign up [here](http://gs-signup-redirect.appspot.com/) and get your credentials [here](https://storage.cloud.google.com/m)
+under the section “Interoperable Access”.
+
+
 ```ruby
 CarrierWave.configure do |config|
   config.fog_credentials = {


### PR DESCRIPTION
Spent ages trying to get it to work thinking it was something in my setup.  Turned out you need to enable "Interoperable Access" in Google storage.

Note: text/links copied straight from Fog docs.
