### PR TITLE
Temp directory overflow issue

### DIFF
--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -268,7 +268,9 @@ module CarrierWave
         image.destroy!
       end
     rescue ::MiniMagick::Error, ::MiniMagick::Invalid => e
-      raise CarrierWave::ProcessingError, I18n.translate(:"errors.messages.mini_magick_processing_error", :e => e, :default => I18n.translate(:"errors.messages.mini_magick_processing_error", :e => e, :locale => :en))
+      default = I18n.translate(:"errors.messages.mini_magick_processing_error", :e => e, :locale => :en)
+      message = I18n.translate(:"errors.messages.mini_magick_processing_error", :e => e, :default => default)
+      raise CarrierWave::ProcessingError, message
     end
 
   end # MiniMagick


### PR DESCRIPTION
### Synopsis

Every `MiniMagick::Image.open(path)` call creates a temp file, which is not deleted after manipulating.
This leads to overflow of tmp directory under high load.
### Pull Request
1. Validate out image with `identify` command instead of opening an image.
2. Delete temp file after manipulating.
