### PR TITLE
fix travis on edge rails (no more bundler --pre)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 before_install:
-  - gem install bundler --pre
+  - gem install bundler
 
 notifications:
   email: false


### PR DESCRIPTION
Travis builds for edge rails are erroring out because edge rails requires the recently released bundler 1.3, but we're using `gem install bundler --pre`, which unsatisfyingly installs bundler 1.3.pre.8.
