### PR TITLE
Bug fix in serializing to xml or json where both :only and :except are passed 

### DIFF
--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -57,7 +57,7 @@ module CarrierWave
           only   = options && options[:only]   && Array.wrap(options[:only]).map(&:to_s)
 
           self.class.uploaders.each do |column, uploader|
-            if (!only && !except) || (only && only.include?(column.to_s)) || (except && !except.include?(column.to_s))
+            if (!only && !except) || (only && only.include?(column.to_s)) || (!only && except && !except.include?(column.to_s))
               hash[column.to_s] = _mounter(column).uploader.serializable_hash
             end
           end

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -127,6 +127,37 @@ describe CarrierWave::ActiveRecord do
 
         expect(@event.as_json(:except => [:id, :image, :foo])).to eq({"textfile" => nil})
       end
+      it "should respect both options[:only] and options[:except] when passed to as_json for the serializable hash" do
+        @event[:image] = 'test.jpeg'
+        @event.save!
+        @event.reload
+
+        expect(@event.as_json(:only => [:foo], :except => [:id])).to eq({"foo" => nil})
+      end
+
+      it "should respect options[:only] when passed to to_xml for the serializable hash" do
+        @event[:image] = 'test.jpeg'
+        @event.save!
+        @event.reload
+
+        expect(Hash.from_xml(@event.to_xml(:only => [:foo]))["event#{$arclass}"]["image"]).to be_nil
+      end
+
+      it "should respect options[:except] when passed to to_xml for the serializable hash" do
+        @event[:image] = 'test.jpeg'
+        @event.save!
+        @event.reload
+
+        expect(Hash.from_xml(@event.to_xml(:except => [:image]))["event#{$arclass}"]["image"]).to be_nil
+      end
+
+      it "should respect both options[:only] and options[:except] when passed to to_xml for the serializable hash" do
+        @event[:image] = 'test.jpeg'
+        @event.save!
+        @event.reload
+
+        expect(Hash.from_xml(@event.to_xml(:only => [:foo], :except => [:id]))["event#{$arclass}"]["image"]).to be_nil
+      end
     end
 
     describe '#image=' do


### PR DESCRIPTION
There was a bug in determining if the uploader should be serialized
when both :only and :except were passed. 

The uploader was being serialized even if it didn't appear in the :only option, because it also didn't appear in the :except option.

:only takes precedence. :except should be taken into account only if :only isn't passed

This bug was especially important with ActiveRecord's to_xml
implementation, which adds an additional :except => :type to the
options hash. This revealed the bug even when I was only passing :only

Please note that this bug may also be present in carrierwave's version for other ORMs, like mongoid, sequel, etc.
