### PR TITLE
Do not retrieve disabled versions

### DIFF
--- a/lib/carrierwave/uploader/versions.rb
+++ b/lib/carrierwave/uploader/versions.rb
@@ -278,11 +278,11 @@ module CarrierWave
       end
 
       def retrieve_versions_from_cache!(cache_name)
-        versions.each { |name, v| v.retrieve_from_cache!(cache_name) }
+        active_versions.each { |name, v| v.retrieve_from_cache!(cache_name) }
       end
 
       def retrieve_versions_from_store!(identifier)
-        versions.each { |name, v| v.retrieve_from_store!(identifier) }
+        active_versions.each { |name, v| v.retrieve_from_store!(identifier) }
       end
 
     end # Versions

--- a/spec/uploader/versions_spec.rb
+++ b/spec/uploader/versions_spec.rb
@@ -475,6 +475,7 @@ describe CarrierWave::Uploader do
       before do
         @uploader_class.storage = mock_storage('base')
         @uploader_class.version(:thumb).storage = mock_storage('thumb')
+        @uploader_class.version(:preview).storage = mock_storage('preview')
 
         @file = File.open(file_path('test.jpg'))
 
@@ -486,14 +487,22 @@ describe CarrierWave::Uploader do
         @thumb_stored_file.stub!(:path).and_return('/path/to/somewhere/thumb')
         @thumb_stored_file.stub!(:url).and_return('http://www.example.com/thumb')
 
+        @preview_stored_file = mock('a preview version of a stored file')
+        @preview_stored_file.stub!(:path).and_return('/path/to/somewhere/preview')
+        @preview_stored_file.stub!(:url).and_return('http://www.example.com/preview')
+
         @storage = mock('a storage engine')
         @storage.stub!(:retrieve!).and_return(@base_stored_file)
 
         @thumb_storage = mock('a storage engine for thumbnails')
         @thumb_storage.stub!(:retrieve!).and_return(@thumb_stored_file)
 
+        @preview_storage = mock('a storage engine for previewnails')
+        @preview_storage.stub!(:retrieve!).and_return(@preview_stored_file)
+
         @uploader_class.storage.stub!(:new).with(@uploader).and_return(@storage)
         @uploader_class.version(:thumb).storage.stub!(:new).with(@uploader.thumb).and_return(@thumb_storage)
+        @uploader_class.version(:preview).storage.stub!(:new).with(@uploader.preview).and_return(@preview_storage)
       end
 
       it "should set the current path" do
@@ -519,6 +528,22 @@ describe CarrierWave::Uploader do
       it "should not set the filename" do
         @uploader.retrieve_from_store!('monkey.txt')
         @uploader.filename.should be_nil
+      end
+
+      it "should process conditional versions if the condition method returns true" do
+        @uploader_class.version(:preview).version_options[:if] = :true?
+        @uploader.should_receive(:true?).at_least(:once).and_return(true)
+        @uploader.retrieve_from_store!('monkey.txt')
+        @uploader.thumb.should be_present
+        @uploader.preview.should be_present
+      end
+
+      it "should not process conditional versions if the condition method returns false" do
+        @uploader_class.version(:preview).version_options[:if] = :false?
+        @uploader.should_receive(:false?).at_least(:once).and_return(false)
+        @uploader.retrieve_from_store!('monkey.txt')
+        @uploader.thumb.should be_present
+        @uploader.preview.should be_blank
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/carrierwaveuploader/carrierwave/issues/1350 (copy from it's content below)

The code speaks for itself

``` ruby
require 'carrierwave'

class BugUploader < CarrierWave::Uploader::Base
  version :thumb, if: :always_false do
    def default_url
      'default.png'
    end
  end

  def root
    '~'
  end

  def always_false(*args)
    false
  end
end

up1 = BugUploader.new
up1.store!(File.open(__FILE__))
puts up1.thumb.url
# default.png

up2 = BugUploader.new
up2.retrieve_from_store!('lalala.png')
puts up2.thumb.url
# /uploads/thumb_lalala.png

```
