### PR TITLE
fix regular expression

### DIFF
--- a/lib/carrierwave/uploader/download.rb
+++ b/lib/carrierwave/uploader/download.rb
@@ -18,7 +18,7 @@ module CarrierWave
 
         def original_filename
           if file.meta.include? 'content-disposition'
-            match = file.meta['content-disposition'].match(/filename=(\"?)(.+)\1/)
+            match = file.meta['content-disposition'].match(/filename=(\")(.+)\1/)
             return match[2] unless match.nil?
           end
           File.basename(file.base_uri.path)


### PR DESCRIPTION
The original regular expression will match the string like `inline;filename=""`, and `match[2]` returns `""`.

I found this issue when I did a remote image download from google+ avatar.
For example: https://lh3.googleusercontent.com/-Y86IN-vEObo/AAAAAAAAAAI/AAAAAAACk4w/yvxY4GMx_8k/photo.jpg

I expect `original_filename` should be `"photo.jpg"`, but it always returns `"__"` due to its `content-disposition` is `inline;filename=""`.

After read [RFC2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html).

> filename-parm = "filename" "=" quoted-string

It seems quoted string is required. I suggest replace `/filename=(\"?)(.+)\1/` by `/filename=(\")(.+)\1/` so that `match.nil?` will return true, and `original_filename` will fallback to `"photo.jpg"`.
