### PR TITLE
File extension missed and wrong filename for remote url

### DIFF
--- a/lib/carrierwave/uploader/download.rb
+++ b/lib/carrierwave/uploader/download.rb
@@ -17,7 +17,19 @@ module CarrierWave
         end
 
         def original_filename
-          File.basename(file.base_uri.path)
+          filename = File.basename(file.base_uri.path)
+
+          if File.extname(filename).blank?
+            ext = case file.meta["content-type"]
+              when "image/jpeg", "image/jpg", "image/pjpeg" then ".jpg"
+              when "image/png", "image/x-png" then ".png"
+              when "image/gif" then ".gif"
+            end
+
+            [filename, ext].join
+          else
+            filename
+          end
         end
 
         def respond_to?(*args)


### PR DESCRIPTION
I have image url without extention, and it isn't saved.
My fast hook for this bug.
Works only for images files.
