### PR TITLE
Fixes incorrect example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ and cropped to exactly 200 by 200 pixels. The uploader could be used like this:
 uploader = AvatarUploader.new
 uploader.store!(my_file)                              # size: 1024x768
 
-uploader.url # => '/url/to/my_file.png'               # size: 800x800
+uploader.url # => '/url/to/my_file.png'               # size: 800x600
 uploader.thumb.url # => '/url/to/thumb_my_file.png'   # size: 200x200
 ```
 


### PR DESCRIPTION
I just looked up the readme to make sure I was using the correct process and ran into this error/typo.

resize_to_fit will retain the aspect ratio so will actually scale to 800x600.
