### PR TITLE
Reset mounter cache on record reload

### DIFF
--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -69,6 +69,12 @@ module CarrierWave
           end
           super(options).merge(hash)
         end
+
+        # Reset cached mounter on record reload
+        def reload
+          @_mounters = nil
+          super
+        end
       RUBY
 
     end

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -158,6 +158,16 @@ describe CarrierWave::ActiveRecord do
 
         expect(Hash.from_xml(@event.to_xml(:only => [:foo], :except => [:id]))["event#{$arclass}"]["image"]).to be_nil
       end
+
+      it "resets cached value on record reload" do
+        @event.image = CarrierWave::SanitizedFile.new(stub_file('new.jpeg', 'image/jpeg'))
+        @event.save!
+
+        expect(@event.reload.image).to be_present
+        @class.find(@event.id).update_column(:image, nil)
+
+        expect(@event.reload.image).to be_blank
+      end
     end
 
     describe '#image=' do


### PR DESCRIPTION
```
user = User.create(avatar: some_file)
user.avatar.present? # => true

double_user = User.find(user.id)
dobule_user.remove_avatar = true
double_user.save

user.reload
user.avatar.present? # => true, but should be false
```
