### PR TITLE
Skip loading RMagick if already loaded

### DIFF
--- a/lib/carrierwave/processing/rmagick.rb
+++ b/lib/carrierwave/processing/rmagick.rb
@@ -62,7 +62,7 @@ module CarrierWave
 
     included do
       begin
-        require "RMagick"
+        require "RMagick" unless defined?(::Magick)
       rescue LoadError => e
         e.message << " (You may need to install the rmagick gem)"
         raise e


### PR DESCRIPTION
In a case-insensitive filesystem environment, there is a possibility that RMagick gets loaded twice(`require 'rmagick'` and `require 'RMagick'` loads the same file, but Ruby sees them as different ones).
This PR solves it by loading RMagick only if needed. 

Refs #1205, #1330
