### PR TITLE
Fixes deprecated File.exists?

### DIFF
--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -142,7 +142,7 @@ module CarrierWave
     # [Boolean] Whether the file exists
     #
     def exists?
-      return File.exists?(self.path) if self.path
+      return File.exist?(self.path) if self.path
       return false
     end
 
@@ -296,7 +296,7 @@ module CarrierWave
     def mkdir!(path, directory_permissions)
       options = {}
       options[:mode] = directory_permissions if directory_permissions
-      FileUtils.mkdir_p(File.dirname(path), options) unless File.exists?(File.dirname(path))
+      FileUtils.mkdir_p(File.dirname(path), options) unless File.exist?(File.dirname(path))
     end
 
     def chmod!(path, permissions)

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -623,7 +623,7 @@ describe CarrierWave::ActiveRecord do
       @event = @class.new
       @event.image = stub_file('old.jpeg')
       expect(@event.save).to be_true
-      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_true
+      expect(File.exist?(public_path('uploads/old.jpeg'))).to be_true
     end
 
     after do
@@ -634,29 +634,29 @@ describe CarrierWave::ActiveRecord do
       it "should remove old file if old file had a different path" do
         @event.image = stub_file('new.jpeg')
         expect(@event.save).to be_true
-        expect(File.exists?(public_path('uploads/new.jpeg'))).to be_true
-        expect(File.exists?(public_path('uploads/old.jpeg'))).to be_false
+        expect(File.exist?(public_path('uploads/new.jpeg'))).to be_true
+        expect(File.exist?(public_path('uploads/old.jpeg'))).to be_false
       end
 
       it "should not remove old file if old file had a different path but config is false" do
         @uploader.stub!(:remove_previously_stored_files_after_update).and_return(false)
         @event.image = stub_file('new.jpeg')
         expect(@event.save).to be_true
-        expect(File.exists?(public_path('uploads/new.jpeg'))).to be_true
-        expect(File.exists?(public_path('uploads/old.jpeg'))).to be_true
+        expect(File.exist?(public_path('uploads/new.jpeg'))).to be_true
+        expect(File.exist?(public_path('uploads/old.jpeg'))).to be_true
       end
 
       it "should not remove file if old file had the same path" do
         @event.image = stub_file('old.jpeg')
         expect(@event.save).to be_true
-        expect(File.exists?(public_path('uploads/old.jpeg'))).to be_true
+        expect(File.exist?(public_path('uploads/old.jpeg'))).to be_true
       end
 
       it "should not remove file if validations fail on save" do
         @class.validate { |r| r.errors.add :textfile, "FAIL!" }
         @event.image = stub_file('new.jpeg')
         expect(@event.save).to be_false
-        expect(File.exists?(public_path('uploads/old.jpeg'))).to be_true
+        expect(File.exist?(public_path('uploads/old.jpeg'))).to be_true
       end
     end
 
@@ -671,22 +671,22 @@ describe CarrierWave::ActiveRecord do
         @event.image = stub_file('old.jpeg')
         @event.foo = 'test'
         expect(@event.save).to be_true
-        expect(File.exists?(public_path('uploads/test.jpeg'))).to be_true
+        expect(File.exist?(public_path('uploads/test.jpeg'))).to be_true
         expect(@event.image.read).to eq('this is stuff')
       end
 
       it "should not remove file if old file had the same dynamic path" do
         @event.image = stub_file('test.jpeg')
         expect(@event.save).to be_true
-        expect(File.exists?(public_path('uploads/test.jpeg'))).to be_true
+        expect(File.exist?(public_path('uploads/test.jpeg'))).to be_true
       end
 
       it "should remove old file if old file had a different dynamic path" do
         @event.foo = "new"
         @event.image = stub_file('test.jpeg')
         expect(@event.save).to be_true
-        expect(File.exists?(public_path('uploads/new.jpeg'))).to be_true
-        expect(File.exists?(public_path('uploads/test.jpeg'))).to be_false
+        expect(File.exist?(public_path('uploads/new.jpeg'))).to be_true
+        expect(File.exist?(public_path('uploads/test.jpeg'))).to be_false
       end
     end
   end
@@ -705,8 +705,8 @@ describe CarrierWave::ActiveRecord do
       @event = @class.new
       @event.image = stub_file('old.jpeg')
       expect(@event.save).to be_true
-      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_true
-      expect(File.exists?(public_path('uploads/thumb_old.jpeg'))).to be_true
+      expect(File.exist?(public_path('uploads/old.jpeg'))).to be_true
+      expect(File.exist?(public_path('uploads/thumb_old.jpeg'))).to be_true
     end
 
     after do
@@ -716,17 +716,17 @@ describe CarrierWave::ActiveRecord do
     it "should remove old file if old file had a different path" do
       @event.image = stub_file('new.jpeg')
       expect(@event.save).to be_true
