### PR TITLE
Added authenticated_url functionality for Openstack storage

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -137,13 +137,13 @@ module CarrierWave
         # [NilClass] no authenticated url available
         #
         def authenticated_url(options = {})
-          if ['AWS', 'Google', 'Rackspace'].include?(@uploader.fog_credentials[:provider])
+          if ['AWS', 'Google', 'Rackspace', 'Openstack'].include?(@uploader.fog_credentials[:provider])
             # avoid a get by using local references
             local_directory = connection.directories.new(:key => @uploader.fog_directory)
             local_file = local_directory.files.new(:key => path)
             if @uploader.fog_credentials[:provider] == "AWS"
               local_file.url(::Fog::Time.now + @uploader.fog_authenticated_url_expiration, options)
-            elsif @uploader.fog_credentials[:provider] == "Rackspace"
+            elsif ['Rackspace', 'Openstack'].include?(@uploader.fog_credentials[:provider])
               connection.get_object_https_url(@uploader.fog_directory, path, ::Fog::Time.now + @uploader.fog_authenticated_url_expiration)
             else
               local_file.url(::Fog::Time.now + @uploader.fog_authenticated_url_expiration)

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -233,7 +233,7 @@ end
             end
 
             it "should have an authenticated_url" do
-              if ['AWS', 'Rackspace', 'Google'].include?(@provider)
+              if ['AWS', 'Rackspace', 'Google', 'Openstack'].include?(@provider)
                 @fog_file.authenticated_url.should_not be_nil
               end
             end


### PR DESCRIPTION
This allows to use signed temporary download URL(s) for Openstack storage.
The same functionality already exists for Rackspace.
