### PR TITLE
Add the base Gemfile to the travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ rvm:
  - ree
 
 gemfile:
+  - Gemfile
   - gemfiles/rails3_2.gemfile
   - gemfiles/rails_master.gemfile
 


### PR DESCRIPTION
This ensures that we have coverage on the most relevant installation scenario.