-      expect(File.exists?(public_path('uploads/new.jpeg'))).to be_true
-      expect(File.exists?(public_path('uploads/thumb_new.jpeg'))).to be_true
-      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_false
-      expect(File.exists?(public_path('uploads/thumb_old.jpeg'))).to be_false
+      expect(File.exist?(public_path('uploads/new.jpeg'))).to be_true
+      expect(File.exist?(public_path('uploads/thumb_new.jpeg'))).to be_true
+      expect(File.exist?(public_path('uploads/old.jpeg'))).to be_false
+      expect(File.exist?(public_path('uploads/thumb_old.jpeg'))).to be_false
     end
 
     it "should not remove file if old file had the same path" do
       @event.image = stub_file('old.jpeg')
       expect(@event.save).to be_true
-      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_true
-      expect(File.exists?(public_path('uploads/thumb_old.jpeg'))).to be_true
+      expect(File.exist?(public_path('uploads/old.jpeg'))).to be_true
+      expect(File.exist?(public_path('uploads/thumb_old.jpeg'))).to be_true
     end
   end
 
@@ -746,8 +746,8 @@ describe CarrierWave::ActiveRecord do
       @event.image = stub_file('old.jpeg')
       @event.textfile = stub_file('old.txt')
       expect(@event.save).to be_true
-      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_true
-      expect(File.exists?(public_path('uploads/old.txt'))).to be_true
+      expect(File.exist?(public_path('uploads/old.jpeg'))).to be_true
+      expect(File.exist?(public_path('uploads/old.txt'))).to be_true
     end
 
     after do
@@ -758,27 +758,27 @@ describe CarrierWave::ActiveRecord do
       @event.image = stub_file('new.jpeg')
       @event.textfile = stub_file('new.txt')
       expect(@event.save).to be_true
-      expect(File.exists?(public_path('uploads/new.jpeg'))).to be_true
-      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_false
-      expect(File.exists?(public_path('uploads/new.txt'))).to be_true
-      expect(File.exists?(public_path('uploads/old.txt'))).to be_false
+      expect(File.exist?(public_path('uploads/new.jpeg'))).to be_true
+      expect(File.exist?(public_path('uploads/old.jpeg'))).to be_false
+      expect(File.exist?(public_path('uploads/new.txt'))).to be_true
+      expect(File.exist?(public_path('uploads/old.txt'))).to be_false
     end
 
     it "should remove old file1 but not file2 if old file1 had a different path but old file2 has the same path" do
       @event.image = stub_file('new.jpeg')
       @event.textfile = stub_file('old.txt')
       expect(@event.save).to be_true
-      expect(File.exists?(public_path('uploads/new.jpeg'))).to be_true
-      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_false
-      expect(File.exists?(public_path('uploads/old.txt'))).to be_true
+      expect(File.exist?(public_path('uploads/new.jpeg'))).to be_true
+      expect(File.exist?(public_path('uploads/old.jpeg'))).to be_false
+      expect(File.exist?(public_path('uploads/old.txt'))).to be_true
     end
 
     it "should not remove file1 or file2 if file1 and file2 have the same paths" do
       @event.image = stub_file('old.jpeg')
       @event.textfile = stub_file('old.txt')
       expect(@event.save).to be_true
-      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_true
-      expect(File.exists?(public_path('uploads/old.txt'))).to be_true
+      expect(File.exist?(public_path('uploads/old.jpeg'))).to be_true
+      expect(File.exist?(public_path('uploads/old.txt'))).to be_true
     end
   end
 
@@ -795,7 +795,7 @@ describe CarrierWave::ActiveRecord do
       @event = @class.new
       @event.avatar = stub_file('old.jpeg')
       expect(@event.save).to be_true
-      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_true
+      expect(File.exist?(public_path('uploads/old.jpeg'))).to be_true
     end
 
     after do
@@ -805,14 +805,14 @@ describe CarrierWave::ActiveRecord do
     it "should remove old file if old file had a different path" do
       @event.avatar = stub_file('new.jpeg')
       expect(@event.save).to be_true
-      expect(File.exists?(public_path('uploads/new.jpeg'))).to be_true
-      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_false
+      expect(File.exist?(public_path('uploads/new.jpeg'))).to be_true
+      expect(File.exist?(public_path('uploads/old.jpeg'))).to be_false
     end
 
     it "should not remove file if old file had the same path" do
       @event.avatar = stub_file('old.jpeg')
       expect(@event.save).to be_true
-      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_true
+      expect(File.exist?(public_path('uploads/old.jpeg'))).to be_true
     end
   end
 end

--- a/spec/sanitized_file_spec.rb
+++ b/spec/sanitized_file_spec.rb
@@ -10,7 +10,7 @@ describe CarrierWave::SanitizedFile do
   end
 
   after(:all) do
-    if File.exists?(file_path('llama.jpg'))
+    if File.exist?(file_path('llama.jpg'))
       FileUtils.rm(file_path('llama.jpg'))
     end
     FileUtils.rm_rf(public_path)
