### PR TITLE
Use filename in Content-Disposition header when present

### DIFF
--- a/lib/carrierwave/uploader/download.rb
+++ b/lib/carrierwave/uploader/download.rb
@@ -17,6 +17,10 @@ module CarrierWave
         end
 
         def original_filename
+          if file.meta.include? 'content-disposition'
+            match = file.meta['content-disposition'].match(/filename=(\"?)(.+)\1/)
+            return match[2] unless match.nil?
+          end
           File.basename(file.base_uri.path)
         end
 


### PR DESCRIPTION
Carrierwave should respect the filename set in the Content-Disposition
header when downloading remote files. This fixes issue #1047 as well.

Included test specs for checking the content-disposition filename against the extension white list or extension black list.

This also solves the case of using a service like [Filepicker.io](http://www.filepicker.io) to handle uploads and then passing them off to Carrierwave to process.
