### PR TITLE
process_uri: only encode if invalid

### DIFF
--- a/lib/carrierwave/uploader/download.rb
+++ b/lib/carrierwave/uploader/download.rb
@@ -70,7 +70,9 @@ module CarrierWave
       # [url (String)] The URL where the remote file is stored
       #
       def process_uri(uri)
-        URI.parse(URI.escape(URI.unescape(uri)))
+        URI.parse(uri)
+      rescue URI::InvalidURIError
+        URI.parse(URI.encode(uri))
       end
 
     end # Download

--- a/spec/uploader/download_spec.rb
+++ b/spec/uploader/download_spec.rb
@@ -168,5 +168,11 @@ describe CarrierWave::Uploader::Download do
     it 'should parse the given uri' do
       @uploader.process_uri(uri).should == URI.parse(uri)
     end
+
+    it "shouldn't unescape already escaped uris" do
+      uri = 'http://www.example.com/%5B.jpg'
+      @uploader.process_uri(uri).should == URI.parse(uri)
+    end
+
   end
 end


### PR DESCRIPTION
This resolves #999 and is a step in the right direction for #733.

Instead of just blindly unescaping and then escaping uris, which breaks on uri-encoded characters that are permitted in uris like "+" (aka "%2B") or "[" aka "%5B", we're only escaping uris if they aren't already valid. 

This pull doesn't let us support urls like 'http://example.com/].jpg', because URI.encode doesn't touch brackets (they're valid in 'http://example.com/?foo[]=bar'). If it's important to someone that we support invalid urls like that, I'll leave it to someone braver than I.