@@ -260,7 +260,7 @@ describe CarrierWave::SanitizedFile do
       it "should be moved to the correct location" do
         @sanitized_file.move_to(file_path('gurr.png'))
 
-        File.exists?( file_path('gurr.png') ).should be_true
+        File.exist?( file_path('gurr.png') ).should be_true
       end
 
       it "should have changed its path when moved" do
@@ -309,7 +309,7 @@ describe CarrierWave::SanitizedFile do
       it "should be copied to the correct location" do
         @sanitized_file.copy_to(file_path('gurr.png'))
 
-        File.exists?( file_path('gurr.png') ).should be_true
+        File.exist?( file_path('gurr.png') ).should be_true
 
         file_path('gurr.png').should be_identical_to(file_path('llama.jpg'))
       end
@@ -403,9 +403,9 @@ describe CarrierWave::SanitizedFile do
 
     describe '#delete' do
       it "should remove it from the filesystem" do
-        File.exists?(@sanitized_file.path).should be_true
+        File.exist?(@sanitized_file.path).should be_true
         @sanitized_file.delete
-        File.exists?(@sanitized_file.path).should be_false
+        File.exist?(@sanitized_file.path).should be_false
       end
     end
 

--- a/spec/uploader/store_spec.rb
+++ b/spec/uploader/store_spec.rb
@@ -333,13 +333,13 @@ describe CarrierWave::Uploader do
         @stored_path = ::File.expand_path(@uploader.store_path, @uploader.root)
 
         @cached_path.should == public_path('uploads/tmp/1369894322-345-2255/test.jpg')
-        File.exists?(@cached_path).should be_true
-        File.exists?(@stored_path).should be_false
+        File.exist?(@cached_path).should be_true
+        File.exist?(@stored_path).should be_false
 
         @uploader.store!
 
-        File.exists?(@cached_path).should be_false
-        File.exists?(@stored_path).should be_true
+        File.exist?(@cached_path).should be_false
+        File.exist?(@stored_path).should be_true
       end
 
       it "should use move_to() during store!()" do

--- a/spec/uploader/versions_spec.rb
+++ b/spec/uploader/versions_spec.rb
@@ -375,13 +375,13 @@ describe CarrierWave::Uploader do
       it "should recreate all versions if any are missing" do
         @uploader.store!(@file)
 
-        File.exists?(@uploader.thumb.path).should == true
+        File.exist?(@uploader.thumb.path).should == true
         FileUtils.rm(@uploader.thumb.path)
-        File.exists?(@uploader.thumb.path).should == false
+        File.exist?(@uploader.thumb.path).should == false
 
         @uploader.recreate_versions!
 
-        File.exists?(@uploader.thumb.path).should == true
+        File.exist?(@uploader.thumb.path).should == true
       end
 
       it "should recreate only specified versions if passed as args" do
@@ -389,21 +389,21 @@ describe CarrierWave::Uploader do
         @uploader_class.version(:maxi)
         @uploader.store!(@file)
 
-        File.exists?(@uploader.thumb.path).should == true
-        File.exists?(@uploader.mini.path).should == true
-        File.exists?(@uploader.maxi.path).should == true
+        File.exist?(@uploader.thumb.path).should == true
+        File.exist?(@uploader.mini.path).should == true
+        File.exist?(@uploader.maxi.path).should == true
         FileUtils.rm(@uploader.thumb.path)
-        File.exists?(@uploader.thumb.path).should == false
+        File.exist?(@uploader.thumb.path).should == false
         FileUtils.rm(@uploader.mini.path)
-        File.exists?(@uploader.mini.path).should == false
+        File.exist?(@uploader.mini.path).should == false
         FileUtils.rm(@uploader.maxi.path)
-        File.exists?(@uploader.maxi.path).should == false
+        File.exist?(@uploader.maxi.path).should == false
 
         @uploader.recreate_versions!(:thumb, :maxi)
 
-        File.exists?(@uploader.thumb.path).should == true
-        File.exists?(@uploader.maxi.path).should == true
-        File.exists?(@uploader.mini.path).should == false
+        File.exist?(@uploader.thumb.path).should == true
+        File.exist?(@uploader.maxi.path).should == true
+        File.exist?(@uploader.mini.path).should == false
       end
 
       it "should not create version if proc returns false" do


### PR DESCRIPTION
Related info: http://www.ruby-doc.org/core-2.1.1/File.html#method-c-exist-3F (In "click to toggle source")

---

Note: All recent pull requests fails probably due to:

```
/home/travis/.rvm/gems/ruby-1.9.3-p484/gems/activerecord-4.1.0/lib/active_record/connection_handling.rb:3:in `block in <module:ConnectionHandling>': undefined method `env' for Rails:Module (NoMethodError)
```

Since: rails/rails@88cd65b174d9a75d9cb0e5e06a57615ccc80fff1

:hatching_chick:
