### PR TITLE
Add to_s for nil path to continue support for carrierwave_direct

### DIFF
--- a/lib/carrierwave/utilities/uri.rb
+++ b/lib/carrierwave/utilities/uri.rb
@@ -10,7 +10,7 @@ module CarrierWave
         safe_string = URI::REGEXP::PATTERN::UNRESERVED + '\/'
         unsafe = Regexp.new("[^#{safe_string}]", false)
 
-        path.gsub(unsafe) do
+        path.to_s.gsub(unsafe) do
           us = $&
           tmp = ''
           us.each_byte do |uc|


### PR DESCRIPTION
URI.rb was giving "no method gsub on Nil" when using with carrierwave_direct's recommended way of doing browser uploads directly to S3. In that instance you don't yet have a path (there's no file), but you use `SomethingUploader.direct_fog_url` as the destination to POST to. 

This just adds a "to_s" because path is nil.

I'm submitting this without being able to run tests locally - apparently there's a Travis CI server which can give me a result if I submit this as-is.
