### PR TITLE
Example of setting `cache_dir` outside of project folder 

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,16 @@ end
 This works for the file storage as well as Amazon S3 and Rackspace Cloud Files.
 Define `store_dir` as `nil` if you'd like to store files at the root level.
 
+If you store files outside the project root folder, you may want to define `cache_dir` in the same way:
+
+```ruby
+class MyUploader < CarrierWave::Uploader::Base
+  def cache_dir
+    '/tmp/projectname-cache'
+  end
+end
+```
+
 ## Securing uploads
 
 Certain file might be dangerous if uploaded to the wrong location, such as php


### PR DESCRIPTION
For now `cache_dir` is independent of `store_dir`.

I am not sure if it would be good to inherit the `cache_dir` path from `store_dir`, but if i set `store_dir` to `/tmp/projectname` then `Carrierwave` keeps creating a `spec/public/uploads/tmp` folder when running tests of a rails app.

spent some time trying to figure out why until found that `cache_dir` exists as a param.

thanks
