### PR TITLE
resolve test failure on travis-ci precise64 with ruby 1.8.7, rmagick 2.13.2, imagemagick 6.6.9-7 2012-08-17 Q16

### DIFF
--- a/lib/carrierwave/processing/rmagick.rb
+++ b/lib/carrierwave/processing/rmagick.rb
@@ -215,7 +215,7 @@ module CarrierWave
     def resize_and_pad(width, height, background=:transparent, gravity=::Magick::CenterGravity)
       manipulate! do |img|
         img.resize_to_fit!(width, height)
-        new_img = ::Magick::Image.new(width, height)
+        new_img = ::Magick::Image.new(width, height) { self.background_color = 'rgba(255,255,255,0)' }
         if background == :transparent
           filled = new_img.matte_floodfill(1, 1)
         else


### PR DESCRIPTION
resolve test failure on travis-ci precise64 with ruby 1.8.7, rmagick 2.13.2, imagemagick 6.6.9-7 2012-08-17 Q16

https://github.com/carrierwaveuploader/carrierwave/pull/1109
