### PR TITLE
Ignore Rackspace 404 response when deleting a file

### DIFF
--- a/lib/carrierwave/uploader/remove.rb
+++ b/lib/carrierwave/uploader/remove.rb
@@ -12,11 +12,22 @@ module CarrierWave
       #
       def remove!
         with_callbacks(:remove) do
-          @file.delete if @file
+          delete_file
           @file = nil
           @cache_id = nil
         end
       end
+
+      private 
+
+      def delete_file
+        begin 
+          @file.delete if @file
+        rescue Fog::Storage::Rackspace::NotFound
+          # it does not exist
+        end
+      end
+
 
     end # Remove
   end # Uploader

--- a/spec/uploader/remove_spec.rb
+++ b/spec/uploader/remove_spec.rb
@@ -65,6 +65,16 @@ describe CarrierWave::Uploader do
     it "should do nothing when trying to remove an empty file" do
       running { @uploader.remove! }.should_not raise_error
     end
+
+    context "a file that does not exist in Rackspace" do
+      before do
+        @stored_file.stub!(:delete).and_raise(Fog::Storage::Rackspace::NotFound)
+      end
+
+      it "should do nothing" do
+        running { @uploader.remove! }.should_not raise_error  
+      end
+    end
   end
 
 end


### PR DESCRIPTION
This change tries to make AWS and Rackspace more similar. AWS currently ignores delete requests to files that do not exist whereas Rackspace is returning a 404. For translate that 404 into an exception. 
