### PR TITLE
Add note about adding remove_avatar in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ easily add a checkbox to the form which will remove the file when checked.
 <% end %>
 ```
 
-Also, make sure to add `:remove_avatar` to `attributes_accessible` for this to work. 
+Also, make sure you have `:remove_avatar` in your `User` model's `attr_accessible` for this to work. 
 
 If you want to remove the file manually, you can call <code>remove_avatar!</code>.
 


### PR DESCRIPTION
Probably could be worded better, but if you don't put `:remove_avatar` in your `attr_accessible`, using the remove_avatar checkbox will not work (at least using Mongo...).

_Note: Fixed spelling error_
