### PR TITLE
Fixes #991, use UTC for CarrierWave.generate_cache_id

### DIFF
--- a/lib/carrierwave/uploader/cache.rb
+++ b/lib/carrierwave/uploader/cache.rb
@@ -16,7 +16,7 @@ module CarrierWave
   # [String] a cache id in the format YYYYMMDD-HHMM-PID-RND
   #
   def self.generate_cache_id
-    Time.now.strftime('%Y%m%d-%H%M') + '-' + Process.pid.to_s + '-' + ("%04d" % rand(9999))
+    Time.now.utc.strftime('%Y%m%d-%H%M') + '-' + Process.pid.to_s + '-' + ("%04d" % rand(9999))
   end
 
   module Uploader

--- a/spec/uploader/cache_spec.rb
+++ b/spec/uploader/cache_spec.rb
@@ -314,5 +314,11 @@ describe CarrierWave::Uploader do
       end
     end
   end
-
+  describe '.generate_cache_id' do
+    it 'should generate dir name bsed on UTC time' do
+      Timecop.travel(Time.utc(2013, 2, 22, 10, 12)) do
+        CarrierWave.generate_cache_id.should match(/\A20130222-1012-\d+-\d+\Z/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://github.com/jnicklas/carrierwave/issues/991
