### PR TITLE
Remove magic comment from generator when using ruby 2.0

### DIFF
--- a/lib/generators/templates/uploader.rb
+++ b/lib/generators/templates/uploader.rb
@@ -1,5 +1,7 @@
+<% if RUBY_VERSION < '2.0' -%>
 # encoding: utf-8
 
+<% end -%>
 class <%= class_name %>Uploader < CarrierWave::Uploader::Base
 
   # Include RMagick or MiniMagick support:


### PR DESCRIPTION
Now that UTF-8 is the default encoding in ruby 2.0.
