### PR TITLE
add pry as development dependency

### DIFF
--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "fog", ">= 1.3.1"
   s.add_development_dependency "mini_magick"
   s.add_development_dependency "rmagick"
+  s.add_development_dependency "pry"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'bundler/setup'
 require 'tempfile'
 require 'time'
 require 'logger'
+require 'pry'
 
 require 'carrierwave'
 require 'timecop'


### PR DESCRIPTION
You guys want to use [pry](https://github.com/pry/pry)? It is awesome, and it makes debugging complicated under-the-hood behavior much easier: just put `binding.pry` where you want it to break, run your spec, and you've got an interactive console going from your breakpoint.
