### PR TITLE
Allow setting file content type based on file content(using libmagic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,21 @@ class MyUploader < CarrierWave::Uploader::Base
 end
 ```
 
+## (Magically) Setting the content type
+
+If you want to set file content type based on its content, you can configure your uploaders
+to use `CarrierWave::MagicMimeTypes`. This adds a dependency on the [ruby-filemagic](http://ruby-filemagic.rubyforge.org/).
+
+```ruby
+require 'carrierwave/processing/mime_types'
+
+class MyUploader < CarrierWave::Uploader::Base
+  include CarrierWave::MagicMimeTypes
+
+  process :set_magic_content_type
+end
+```
+
 ## Adding versions
 
 Often you'll want to add different versions of the same file. The classic

--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "fog", ">= 1.3.1"
   s.add_development_dependency "mini_magick"
   s.add_development_dependency "rmagick"
+  s.add_development_dependency "ruby-filemagic"
 end

--- a/lib/carrierwave/locale/en.yml
+++ b/lib/carrierwave/locale/en.yml
@@ -8,4 +8,5 @@ en:
       extension_black_list_error: "You are not allowed to upload %{extension} files, prohibited types: %{prohibited_types}"
       rmagick_processing_error: "Failed to manipulate with rmagick, maybe it is not an image? Original Error: %{e}"
       mime_types_processing_error: "Failed to process file with MIME::Types, maybe not valid content-type? Original Error: %{e}"
+      magic_mime_types_processing_error: "Failed to process file with FileMagic, Original Error: %{e}"
       mini_magick_processing_error: "Failed to manipulate with MiniMagick, maybe it is not an image? Original Error: %{e}"

--- a/lib/carrierwave/processing.rb
+++ b/lib/carrierwave/processing.rb
@@ -1,3 +1,5 @@
 require "carrierwave/processing/rmagick"
 require "carrierwave/processing/mini_magick"
+require "carrierwave/processing/generic_content_types"
 require "carrierwave/processing/mime_types"
+require "carrierwave/processing/magic_mime_types"

--- a/lib/carrierwave/processing/generic_content_types.rb
+++ b/lib/carrierwave/processing/generic_content_types.rb
@@ -1,0 +1,91 @@
+module CarrierWave
+
+  ##
+  # This module defines a list of generic content-types which might come from user agent
+  #
+  module GenericContentTypes
+
+    GENERIC_CONTENT_TYPES = %w[
+      application-x/octet-stream
+
+      application/
+      application/*
+      application/binary
+      application/download
+      application/download-file
+      application/downloadfile
+      application/force-download
+      application/force_download
+      application/oclet-stream
+      application/octec-stream
+      application/octect-stream
+      application/octed-stream
+      application/octet
+      application/octet-binary
+      application/octet-stream
+      application/octet_stream
+      application/octetstream
+      application/octlet-stream
+      application/save
+      application/save-as
+      application/stream
+      application/unknown
+      application/x-download
+      application/x-file-download
+      application/x-force-download
+      application/x-forcedownload
+      application/x-octet-stream
+      application/x-octets
+      application/x-octetstream
+      application/x-unknown
+      application/x-unknown-application-octet-stream
+      application/x-unknown-content-type
+      application/x-unknown-octet-stream
+
+      applicaton/octet-stream
+
+      attachment/octet-stream
+
+      bad/type
+
+      binary/
+      binary/*
+      binary/octec-stream
+      binary/octet-stream
+      binary/octet_stream
+      binary/octetstream
+
+      content-transfer-encoding/binary
+
+      download/file
+      download/test
+
+      file/octet-stream
+      file/unknown
+
+      multipart/alternative
+      multipart/form-data
+      multipart/octet-stream
+
+      octet/stream
+
+      type/unknown
+
+      unknown/
+      unknown/application
+      unknown/data
+      unknown/unknown
+
+      x-application/octet-stream
+      x-application/octetstream
+
+      x-unknown/octet-stream
+      x-unknown/x-unknown
+    ]
+
+    def generic_content_type?(content_type)
+      GENERIC_CONTENT_TYPES.include? content_type
+    end
+
+  end # GenericContentTypes
+end # CarrierWave

--- a/lib/carrierwave/processing/magic_mime_types.rb
+++ b/lib/carrierwave/processing/magic_mime_types.rb
@@ -1,0 +1,63 @@
+# encoding: utf-8
+
+module CarrierWave
+
+  ##
+  # This module uses ruby-filemagic gem to intelligently
+  # guess and set the content-type of a file. It uses libmagic(man 3 libmagic)
+  # If you want to use this, you'll need to require this file:
+  #
+  #     require 'carrierwave/processing/magic_mime_types'
+  #
+  # And then include it in your uploader:
+  #
+  #     class MyUploader < CarrierWave::Uploader::Base
+  #       include CarrierWave::MagicMimeTypes
+  #     end
+  #
+  # After that you can use the provided helper:
+  #
+  #     class MyUploader < CarrierWave::Uploader::Base
+  #       include CarrierWave::MagicMimeTypes
+  #
+  #       process :set_magic_content_type
+  #     end
+  #
+  module MagicMimeTypes
+    include CarrierWave::GenericContentTypes
+    extend ActiveSupport::Concern
+
+    included do
+      begin
+        require 'filemagic'
+      rescue LoadError => e
+        e.message << ' (You may need to install the ruby-filemagic gem)'
+        raise e
+      end
+    end
+
+    module ClassMethods
+      def set_magic_content_type(override=false)
+        process :set_magic_content_type => override
+      end
+    end
+
+    ##
+    # Changes the file content_type using the ruby-filemagic gem
+    #
+    def set_magic_content_type(override=false)
+      if override || file.content_type.blank? || generic_content_type?(file.content_type)
+        new_content_type = FileMagic.new(FileMagic::MAGIC_MIME).file( file.path ).split(';').first
+
+        if file.respond_to?(:content_type=)
+          file.content_type = new_content_type
+        else
+          file.instance_variable_set(:@content_type, new_content_type)
+        end
+      end
+    rescue ::Exception => e
+      raise CarrierWave::ProcessingError, I18n.translate(:"errors.messages.magic_mime_types_processing_error", :e => e)
+    end
+
+  end # MagicMimeTypes
+end # CarrierWave

--- a/lib/carrierwave/processing/mime_types.rb
+++ b/lib/carrierwave/processing/mime_types.rb
@@ -24,6 +24,7 @@ module CarrierWave
   #     end
   #
   module MimeTypes
+    include CarrierWave::GenericContentTypes
     extend ActiveSupport::Concern
 
     included do
@@ -41,12 +42,6 @@ module CarrierWave
       end
     end
 
-    GENERIC_CONTENT_TYPES = %w[application/octet-stream binary/octet-stream]
-
-    def generic_content_type?
-      GENERIC_CONTENT_TYPES.include? file.content_type
-    end
-
     ##
     # Changes the file content_type using the mime-types gem
     #
@@ -57,7 +52,7 @@ module CarrierWave
     #                      false by default
     #
     def set_content_type(override=false)
-      if override || file.content_type.blank? || generic_content_type?
+      if override || file.content_type.blank? || generic_content_type?(file.content_type)
         new_content_type = ::MIME::Types.type_for(file.original_filename).first.to_s
         if file.respond_to?(:content_type=)
           file.content_type = new_content_type

--- a/spec/processing/magic_mime_types_spec.rb
+++ b/spec/processing/magic_mime_types_spec.rb
@@ -1,0 +1,65 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe CarrierWave::MagicMimeTypes do
+
+  before do
+    @klass = Class.new do
+      attr_accessor :content_type
+      include CarrierWave::MagicMimeTypes
+    end
+    @instance = @klass.new
+    FileUtils.cp(file_path('sponsored.doc'), file_path('sponsored_copy.doc'))
+    @instance.stub(:original_filename).and_return file_path('sponsored_copy.doc')
+    @instance.stub(:file).and_return CarrierWave::SanitizedFile.new(file_path('sponsored_copy.doc'))
+    @file = @instance.file
+  end
+
+  after do
+    FileUtils.rm(file_path('sponsored_copy.doc'))
+  end
+
+  describe '#set_magic_content_type' do
+
+    it "does not set content_type if already set" do
+      @instance.file.content_type = 'text/plain'
+      @instance.file.should_not_receive(:content_type=)
+      @instance.set_magic_content_type
+    end
+
+    it "set content_type if content_type is nil" do
+      @instance.file.content_type = nil
+      @instance.file.should_receive(:content_type=).with('text/plain')
+      @instance.set_magic_content_type
+    end
+
+    it "set content_type if content_type is empty" do
+      @instance.file.content_type = ''
+      @instance.file.should_receive(:content_type=).with('text/plain')
+      @instance.set_magic_content_type
+    end
+
+    %w[ application/download application/save bad/type
+        file/unknown unknown/application unknown/data ].each do |type|
+      it "sets content_type if content_type is generic (#{type})" do
+        @instance.file.content_type = type
+        @instance.file.should_receive(:content_type=).with('text/plain')
+        @instance.set_magic_content_type
+      end
+    end
+
+    it "set content_type based on file content" do
+      @instance.file.should_receive(:content_type=).with( 'text/plain' )
+      @instance.set_magic_content_type
+    end
+
+    it "sets content_type if override is true" do
+      @instance.file.content_type = 'image/jpeg'
+      @instance.file.should_receive(:content_type=).with('text/plain')
+      @instance.set_magic_content_type(true)
+    end
+
+  end
+
+end


### PR DESCRIPTION
Currently the only way to set content type in carrierwave is using file extension(CarrierWave::MimeTypes).
There is a ruby-filemagic gem which offers ruby bindings to the libmagic library.
This commit adds libmagic-based processor which allows to detect file MIME type based on file content.
