### PR TITLE
Unscoped model retrieval

### DIFF
--- a/lib/carrierwave/mount.rb
+++ b/lib/carrierwave/mount.rb
@@ -247,7 +247,7 @@ module CarrierWave
         end
 
         def find_previous_model_for_#{column}
-          self.class.find(to_key.first)
+          self.class.unscoped.find(to_key.first)
         end
 
         def remove_previously_stored_#{column}
@@ -344,7 +344,7 @@ module CarrierWave
         @integrity_error = nil
 
         @remote_url = url
-        
+
         uploader.download!(url)
 
       rescue CarrierWave::DownloadError => e


### PR DESCRIPTION
I'm using `default_scope` so this find blows up, but i'm not sure that it's a good solution to just go with `unscoped` here. What are your thoughts about it @bensie & @thiagofm ?
