### PR TITLE
Fixed #public_url to generate proper HTTPS URL.

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -296,7 +296,9 @@ module CarrierWave
                 protocol = @uploader.fog_use_ssl_for_aws ? "https" : "http"
                 # if directory is a valid subdomain, use that style for access
                 if @uploader.fog_directory.to_s =~ /^(?:[a-z]|\d(?!\d{0,2}(?:\d{1,3}){3}$))(?:[a-z0-9\.]|(?![\-])|\-(?![\.])){1,61}[a-z0-9]$/
-                  "#{protocol}://#{@uploader.fog_directory}.s3.amazonaws.com/#{encoded_path}"
+                  protocol == "https" ?
+                    "https://#{connection.region}.amazonaws.com/#{@uploader.fog_directory}/#{encoded_path}" :
+                    "http://#{@uploader.fog_directory}.s3.amazonaws.com/#{encoded_path}"
                 else
                   # directory is not a valid subdomain, so use path style for access
                   "#{protocol}://s3.amazonaws.com/#{@uploader.fog_directory}/#{encoded_path}"


### PR DESCRIPTION
I'm don't know all the ins and outs of CarrierWave and Fog but I know that:
- CarrierWave generates public URLs itself
- Fog also does that in a more thorough way

The problem is CarrierWave public URL generation doesn't consider a HTTPS scenario.
One should not use it with subdomains or custom domains.
Browsers raise security warnings if we do.

That said, I'm suggesting in this PR to use the "directory" URL syntax when HTTPS and custom domains are required.
Anyway, I think this doesn't look DRY and we should leave URL generation to Fog.

What do you guys think?
Maybe I'm missing something here...
