### PR TITLE
Fix default gravity in MiniMagick resize_and_pad helper

### DIFF
--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -81,7 +81,7 @@ module CarrierWave
         process :resize_to_fill => [width, height, gravity]
       end
 
-      def resize_and_pad(width, height, background=:transparent, gravity=::Magick::CenterGravity)
+      def resize_and_pad(width, height, background=:transparent, gravity='Center')
         process :resize_and_pad => [width, height, background, gravity]
       end
     end


### PR DESCRIPTION
The default gravity option in the MiniMagick `resize_and_pad` helper is relying on an RMagick constant.  This was causing an error in my uploader (`NameError: uninitialized constant Magick`) when I wasn't passing in a value for the gravity.  Sample class that was giving me the issue:

``` ruby
class ImageUploader < CarrierWave::Uploader::Base
  include CarrierWave::MiniMagick

  version :thumbnail do
    resize_and_pad(160, 160)
  end
end
```

This probably won't affect many people since the docs specify using `process` directly.
