### PR TITLE
Make the #remove_ accessor set the mounted column as changed

### DIFF
--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -45,6 +45,11 @@ module CarrierWave
           super
         end
 
+        def remove_#{column}=(value)
+          send(:"#{column}_will_change!")
+          super
+        end
+
         def remove_#{column}!
           super
           _mounter(:#{column}).remove = true

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -384,6 +384,15 @@ describe CarrierWave::ActiveRecord do
       end
     end
 
+    describe "remove_image=" do
+      it "should mark the image as changed if changed" do
+        expect(@event.image_changed?).to be_false
+        @event.remove_image.should be_nil
+        @event.remove_image = "1"
+        expect(@event.image_changed?).to be_true
+      end
+    end
+
     describe "#remote_image_url=" do
 
       # FIXME ideally image_changed? and remote_image_url_changed? would return true


### PR DESCRIPTION
This is so that the record is still saved (and the callbacks that do the actual removal are still run) even if no other columns on the model are changed.

This can happen if using `accepts_nested_attributes_for` with a child model that has a carrierwave mounted column, for instance.
