### PR TITLE
Memoize uploaders and uploader_options

### DIFF
--- a/lib/carrierwave/mount.rb
+++ b/lib/carrierwave/mount.rb
@@ -20,15 +20,11 @@ module CarrierWave
     # [Hash{Symbol => CarrierWave}] what uploaders are mounted on which columns
     #
     def uploaders
-      @uploaders ||= {}
-      @uploaders = superclass.uploaders.merge(@uploaders) if superclass.respond_to?(:uploaders)
-      @uploaders
+      @uploaders ||= superclass.respond_to?(:uploaders) ? superclass.uploaders.dup : {}
     end
 
     def uploader_options
-      @uploader_options ||= {}
-      @uploader_options = superclass.uploader_options.merge(@uploader_options) if superclass.respond_to?(:uploader_options)
-      @uploader_options
+      @uploader_options ||= superclass.respond_to?(:uploader_options) ? superclass.uploader_options.dup : {}
     end
 
     ##


### PR DESCRIPTION
Profiling an app revealed that these two methods were called alot, and
every time they merged in their superclass's options/uploaders. This
change ensures that we only dup once or return an empty hash and memoize, instead of
merging in an empty hash every time in order to dup.

This ends up saving a lot of computation cycles and memory, since we are
only creating a copy of the hash once, as opposed to every time these
methods are called.
