### PR TITLE
refactor: make encode_path private

### DIFF
--- a/lib/carrierwave.rb
+++ b/lib/carrierwave.rb
@@ -62,6 +62,7 @@ elsif defined?(Sinatra)
   end
 end
 
+require "carrierwave/utilities"
 require "carrierwave/error"
 require "carrierwave/sanitized_file"
 require "carrierwave/mount"

--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -104,6 +104,7 @@ module CarrierWave
       end
 
       class File
+        include CarrierWave::Utilities::Uri
 
         ##
         # Current local path to file
@@ -276,7 +277,7 @@ module CarrierWave
         # [NilClass] no public url available
         #
         def public_url
-          encoded_path = @uploader.encode_path(path)
+          encoded_path = encode_path(path)
           if host = @uploader.asset_host
             if host.respond_to? :call
               "#{host.call(self)}/#{encoded_path}"

--- a/lib/carrierwave/uploader/url.rb
+++ b/lib/carrierwave/uploader/url.rb
@@ -5,23 +5,7 @@ module CarrierWave
     module Url
       extend ActiveSupport::Concern
       include CarrierWave::Uploader::Configuration
-
-      module ClassMethods
-        def encode_path(path)
-          # based on Ruby < 2.0's URI.encode
-          safe_string = URI::REGEXP::PATTERN::UNRESERVED + '\/'
-          unsafe = Regexp.new("[^#{safe_string}]", false)
-
-          path.gsub(unsafe) do
-            us = $&
-            tmp = ''
-            us.each_byte do |uc|
-              tmp << sprintf('%%%02X', uc)
-            end
-            tmp
-          end
-        end
-      end
+      include CarrierWave::Utilities::Uri
 
       ##
       # === Parameters
@@ -36,7 +20,7 @@ module CarrierWave
         if file.respond_to?(:url) and not file.url.blank?
           file.method(:url).arity == 0 ? file.url : file.url(options)
         elsif file.respond_to?(:path)
-          path = self.class.encode_path(file.path.gsub(File.expand_path(root), ''))
+          path = encode_path(file.path.gsub(File.expand_path(root), ''))
 
           if host = asset_host
             if host.respond_to? :call

--- a/lib/carrierwave/utilities.rb
+++ b/lib/carrierwave/utilities.rb
@@ -1,0 +1,8 @@
+# encoding: utf-8
+
+require 'carrierwave/utilities/uri'
+
+module CarrierWave
+  module Utilities
+  end
+end

--- a/lib/carrierwave/utilities/uri.rb
+++ b/lib/carrierwave/utilities/uri.rb
@@ -1,0 +1,24 @@
+# encoding: utf-8
+
+module CarrierWave
+  module Utilities
+    module Uri
+
+    private
+      def encode_path(path)
+        # based on Ruby < 2.0's URI.encode
+        safe_string = URI::REGEXP::PATTERN::UNRESERVED + '\/'
+        unsafe = Regexp.new("[^#{safe_string}]", false)
+
+        path.gsub(unsafe) do
+          us = $&
+          tmp = ''
+          us.each_byte do |uc|
+            tmp << sprintf('%%%02X', uc)
+          end
+          tmp
+        end
+      end
+    end # Uri
+  end # Utilities
+end # CarrierWave


### PR DESCRIPTION
This is a first draft of the discussed refactor of #1006 to keep encode_url out of our api. If there's a better way to do it, I'd love to; this is just the first way I found that worked.

(Also, given that Uploader#process_uri is using the "obsoleted" URI.encode, Utilities#Uri seems like a likely home for the (I wish it weren't necessary) URI.encode replacement we're presumably going to have to write before ruby 2.1. If that sounds ugly, at least we aren't Fog, who apparently have to maintain custom versions of URI.encode aka escape for [aws](https://github.com/fog/fog/blob/master/lib/fog/aws.rb#L88), [cloudstack](https://github.com/fog/fog/blob/master/lib/fog/cloudstack.rb#L13), [hp](https://github.com/fog/fog/blob/master/lib/fog/hp.rb#L192), and [rackspace](https://github.com/fog/fog/blob/master/lib/fog/rackspace.rb#L90).)
