### PR TITLE
avoid TypeError when root is nil

### DIFF
--- a/lib/carrierwave/uploader/url.rb
+++ b/lib/carrierwave/uploader/url.rb
@@ -20,7 +20,7 @@ module CarrierWave
         if file.respond_to?(:url) and not file.url.blank?
           file.method(:url).arity == 0 ? file.url : file.url(options)
         elsif file.respond_to?(:path)
-          path = encode_path(file.path.gsub(File.expand_path(root), ''))
+          path = encode_path(file.path.gsub(File.expand_path(root.to_s), ''))
 
           if host = asset_host
             if host.respond_to? :call

--- a/spec/uploader/url_spec.rb
+++ b/spec/uploader/url_spec.rb
@@ -13,6 +13,7 @@ describe CarrierWave::Uploader do
   after do
     FileUtils.rm_rf(public_path)
     Object.send(:remove_const, "MyCoolUploader") if defined?(::MyCoolUploader)
+    CarrierWave.root = public_path
   end
 
   describe '#url' do
@@ -30,6 +31,13 @@ describe CarrierWave::Uploader do
 
     it "should not raise exception when hash specified as argument" do
       lambda { @uploader.url({}) }.should_not raise_error
+    end
+
+    it "should not raise exception when CarrierWave#root not available" do
+      CarrierWave.root = nil
+      @uploader.cache!(File.open(file_path('test.jpg')))
+      @uploader.file.stub!(:url).and_return('')
+      lambda { @uploader.url }.should_not raise_error
     end
 
     it "should not raise ArgumentError when storage's File#url method doesn't get params" do


### PR DESCRIPTION
When used with `carrierwave-datamapper` it throws exception `TypeError: no implicit conversion of nil into String`.
