### PR TITLE
Change write_uploader to set column to nil on remove

### DIFF
--- a/lib/carrierwave/mount.rb
+++ b/lib/carrierwave/mount.rb
@@ -304,7 +304,7 @@ module CarrierWave
         return if record.frozen?
 
         if remove?
-          record.write_uploader(serialization_column, '')
+          record.write_uploader(serialization_column, nil)
         elsif uploader.identifier.present?
           record.write_uploader(serialization_column, uploader.identifier)
         end

--- a/spec/mount_spec.rb
+++ b/spec/mount_spec.rb
@@ -547,7 +547,7 @@ describe CarrierWave::Mount do
         @instance.image = stub_file('test.jpg')
         @instance.store_image!
         @instance.remove_image = true
-        @instance.should_receive(:write_uploader).with(:image, "")
+        @instance.should_receive(:write_uploader).with(:image, nil)
         @instance.write_image_identifier
       end
     end
@@ -774,7 +774,7 @@ describe CarrierWave::Mount do
         @instance.image = stub_file('test.jpg')
         @instance.store_image!
         @instance.remove_image = true
-        @instance.should_receive(:write_uploader).with(:monkey, "")
+        @instance.should_receive(:write_uploader).with(:monkey, nil)
         @instance.write_image_identifier
       end
     end

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -349,8 +349,8 @@ describe CarrierWave::ActiveRecord do
         @event.save!
         @event.reload
         expect(@event.image).to be_blank
-        expect(@event[:image]).to eq('')
-        expect(@event.image_identifier).to eq('')
+        expect(@event[:image]).to eq(nil)
+        expect(@event.image_identifier).to eq(nil)
       end
 
       it "should mark image as changed when saving a new image" do


### PR DESCRIPTION
Previously when removing images the mounted column was being set to `''`; this changes it to `nil`.
