### PR TITLE
update readme: you should validate remote_url fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,13 @@ form and you're good to go:
 <% end %>
 ```
 
+Note that it's up to you to validate that users have entered a valid URL. 
+CarrierWave does its best to interpret URLs intelligently, but this is
+[not always possible](https://github.com/jnicklas/carrierwave/issues/1003#issuecomment-14301719).
+Depending on whether or not you've turned off `ignore_download_errors`, upon 
+encountering an invalid URL CarrierWave will either throw an
+`URI::InvalidURIError`, or fail silently.
+
 ## Providing a default URL
 
 In many cases, especially when working with images, it might be a good idea to


### PR DESCRIPTION
Given that you seem to get a non-stop onslaught of issues around this, it seems worthwhile to remind people that despite our best efforts, CarrierWave still can't interpret every URL a user types or pastes into a text field the way they'd like. Also probably useful to remind them that, by default, CarrierWave fails silently upon encountering invalid URLs.
