### PR TITLE
Add note about adding remove_avatar in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,8 @@ easily add a checkbox to the form which will remove the file when checked.
 <% end %>
 ```
 
+Also, make sure to add `:remove_avatar` to `attributes_accessible` for this to work. 
+
 If you want to remove the file manually, you can call <code>remove_avatar!</code>.
 
 ## Uploading files from a remote location


### PR DESCRIPTION
Probably could be worded better, but if you don't put `:remove_avatar` in your `attributes_accessible`, using the remove_avatar checkbox will not work (at least using Mongo...).
