### PR TITLE
Pass #url `args` to #default_url

### DIFF
--- a/lib/carrierwave/uploader/default_url.rb
+++ b/lib/carrierwave/uploader/default_url.rb
@@ -5,14 +5,14 @@ module CarrierWave
     module DefaultUrl
 
       def url(*args)
-        super || default_url
+        super || default_url(*args)
       end
 
       ##
       # Override this method in your uploader to provide a default url
       # in case no file has been cached/stored yet.
       #
-      def default_url; end
+      def default_url(*args); end
 
     end # DefaultPath
   end # Uploader


### PR DESCRIPTION
This will give us a few extra pieces to work with to name
a certain thumbnail for something. For instance:

``` ruby
def default_url(*args)
  vname = version_name || (args.first if versions.key?(args.first))
  [model.mounted_as.to_s, vname.to_s, "default.png"].join("_")
end
```

This will allow us to call `model.attachment.url(:not_a_version)` and still
return `"attachment_not_a_version_default.png"`, which is useful in cases of
conditional versioning.
