### PR TITLE
Possible fix for bug when there is "content-disposition" but filename=""

### DIFF
--- a/lib/carrierwave/uploader/download.rb
+++ b/lib/carrierwave/uploader/download.rb
@@ -18,8 +18,8 @@ module CarrierWave
 
         def original_filename
           if file.meta.include? 'content-disposition'
-            match = file.meta['content-disposition'].match(/filename=(\"?)(.+)\1/)
-            return match[2] unless match.nil?
+            match = file.meta['content-disposition'].match(/filename="(.*?)"/)
+            return match[ 1 ] if !match.nil? && !match[ 1 ].empty?
           end
           File.basename(file.base_uri.path)
         end


### PR DESCRIPTION
When there is "content-disposition" and the filename="" the returned "original_filename" are two (2) empty double quotes ( "" ) causing obvious errors due to a wrong filename.
