### PR TITLE
process_uri should throw CarrierWave::DownloadError

### DIFF
--- a/lib/carrierwave/uploader/download.rb
+++ b/lib/carrierwave/uploader/download.rb
@@ -72,7 +72,7 @@ module CarrierWave
       def process_uri(uri)
         URI.parse(uri)
       rescue URI::InvalidURIError
-        URI.parse(URI.encode(uri))
+        URI.parse(URI.encode(uri)) rescue raise CarrierWave::DownloadError, "couldn't parse URL"
       end
 
     end # Download

--- a/spec/uploader/download_spec.rb
+++ b/spec/uploader/download_spec.rb
@@ -184,7 +184,7 @@ describe CarrierWave::Uploader::Download do
       # how to do that without breaking the above, testing to ensure an exception
       # is raised is the best we can do.
       uri = 'http://www.example.com/].jpg'
-      expect { @uploader.process_uri(uri) }.to raise_error(URI::InvalidURIError)
+      expect { @uploader.process_uri(uri) }.to raise_error(CarrierWave::DownloadError)
     end
   end
 end


### PR DESCRIPTION
Seriously? Another pull for URLs? Yes. (And there's at least one more coming after this...)

Given that we're [already using `CarrierWave::DownloadError`s](https://github.com/jnicklas/carrierwave/blob/master/lib/carrierwave/mount.rb#L356) for [validation under ActiveRecord](https://github.com/jnicklas/carrierwave/blob/master/lib/carrierwave/validations/active_model.rb#L33) (who knew?), process_uri should probably be throwing one of those, so that people are able to show invalid URL errors with the same already-available code that shows 404 errors and protocol errors. 
