### PR TITLE
Allow not ascii character.

### DIFF
--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -21,7 +21,7 @@ module CarrierWave
       attr_writer :sanitize_regexp
 
       def sanitize_regexp
-        @sanitize_regexp ||= /[^a-zA-Z0-9\.\-\+_]/
+        @sanitize_regexp ||= /[^[:word:]a-zA-Z0-9\.\-\+_]/
       end
     end
 

--- a/spec/sanitized_file_spec.rb
+++ b/spec/sanitized_file_spec.rb
@@ -132,6 +132,11 @@ describe CarrierWave::SanitizedFile do
       @sanitized_file.filename.should == "DSC4056.JPG"
     end
 
+    it "should remove illegal characters from a filename but accept Japanese character" do
+      @sanitized_file.should_receive(:original_filename).at_least(:once).and_return("テストtest-s,%&m#st?.jpg")
+      @sanitized_file.filename.should == "テストtest-s___m_st_.jpg"
+    end
+
   end
 
   describe '#filename with an overridden sanitize_regexp' do


### PR DESCRIPTION
Hi.

carrierwave is very useful.
I love it.
I would use in Japanese environment, but it would sanitize Japanese file name.
I want to use Japanese character filename.
I try to fix it.

thanks.
