### PR TITLE
Adding Jruby to experimental test environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ rvm:
  - 2.0.0
  - 2.1.1
  - ruby-head
+ - jruby-19mode
+ - jruby-head
 
 gemfile:
   - Gemfile
@@ -20,6 +22,8 @@ gemfile:
 matrix:
   allow_failures:
     - rvm: ruby-head
+    - rvm: jruby-19mode
+    - rvm: jruby-head
   include:
     - rvm: 1.8.7
       gemfile: gemfiles/rails-3-2-stable.gemfile


### PR DESCRIPTION
_NOTE_ - This patch does _not_ imply official Jruby support in any way and is for informational purposes only.

I realize that Jruby is not officially supported (so the jruby test environments are separated into the 'allow_failures' area) but adding Jruby tests will give curious jruby users a good idea of how viable it would be to user Carrierwave with jruby. If there are not many errors, perhaps jruby users could step up and propose changes that might allow Carrierwave to support jruby. 
