### PR TITLE
Allow file names with square brackets in them.

### DIFF
--- a/lib/carrierwave/uploader/download.rb
+++ b/lib/carrierwave/uploader/download.rb
@@ -70,9 +70,7 @@ module CarrierWave
       # [url (String)] The URL where the remote file is stored
       #
       def process_uri(uri)
-        URI.parse(uri)
-      rescue URI::InvalidURIError
-        URI.parse(URI.encode(URI.encode(uri), "[]"))
+        URI.parse(URI.escape(URI.escape(URI.unescape(uri)), "[]"))
       end
 
     end # Download


### PR DESCRIPTION
Allowing file names to have square brackets in them without showing an error of the form URI::InvalidURIError.
