### PR TITLE
Do not display rmagick exception in I18n message

### DIFF
--- a/lib/carrierwave/locale/en.yml
+++ b/lib/carrierwave/locale/en.yml
@@ -6,6 +6,6 @@ en:
       carrierwave_download_error: could not be downloaded
       extension_white_list_error: "You are not allowed to upload %{extension} files, allowed types: %{allowed_types}"
       extension_black_list_error: "You are not allowed to upload %{extension} files, prohibited types: %{prohibited_types}"
-      rmagick_processing_error: "Failed to manipulate with rmagick, maybe it is not an image? Original Error: %{e}"
+      rmagick_processing_error: "Failed to manipulate with rmagick, maybe it is not an image?"
       mime_types_processing_error: "Failed to process file with MIME::Types, maybe not valid content-type? Original Error: %{e}"
       mini_magick_processing_error: "Failed to manipulate with MiniMagick, maybe it is not an image? Original Error: %{e}"


### PR DESCRIPTION
For instance, if you upload a text file with a JPG extension, rmagick generate an exception, whose message contains the full path of your project directory. It seems to me that it's a security issue, since the generated message displayed to the frontoffice user contains the server project directory.
I didn't test other cases (for the orher messages), but potentially this problem can appear somewhere else
