### PR TITLE
Added configuration param to disable removing files after destroy

### DIFF
--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -27,7 +27,7 @@ module CarrierWave
 
       after_save :"store_#{column}!"
       before_save :"write_#{column}_identifier"
-      after_commit :"remove_#{column}!", :on => :destroy
+      after_commit :"remove_#{column}!", :on => :destroy if uploader_option(column.to_sym, :remove_files_after_destroy)
       before_update :"store_previous_model_for_#{column}"
       after_save :"remove_previously_stored_#{column}"
 

--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -21,6 +21,7 @@ module CarrierWave
         add_config :move_to_cache
         add_config :move_to_store
         add_config :remove_previously_stored_files_after_update
+        add_config :remove_files_after_destroy
 
         # fog
         add_config :fog_attributes
@@ -131,6 +132,7 @@ module CarrierWave
             config.move_to_cache = false
             config.move_to_store = false
             config.remove_previously_stored_files_after_update = true
+            config.remove_files_after_destroy = true
             config.ignore_integrity_errors = true
             config.ignore_processing_errors = true
             config.ignore_download_errors = true


### PR DESCRIPTION
Allow user to disable removing stored files after destroying a model. That could be helpful while implementing undo/redo and versioning (using paper_trail or similar).
