### PR TITLE
Performance optimization of SanitizedFile#path

### DIFF
--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -108,13 +108,7 @@ module CarrierWave
     # [String, nil] the path where the file is located.
     #
     def path
-      unless @file.blank?
-        if is_path?
-          File.expand_path(@file)
-        elsif @file.respond_to?(:path) and not @file.path.blank?
-          File.expand_path(@file.path)
-        end
-      end
+      @path ||= expanded_path
     end
 
     ##
@@ -270,6 +264,17 @@ module CarrierWave
     end
 
   private
+
+    def expanded_path
+      unless @file.blank?
+        if is_path?
+          File.expand_path(@file)
+        elsif @file.respond_to?(:path) and not @file.path.blank?
+          File.expand_path(@file.path)
+        end
+      end
+    end
+
 
     def file=(file)
       if file.is_a?(Hash)


### PR DESCRIPTION
Noticed when running my integration tests through ruby-prof that significant time was being spent within SanitizedFile#path.  Memoized the result of that calculation which reduced the number of calls to File#expand_path by around 200X and the bottle neck seemed to go away.
