### PR TITLE
Fixed i18n override problem with rails 4

### DIFF
--- a/lib/carrierwave.rb
+++ b/lib/carrierwave.rb
@@ -92,6 +92,13 @@ elsif defined?(Rails)
           require 'carrierwave/orm/activerecord'
         end
       end
+
+      ##
+      # Loads the Carrierwave locale files before the Rails application locales
+      # letting the Rails application overrite the carrierwave locale defaults
+      config.before_configuration do
+        I18n.load_path << File.join(File.dirname(__FILE__), "carrierwave", "locale", 'en.yml')
+      end
     end
   end
 

--- a/lib/carrierwave/validations/active_model.rb
+++ b/lib/carrierwave/validations/active_model.rb
@@ -78,5 +78,3 @@ module CarrierWave
     end
   end
 end
-
-I18n.load_path << File.join(File.dirname(__FILE__), "..", "locale", 'en.yml')


### PR DESCRIPTION
Solves #1229 and the following post: http://stackoverflow.com/questions/19068821/custom-error-message-for-carrierwave-0-9-0-doesnt-work-for-rails-4

:+1: 

Please test my patch and leave feedback if possible.
