### PR TITLE
Uri encode url path parts

### DIFF
--- a/lib/carrierwave/uploader/url.rb
+++ b/lib/carrierwave/uploader/url.rb
@@ -16,25 +16,54 @@ module CarrierWave
       # [String] the location where this file is accessible via a url
       #
       def url(options = {})
-        if file.respond_to?(:url) and not file.url.blank?
-          file.method(:url).arity == 0 ? file.url : file.url(options)
-        elsif file.respond_to?(:path)
-          path = file.path.gsub(File.expand_path(root), '')
+        url =
+          if file.respond_to?(:url) and not file.url.blank?
+            file.method(:url).arity == 0 ? file.url : file.url(options)
+          elsif file.respond_to?(:path)
+            path = file.path.gsub(File.expand_path(root), '')
 
-          if host = asset_host
-            if host.respond_to? :call
-              "#{host.call(file)}#{path}"
+            if host = asset_host
+              if host.respond_to? :call
+                "#{host.call(file)}#{path}"
+              else
+                "#{host}#{path}"
+              end
             else
-              "#{host}#{path}"
+              (base_path || "") + path
             end
-          else
-            (base_path || "") + path
           end
-        end
+
+        uri_encode_url(url)
       end
 
       def to_s
         url || ''
+      end
+
+    private
+
+      def uri_encode_url(url)
+        if url = URI.parse(url)
+          url.path = uri_encode_path(url.path)
+          url.to_s
+        end
+      rescue URI::InvalidURIError
+        nil
+      end
+
+      def uri_encode_path(path)
+        # based on Ruby < 2.0's URI.encode
+        safe_string = URI::REGEXP::PATTERN::UNRESERVED + '\/'
+        unsafe = Regexp.new("[^#{safe_string}]", false)
+
+        path.gsub(unsafe) do
+          us = $&
+          tmp = ''
+          us.each_byte do |uc|
+            tmp << sprintf('%%%02X', uc)
+          end
+          tmp
+        end
       end
 
     end # Url

--- a/spec/fixtures/test+.jpg
+++ b/spec/fixtures/test+.jpg
@@ -1,0 +1,1 @@
+this is stuff

--- a/spec/uploader/url_spec.rb
+++ b/spec/uploader/url_spec.rb
@@ -101,6 +101,35 @@ describe CarrierWave::Uploader do
       @uploader.file.stub!(:url).and_return('')
       @uploader.url.should == '/uploads/tmp/20071201-1234-345-2255/test.jpg'
     end
+
+    it "should uri encode the path of a file without an asset host" do
+      @uploader.cache!(File.open(file_path('test+.jpg')))
+      @uploader.url.should == '/uploads/tmp/20071201-1234-345-2255/test%2B.jpg'
+    end
+
+    it "should uri encode the path of a file with a string asset host" do
+      MyCoolUploader.version(:thumb)
+      @uploader.class.configure do |config|
+        config.asset_host = "http://foo.bar"
+      end
+      @uploader.cache!(File.open(file_path('test+.jpg')))
+      @uploader.url(:thumb).should == 'http://foo.bar/uploads/tmp/20071201-1234-345-2255/thumb_test%2B.jpg'
+    end
+
+    it "should uri encode the path of a file with a proc asset host" do
+      MyCoolUploader.version(:thumb)
+      @uploader.class.configure do |config|
+        config.asset_host = proc { "http://foo.bar" }
+      end
+      @uploader.cache!(File.open(file_path('test+.jpg')))
+      @uploader.url(:thumb).should == 'http://foo.bar/uploads/tmp/20071201-1234-345-2255/thumb_test%2B.jpg'
+    end
+
+    it "should uri encode the path of an available file#url" do
+      @uploader.cache!(File.open(file_path('test.jpg')))
+      @uploader.file.stub!(:url).and_return('http://www.example.com/directory+name/another+directory/some+url.jpg')
+      @uploader.url.should == 'http://www.example.com/directory%2Bname/another%2Bdirectory/some%2Burl.jpg'
+    end
   end
 
   describe '#to_json' do


### PR DESCRIPTION
This is an attempt to fix the longstanding issue where we generate bad urls if somebody uploads a file with a "+" (plus) character in the filename.

See: #994, #989, #986, #733 etc

Long story short I'm making sure the path parts are uri encoded before sending urls out into the world.

Notes:
- This is a breaking change because it requires that `store_dir` is always _not_ uri encoded. This seemed like a good assumption, since `store_dir` is generally a filesystem path.
- My thoughts that got me here are [here](https://github.com/jnicklas/carrierwave/issues/994#issuecomment-14009327), and earlier in the thread.
- Yes, I'm seriously reimplementing Ruby 1.9.3's deprecated URI.encode so we can use it on 2.0+. Would love an alternative.
- May have problems on windows since their directory separators are different, but I'm not sure how the existing code works on Windows anyway.

Very interested in feedback.
