### PR TITLE
Fix set_content_type(true) for fog files

### DIFF
--- a/lib/carrierwave/processing/mime_types.rb
+++ b/lib/carrierwave/processing/mime_types.rb
@@ -58,7 +58,8 @@ module CarrierWave
     #
     def set_content_type(override=false)
       if override || file.content_type.blank? || generic_content_type?
-        new_content_type = ::MIME::Types.type_for(file.original_filename).first.to_s
+        fname = file.respond_to?(:original_filename) ? file.original_filename : file.filename
+        new_content_type = ::MIME::Types.type_for(fname).first.to_s
         if file.respond_to?(:content_type=)
           file.content_type = new_content_type
         else


### PR DESCRIPTION
Remote (fog) files don't have an original_filename method defined.  This tweak makes things generally more flexible, and fixes https://github.com/gzigzigzeo/carrierwave-meta/issues/4 in particular.
