### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It works well with Rack based web applications, such as Ruby on Rails.
 
 [![Build Status](https://travis-ci.org/carrierwaveuploader/carrierwave.png?branch=master)](http://travis-ci.org/carrierwaveuploader/carrierwave)
 [![Code Climate](https://codeclimate.com/github/carrierwaveuploader/carrierwave.png)](https://codeclimate.com/github/carrierwaveuploader/carrierwave)
-[![Inline docs](http://inch-pages.github.io/github/carrierwaveuploader/carrierwave.png)](http://inch-pages.github.io/github/carrierwaveuploader/carrierwave)
+[![Inline docs](http://inch-ci.org/github/carrierwaveuploader/carrierwave.png)](http://inch-ci.org/github/carrierwaveuploader/carrierwave)
 
 ## Information
 


### PR DESCRIPTION
Hi there,

this patch adds a docs badge to the README to show off inline-documentation to potential contributors: [![Inline docs](http://inch-pages.github.io/github/carrierwaveuploader/carrierwave.png)](http://inch-pages.github.io/github/carrierwaveuploader/carrierwave)

The badge links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of inline-docs to encourage aspiring Rubyists to document their code. Your status page is http://inch-pages.github.io/github/carrierwaveuploader/carrierwave/

Inch Pages is still a young project, but already used by projects like [Guard](https://github.com/guard/guard), [Haml](https://github.com/haml/haml), [Pry](https://github.com/pry/pry), and [ROM](https://github.com/rom-rb/rom).

What do you think?
