### PR TITLE
Error in README. Using Amazon S3 config options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ CarrierWave.configure do |config|
     :aws_access_key_id      => 'xxx',                        # required
     :aws_secret_access_key  => 'yyy',                        # required
     :region                 => 'eu-west-1',                  # optional, defaults to 'us-east-1'
-    :hosts                  => 's3.example.com',             # optional, defaults to nil
+    :host                   => 's3.example.com',             # optional, defaults to nil
     :endpoint               => 'https://s3.example.com:8080' # optional, defaults to nil
   }
   config.fog_directory  = 'name_of_directory'                     # required


### PR DESCRIPTION
Very small patch, but caused us a bit of head scratching until we looked in the Fog source.

:hosts should be :host
