### PR TITLE
fix recreate_versions! when version if proc returns false

### DIFF
--- a/lib/carrierwave/uploader/versions.rb
+++ b/lib/carrierwave/uploader/versions.rb
@@ -240,7 +240,8 @@ module CarrierWave
 
       def store_versions!(new_file, versions=nil)
         if versions
-          versions.each { |v| Hash[active_versions][v].store!(new_file) }
+          active = Hash[active_versions]
+          versions.each { |v| active[v].try(:store!, new_file) } unless active.empty?
         else
           active_versions.each { |name, v| v.store!(new_file) }
         end

--- a/spec/uploader/versions_spec.rb
+++ b/spec/uploader/versions_spec.rb
@@ -371,6 +371,17 @@ describe CarrierWave::Uploader do
         File.exists?(@uploader.mini.path).should == false
       end
 
+      it "should not create version if proc returns false" do
+        @uploader_class.version(:mini, :if => Proc.new { |*args| false } )
+        @uploader.store!(@file)
+
+        @uploader.mini.path.should be_nil
+
+        @uploader.recreate_versions!(:mini)
+
+        @uploader.mini.path.should be_nil
+      end
+
       it "should not change the case of versions" do
         @file = File.open(file_path('Uppercase.jpg'))
         @uploader.store!(@file)


### PR DESCRIPTION
When trying to recreate an specific version(`recreate_versions!`) and that version had a proc returning false, there was an error trying to store that object.
