### PR TITLE
Add method #version_exists?

### DIFF
--- a/lib/carrierwave/uploader/versions.rb
+++ b/lib/carrierwave/uploader/versions.rb
@@ -180,7 +180,7 @@ module CarrierWave
         if (version = args.first) && version.respond_to?(:to_sym)
           raise ArgumentError, "Version #{version} doesn't exist!" if versions[version.to_sym].nil?
           # recursively proxy to version
-          versions[version.to_sym].url(*args[1..-1])
+          versions[version.to_sym].url(*args[1..-1]) if version_exists?(version)
         elsif args.first
           super(args.first)
         else


### PR DESCRIPTION
This pull request fixes #1089 by introducing a method calles #version_exists?

This method was extracted from `active_versions`: https://github.com/carrierwaveuploader/carrierwave/blob/master/lib/carrierwave/uploader/versions.rb#L152-L162

an `url` is just returned if the version exists according to the `:if` condition.
