### PR TITLE
An IO object passed to an uploader is never closed, so file handles are leaked

### DIFF
--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -153,11 +153,15 @@ module CarrierWave
     # [String] contents of the file
     #
     def read
-      if is_path?
+      if @content
+        @content
+      elsif is_path?
         File.open(@file, "rb") {|file| file.read}
       else
         @file.rewind if @file.respond_to?(:rewind)
-        @file.read
+        @content = @file.read
+        @file.close if @file.respond_to?(:close) && @file.respond_to?(:closed?) && !@file.closed?
+        @content
       end
     end
 

--- a/spec/sanitized_file_spec.rb
+++ b/spec/sanitized_file_spec.rb
@@ -419,6 +419,20 @@ describe CarrierWave::SanitizedFile do
     end
   end
 
+  shared_examples_for "all valid sanitized files that are read from an IO object" do
+
+    describe '#read' do
+      it "should have an open IO object" do
+        @sanitized_file.instance_variable_get(:@file).closed?.should be_false
+      end
+
+      it "should close the IO object after reading" do
+        @sanitized_file.read
+        @sanitized_file.instance_variable_get(:@file).closed?.should be_true
+      end
+    end
+  end
+
   describe "with a valid Hash" do
     before do
       @hash = {
@@ -432,6 +446,8 @@ describe CarrierWave::SanitizedFile do
     it_should_behave_like "all valid sanitized files"
 
     it_should_behave_like "all valid sanitized files that are stored on disk"
+
+    it_should_behave_like "all valid sanitized files that are read from an IO object"
 
     describe '#path' do
       it "should return the path of the tempfile" do
@@ -458,6 +474,8 @@ describe CarrierWave::SanitizedFile do
 
     it_should_behave_like "all valid sanitized files that are stored on disk"
 
+    it_should_behave_like "all valid sanitized files that are read from an IO object"
+
     describe '#is_path?' do
       it "should be false" do
         @sanitized_file.is_path?.should be_false
@@ -479,6 +497,8 @@ describe CarrierWave::SanitizedFile do
     end
 
     it_should_behave_like "all valid sanitized files"
+
+    it_should_behave_like "all valid sanitized files that are read from an IO object"
 
     describe '#exists?' do
       it "should be false" do
@@ -523,6 +543,8 @@ describe CarrierWave::SanitizedFile do
 
     it_should_behave_like "all valid sanitized files that are stored on disk"
 
+    it_should_behave_like "all valid sanitized files that are read from an IO object"
+
     describe '#is_path?' do
       it "should be false" do
         @sanitized_file.is_path?.should be_false
@@ -548,6 +570,8 @@ describe CarrierWave::SanitizedFile do
     end
 
     it_should_behave_like "all valid sanitized files that are stored on disk"
+
+    it_should_behave_like "all valid sanitized files that are read from an IO object"
 
     describe '#is_path?' do
       it "should be false" do


### PR DESCRIPTION
To avoid this, if we're passed an IO object that we retrieve via #read, #close it after #read is complete.  This affects custom IO objects passed in as well as remote_urls by the looks - they're not opened/read using a block, and there's no #close called anywhere that I can see.
