### PR TITLE
Add ```require 'date'```, because Date.today requires this

### DIFF
--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -3,6 +3,7 @@ lib = File.expand_path('../lib/', __FILE__)
 $:.unshift lib unless $:.include?(lib)
 
 require 'carrierwave/version'
+require 'date'
 
 Gem::Specification.new do |s|
   s.name = "carrierwave"


### PR DESCRIPTION
For Ruby2.0.0-rc1

```
$ bundle exec rake -T
There was an error in your Gemfile, and Bundler cannot continue.
$ rake -T
There was an error in your Gemfile, and Bundler cannot continue.
```

`Data.today` in carrierwave.gemspec brings this.
Simular to this SO:
http://stackoverflow.com/questions/9704969/why-is-rubys-date-class-automatically-loaded-but-datetime-is-not
