### PR TITLE
Make generator namespace aware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ more/activerecord/spec/public
 more/datamapper/spec/public
 *.project
 spec/test.log
+spec/tmp
 *.swp
 .rvmrc
 .bundle

--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -39,4 +39,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rmagick"
   s.add_development_dependency "nokogiri", "~> 1.5.10" # 1.6 requires ruby > 1.8.7
   s.add_development_dependency "timecop", "0.6.1" # 0.6.2 requires ruby > 1.8.7
+  s.add_development_dependency "generator_spec"
 end

--- a/lib/generators/uploader_generator.rb
+++ b/lib/generators/uploader_generator.rb
@@ -2,6 +2,6 @@ class UploaderGenerator < Rails::Generators::NamedBase
   source_root File.expand_path("../templates", __FILE__)
 
   def create_uploader_file
-    template "uploader.rb", "app/uploaders/#{file_name}_uploader.rb"
+    template "uploader.rb", File.join('app/uploaders', class_path, "#{file_name}_uploader.rb")
   end
 end

--- a/spec/generators/uploader_generator_spec.rb
+++ b/spec/generators/uploader_generator_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'generators/uploader_generator'
+
+describe UploaderGenerator, :type => :generator do
+  destination File.expand_path("../../tmp", __FILE__)
+
+  before :each do
+    prepare_destination
+  end
+
+  it "should properly create uploader file" do
+    run_generator %w(Avatar)
+    assert_file 'app/uploaders/avatar_uploader.rb', /class AvatarUploader < CarrierWave::Uploader::Base/
+  end
+
+  it "should properly create namespaced uploader file" do
+    run_generator %w(MyModule::Avatar)
+    assert_file 'app/uploaders/my_module/avatar_uploader.rb', /class MyModule::AvatarUploader < CarrierWave::Uploader::Base/
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ require 'timecop'
 require 'open-uri'
 require 'sham_rack'
 require 'mini_magick'
+require 'generator_spec'
 
 require 'mysql2'
 


### PR DESCRIPTION
Currently the uploader generator is not namespace aware.

```
$ rails generate uploader MyModule::Avatar
create  app/uploaders/avatar_uploader.rb
```

In the above situation the uploader class is `MyModule::Avatar` and is defined properly in the generated file. But the path of the generated uploader class is wrong, it should have been `app/uploaders/my_module/avatar_uploader.rb`
