### PR TITLE
Add option for always using the public URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ CarrierWave.configure do |config|
   }
   config.fog_directory  = 'name_of_directory'                     # required
   config.fog_public     = false                                   # optional, defaults to true
+  config.fog_public_url = true                                    # optional, defaults to false
   config.fog_attributes = {'Cache-Control'=>'max-age=315576000'}  # optional, defaults to {}
 end
 ```

--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -17,6 +17,7 @@ module CarrierWave
     #
     # [:fog_attributes]                   (optional) additional attributes to set on files
     # [:fog_public]                       (optional) public readability, defaults to true
+    # [:fog_public_url]                   (optional) always return non-authenticated URLs.  Defaults to false.
     # [:fog_authenticated_url_expiration] (optional) time (in seconds) that authenticated urls
     #   will be valid, when fog_public is false and provider is AWS or Google, defaults to 600
     # [:fog_use_ssl_for_aws]              (optional) #public_url will use https for the AWS generated URL]
@@ -320,7 +321,7 @@ module CarrierWave
         # [NilClass] no url available
         #
         def url(options = {})
-          if !@uploader.fog_public
+          if !@uploader.fog_public && !@uploader.fog_public_url
             authenticated_url(options)
           else
             public_url

--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -27,6 +27,7 @@ module CarrierWave
         add_config :fog_credentials
         add_config :fog_directory
         add_config :fog_public
+        add_config :fog_public_url
         add_config :fog_authenticated_url_expiration
         add_config :fog_use_ssl_for_aws
 
@@ -125,6 +126,7 @@ module CarrierWave
             config.fog_attributes = {}
             config.fog_credentials = {}
             config.fog_public = true
+            config.fog_public_url = false
             config.fog_authenticated_url_expiration = 600
             config.fog_use_ssl_for_aws = true
             config.store_dir = 'uploads'

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -247,6 +247,48 @@ end
           end
         end
 
+        describe 'fog_public_url' do
+          before do
+            directory_key = "#{CARRIERWAVE_DIRECTORY}public"
+            @directory = @storage.connection.directories.create(:key => directory_key, :public => false)
+            @uploader.stub!(:fog_public).and_return(false)
+            @uploader.stub!(:fog_directory).and_return(directory_key)
+            @uploader.stub!(:store_path).and_return('uploads/public.txt')
+            @fog_file = @storage.store!(@file)
+          end
+
+          after do
+            @directory.files.new(:key => 'uploads/public.txt').destroy
+            @directory.destroy
+          end
+
+          context "true" do
+            before do
+              @uploader.stub!(:fog_public_url).and_return(true)
+            end
+
+            it "should always return the public URL" do
+              @fog_file.url.should == @fog_file.public_url
+            end
+          end
+          context "false" do
+            before do
+              @uploader.stub!(:fog_public).and_return(false)
+            end
+            it "should have an authenticated_url" do
+              if ['AWS', 'Rackspace', 'Google'].include?(@provider)
+                @fog_file.authenticated_url.should_not be_nil
+                @fog_file.url.should == @fog_file.authenticated_url
+              end
+            end
+            it "should handle query params" do
+              if @provider == 'AWS' && !Fog.mocking?
+                headers = Excon.get(@fog_file.url(:query => {"response-content-disposition" => "attachment"})).headers
+                headers["Content-Disposition"].should == "attachment"
+              end
+            end
+          end
+        end
       end
 
     end


### PR DESCRIPTION
This change makes it possible to not grant your `AWS` user `s3:PutObjectAcl` use and still use non-authenticated URLs.

For example: the bucket policy below grants `s3:GetObject` use to everyone (making all objects public), and `s3:PutObject` to a (fog) user.

```
{
  "Id": "AppBucketPolicy",
  "Statement": [
    {
      "Sid"       : "AppReadAccess",
      "Effect"    : "Allow",
      "Principal" : { "AWS": "*" },
      "Action"    : "s3:GetObject",
      "Resource"  : "arn:aws:s3:::fog-directory/*"
    },
    {
      "Sid": "AppReadWriteAccess",
      "Effect": "Allow",
      "Principal": {
        "AWS": "arn:aws:iam::XXXXXXXXXXXX:user/fog-user-YYYYYYYYYYYY"
      },
      "Action": [
        "s3:GetObject",
        "s3:PutObject"
      ],
      "Resource": "arn:aws:s3:::fog-directory/*"
    }
  ]
}
```
