### PR TITLE
Simplify build matrix definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,9 @@ notifications:
   email: false
 
 rvm:
- - 1.8.7
- - 1.9.2
  - 1.9.3
  - 2.0.0
  - ruby-head
- - ree
 
 gemfile:
   - Gemfile
@@ -21,25 +18,13 @@ gemfile:
 matrix:
   allow_failures:
     - rvm: ruby-head
-  exclude:
+  include:
     - rvm: 1.8.7
-      gemfile: gemfiles/rails-master.gemfile
-    - rvm: 1.8.7
-      gemfile: gemfiles/rails-4-0-stable.gemfile
-    - rvm: 1.8.7
-      gemfile: Gemfile
+      gemfile: gemfiles/rails-3-2-stable.gemfile
     - rvm: 1.9.2
-      gemfile: gemfiles/rails-master.gemfile
-    - rvm: 1.9.2
-      gemfile: gemfiles/rails-4-0-stable.gemfile
-    - rvm: 1.9.2
-      gemfile: Gemfile
+      gemfile: gemfiles/rails-3-2-stable.gemfile
     - rvm: ree
-      gemfile: gemfiles/rails-master.gemfile
-    - rvm: ree
-      gemfile: gemfiles/rails-4-0-stable.gemfile
-    - rvm: ree
-      gemfile: Gemfile
+      gemfile: gemfiles/rails-3-2-stable.gemfile
 
 before_script:
   - "mysql -e 'create database carrierwave_test;'"


### PR DESCRIPTION
Whitelist a few vectors in the build matrix to test Ruby 1.8 with Rails 3.2 instead of blacklisting a bunch of vectors.
