### PR TITLE
Only require generator_spec when needed

### DIFF
--- a/spec/generators/uploader_generator_spec.rb
+++ b/spec/generators/uploader_generator_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'generator_spec'
 require 'generators/uploader_generator'
 
 describe UploaderGenerator, :type => :generator do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,6 @@ require 'timecop'
 require 'open-uri'
 require 'sham_rack'
 require 'mini_magick'
-require 'generator_spec'
 
 require 'mysql2'
 


### PR DESCRIPTION
`generator_spec` has a dependency on Railties, which defines the Rails module, apparently without defining the `.env` method that is needed when testing on Rails 4.1.

See https://github.com/rails/rails/blob/v4.1.0/activerecord/lib/active_record/connection_handling.rb#L3

This will hopefully fix the failing specs in #1364.
