### PR TITLE
Bump RSpec to ~> 2.14.0 and convert to new syntax/fix most deprecation warnings

### DIFF
--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -28,18 +28,18 @@ Gem::Specification.new do |s|
   s.add_dependency "activemodel", ">= 3.2.0"
   s.add_dependency "json", ">= 1.7"
   s.add_dependency "mime-types", ">= 1.16"
-  if RUBY_ENGINE == 'jruby'
+  if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
     s.add_development_dependency 'activerecord-jdbcmysql-adapter'
   else
     s.add_development_dependency "mysql2"
   end
   s.add_development_dependency "rails", ">= 3.2.0"
   s.add_development_dependency "cucumber", "~> 1.3.2"
-  s.add_development_dependency "rspec", "~> 2.13.0"
+  s.add_development_dependency "rspec", "~> 2.14.0"
   s.add_development_dependency "sham_rack"
   s.add_development_dependency "fog", ">= 1.3.1"
   s.add_development_dependency "mini_magick", ">= 3.6.0"
-  if RUBY_ENGINE != 'jruby'
+  if defined?(RUBY_ENGINE) && RUBY_ENGINE != 'jruby'
     s.add_development_dependency "rmagick"
   end
   s.add_development_dependency "nokogiri", "~> 1.5.10" # 1.6 requires ruby > 1.8.7

--- a/spec/compatibility/paperclip_spec.rb
+++ b/spec/compatibility/paperclip_spec.rb
@@ -9,8 +9,8 @@ module Rails; end unless defined?(Rails)
 describe CarrierWave::Compatibility::Paperclip do
 
   before do
-    Rails.stub(:root).and_return('/rails/root')
-    Rails.stub(:env).and_return('test')
+    allow(Rails).to receive(:root).and_return('/rails/root')
+    allow(Rails).to receive(:env).and_return('test')
     @uploader_class = Class.new(CarrierWave::Uploader::Base) do
       include CarrierWave::Compatibility::Paperclip
 
@@ -19,10 +19,10 @@ describe CarrierWave::Compatibility::Paperclip do
 
     end
 
-    @model = mock('a model')
-    @model.stub!(:id).and_return(23)
-    @model.stub!(:ook).and_return('eek')
-    @model.stub!(:money).and_return('monkey.png')
+    @model = double('a model')
+    allow(@model).to receive(:id).and_return(23)
+    allow(@model).to receive(:ook).and_return('eek')
+    allow(@model).to receive(:money).and_return('monkey.png')
 
     @uploader = @uploader_class.new(@model, :monkey)
   end
@@ -33,37 +33,37 @@ describe CarrierWave::Compatibility::Paperclip do
 
   describe '#store_path' do
     it "should mimics paperclip default" do
-      @uploader.store_path("monkey.png").should == "/rails/root/public/system/monkeys/23/original/monkey.png"
+      expect(@uploader.store_path("monkey.png")).to eq("/rails/root/public/system/monkeys/23/original/monkey.png")
     end
 
     it "should interpolate the root path" do
-      @uploader.stub!(:paperclip_path).and_return(":rails_root/foo/bar")
-      @uploader.store_path("monkey.png").should == Rails.root + "/foo/bar"
+      allow(@uploader).to receive(:paperclip_path).and_return(":rails_root/foo/bar")
+      expect(@uploader.store_path("monkey.png")).to eq(Rails.root + "/foo/bar")
     end
 
     it "should interpolate the attachment" do
-      @uploader.stub!(:paperclip_path).and_return("/foo/:attachment/bar")
-      @uploader.store_path("monkey.png").should == "/foo/monkeys/bar"
+      allow(@uploader).to receive(:paperclip_path).and_return("/foo/:attachment/bar")
+      expect(@uploader.store_path("monkey.png")).to eq("/foo/monkeys/bar")
     end
 
     it "should interpolate the id" do
-      @uploader.stub!(:paperclip_path).and_return("/foo/:id/bar")
-      @uploader.store_path("monkey.png").should == "/foo/23/bar"
+      allow(@uploader).to receive(:paperclip_path).and_return("/foo/:id/bar")
+      expect(@uploader.store_path("monkey.png")).to eq("/foo/23/bar")
     end
 
     it "should interpolate the id partition" do
-      @uploader.stub!(:paperclip_path).and_return("/foo/:id_partition/bar")
-      @uploader.store_path("monkey.png").should == "/foo/000/000/023/bar"
+      allow(@uploader).to receive(:paperclip_path).and_return("/foo/:id_partition/bar")
+      expect(@uploader.store_path("monkey.png")).to eq("/foo/000/000/023/bar")
     end
 
     it "should interpolate the basename" do
-      @uploader.stub!(:paperclip_path).and_return("/foo/:basename/bar")
-      @uploader.store_path("monkey.png").should == "/foo/monkey/bar"
+      allow(@uploader).to receive(:paperclip_path).and_return("/foo/:basename/bar")
+      expect(@uploader.store_path("monkey.png")).to eq("/foo/monkey/bar")
     end
 
     it "should interpolate the extension" do
-      @uploader.stub!(:paperclip_path).and_return("/foo/:extension/bar")
-      @uploader.store_path("monkey.png").should == "/foo/png/bar"
+      allow(@uploader).to receive(:paperclip_path).and_return("/foo/:extension/bar")
+      expect(@uploader.store_path("monkey.png")).to eq("/foo/png/bar")
     end
 
   end
@@ -81,13 +81,13 @@ describe CarrierWave::Compatibility::Paperclip do
     end
 
     it 'should allow you to add custom interpolations' do
-      @uploader.stub!(:paperclip_path).and_return("/foo/:id/:ook")
-      @uploader.store_path("monkey.png").should == '/foo/23/eek'
+      allow(@uploader).to receive(:paperclip_path).and_return("/foo/:id/:ook")
+      expect(@uploader.store_path("monkey.png")).to eq('/foo/23/eek')
     end
 
     it 'mimics paperclips arguments' do
-      @uploader.stub!(:paperclip_path).and_return("/foo/:aak")
-      @uploader.store_path("monkey.png").should == '/foo/original'
+      allow(@uploader).to receive(:paperclip_path).and_return("/foo/:aak")
+      expect(@uploader.store_path("monkey.png")).to eq('/foo/original')
     end
 
     context 'when multiple uploaders include the compatibility module' do
@@ -103,8 +103,8 @@ describe CarrierWave::Compatibility::Paperclip do
       end
 
       it 'should not share custom interpolations' do
-        @uploader.stub!(:paperclip_path).and_return("/foo/:id/:ook")
-        @uploader.store_path('monkey.jpg').should == '/foo/23/:ook'
+        allow(@uploader).to receive(:paperclip_path).and_return("/foo/:id/:ook")
+        expect(@uploader.store_path('monkey.jpg')).to eq('/foo/23/:ook')
       end
 
     end
@@ -132,8 +132,8 @@ describe CarrierWave::Compatibility::Paperclip do
       it 'should interpolate for all versions correctly' do
         @file = File.open(file_path('test.jpg'))
         @uploader.store!(@file)
-        @uploader.thumb.path.should == "#{public_path}/foo/eek/23/thumb"
-        @uploader.list.path.should == "#{public_path}/foo/eek/23/list"
+        expect(@uploader.thumb.path).to eq("#{public_path}/foo/eek/23/thumb")
+        expect(@uploader.list.path).to eq("#{public_path}/foo/eek/23/list")
       end
     end
   end

--- a/spec/mount_spec.rb
+++ b/spec/mount_spec.rb
@@ -32,14 +32,14 @@ describe CarrierWave::Mount do
       end
 
       @instance.image = stub_file('test.jpg')
-      @instance.image.should be_an_instance_of(@uploader)
+      expect(@instance.image).to be_an_instance_of(@uploader)
     end
 
     it "should inherit uploaders to subclasses" do
       @subclass = Class.new(@class)
       @subclass_instance = @subclass.new
       @subclass_instance.image = stub_file('test.jpg')
-      @subclass_instance.image.should be_an_instance_of(@uploader)
+      expect(@subclass_instance.image).to be_an_instance_of(@uploader)
     end
 
     it "should allow marshalling uploaders and versions" do
@@ -53,7 +53,7 @@ describe CarrierWave::Mount do
         process :rotate
       end
       @instance.image = stub_file('test.jpg')
-      lambda { Marshal.dump @instance.image }.should_not raise_error
+      expect { Marshal.dump @instance.image }.not_to raise_error
     end
 
     describe "expected behavior with subclassed uploaders" do
@@ -76,46 +76,46 @@ describe CarrierWave::Mount do
       end
 
       it "should inherit defined versions" do
-        @instance.image1.should respond_to(:thumb)
-        @instance.image2.should respond_to(:thumb)
+        expect(@instance.image1).to respond_to(:thumb)
+        expect(@instance.image2).to respond_to(:thumb)
       end
 
       it "should not inherit versions defined in subclasses" do
-        @instance.image1.should_not respond_to(:secret)
-        @instance.image2.should respond_to(:secret)
+        expect(@instance.image1).not_to respond_to(:secret)
+        expect(@instance.image2).to respond_to(:secret)
       end
 
       it "should inherit defined processors properly" do
-        @uploader1.processors.should == [[:rotate, [], nil]]
-        @uploader2.processors.should == [[:rotate, [], nil], [:shrink, [], nil]]
-        @uploader1.versions[:thumb].processors.should == [[:compress, [], nil]]
-        @uploader2.versions[:thumb].processors.should == [[:compress, [], nil]]
-        @uploader2.versions[:secret].processors.should == [[:encrypt, [], nil]]
+        expect(@uploader1.processors).to eq([[:rotate, [], nil]])
+        expect(@uploader2.processors).to eq([[:rotate, [], nil], [:shrink, [], nil]])
+        expect(@uploader1.versions[:thumb].processors).to eq([[:compress, [], nil]])
+        expect(@uploader2.versions[:thumb].processors).to eq([[:compress, [], nil]])
+        expect(@uploader2.versions[:secret].processors).to eq([[:encrypt, [], nil]])
       end
     end
 
     describe '#image' do
 
       it "should return a blank uploader when nothing has been assigned" do
-        @instance.should_receive(:read_uploader).with(:image).twice.and_return(nil)
-        @instance.image.should be_an_instance_of(@uploader)
-        @instance.image.should be_blank
+        expect(@instance).to receive(:read_uploader).with(:image).twice.and_return(nil)
+        expect(@instance.image).to be_an_instance_of(@uploader)
+        expect(@instance.image).to be_blank
       end
 
       it "should return a blank uploader when an empty string has been assigned" do
-        @instance.should_receive(:read_uploader).with(:image).twice.and_return('')
-        @instance.image.should be_an_instance_of(@uploader)
-        @instance.image.should be_blank
+        expect(@instance).to receive(:read_uploader).with(:image).twice.and_return('')
+        expect(@instance.image).to be_an_instance_of(@uploader)
+        expect(@instance.image).to be_blank
       end
 
       it "should retrieve a file from the storage if a value is stored in the database" do
-        @instance.should_receive(:read_uploader).with(:image).at_least(:once).and_return('test.jpg')
-        @instance.image.should be_an_instance_of(@uploader)
+        expect(@instance).to receive(:read_uploader).with(:image).at_least(:once).and_return('test.jpg')
+        expect(@instance.image).to be_an_instance_of(@uploader)
       end
 
       it "should set the path to the store dir" do
-        @instance.should_receive(:read_uploader).with(:image).at_least(:once).and_return('test.jpg')
-        @instance.image.current_path.should == public_path('uploads/test.jpg')
+        expect(@instance).to receive(:read_uploader).with(:image).at_least(:once).and_return('test.jpg')
+        expect(@instance.image.current_path).to eq(public_path('uploads/test.jpg'))
       end
 
     end
@@ -124,21 +124,21 @@ describe CarrierWave::Mount do
 
       it "should cache a file" do
         @instance.image = stub_file('test.jpg')
-        @instance.image.should be_an_instance_of(@uploader)
+        expect(@instance.image).to be_an_instance_of(@uploader)
       end
 
       it "should copy a file into into the cache directory" do
         @instance.image = stub_file('test.jpg')
-        @instance.image.current_path.should =~ /^#{public_path('uploads/tmp')}/
+        expect(@instance.image.current_path).to match(/^#{public_path('uploads/tmp')}/)
       end
 
       it "should do nothing when nil is assigned" do
-        @instance.should_not_receive(:write_uploader)
+        expect(@instance).not_to receive(:write_uploader)
         @instance.image = nil
       end
 
       it "should do nothing when an empty string is assigned" do
-        @instance.should_not_receive(:write_uploader)
+        expect(@instance).not_to receive(:write_uploader)
         @instance.image = stub_file('test.jpg')
       end
 
@@ -149,7 +149,7 @@ describe CarrierWave::Mount do
           end
         end
         @instance.image = stub_file('test.jpg')
-        @instance.image.should be_blank
+        expect(@instance.image).to be_blank
       end
 
       it "should fail silently if the image fails a black list integrity check" do
@@ -159,7 +159,7 @@ describe CarrierWave::Mount do
           end
         end
         @instance.image = stub_file('test.jpg')
-        @instance.image.should be_blank
+        expect(@instance.image).to be_blank
       end
 
       it "should fail silently if the image fails to be processed" do
@@ -177,18 +177,18 @@ describe CarrierWave::Mount do
     describe '#image?' do
 
       it "should be false when nothing has been assigned" do
-        @instance.should_receive(:read_uploader).with(:image).and_return(nil)
-        @instance.image?.should be_false
+        expect(@instance).to receive(:read_uploader).with(:image).and_return(nil)
+        expect(@instance.image?).to be_false
       end
 
       it "should be false when an empty string has been assigned" do
-        @instance.should_receive(:read_uploader).with(:image).and_return('')
-        @instance.image?.should be_false
+        expect(@instance).to receive(:read_uploader).with(:image).and_return('')
+        expect(@instance.image?).to be_false
       end
 
       it "should be true when a file has been cached" do
         @instance.image = stub_file('test.jpg')
-        @instance.image?.should be_true
+        expect(@instance.image?).to be_true
       end
 
     end
@@ -196,29 +196,29 @@ describe CarrierWave::Mount do
     describe '#image_url' do
 
       it "should return nil when nothing has been assigned" do
-        @instance.should_receive(:read_uploader).with(:image).and_return(nil)
-        @instance.image_url.should be_nil
+        expect(@instance).to receive(:read_uploader).with(:image).and_return(nil)
+        expect(@instance.image_url).to be_nil
       end
 
       it "should return nil when an empty string has been assigned" do
-        @instance.should_receive(:read_uploader).with(:image).and_return('')
-        @instance.image_url.should be_nil
+        expect(@instance).to receive(:read_uploader).with(:image).and_return('')
+        expect(@instance.image_url).to be_nil
       end
 
       it "should get the url from a retrieved file" do
-        @instance.should_receive(:read_uploader).at_least(:once).with(:image).and_return('test.jpg')
-        @instance.image_url.should == '/uploads/test.jpg'
+        expect(@instance).to receive(:read_uploader).at_least(:once).with(:image).and_return('test.jpg')
+        expect(@instance.image_url).to eq('/uploads/test.jpg')
       end
 
       it "should get the url from a cached file" do
         @instance.image = stub_file('test.jpg')
-        @instance.image_url.should =~ %r{uploads/tmp/[\d\-]+/test.jpg}
+        expect(@instance.image_url).to match(%r{uploads/tmp/[\d\-]+/test.jpg})
       end
 
       it "should get the url from a cached file's version" do
         @uploader.version(:thumb)
         @instance.image = stub_file('test.jpg')
-        @instance.image_url(:thumb).should =~ %r{uploads/tmp/[\d\-]+/thumb_test.jpg}
+        expect(@instance.image_url(:thumb)).to match(%r{uploads/tmp/[\d\-]+/thumb_test.jpg})
       end
 
     end
@@ -226,23 +226,23 @@ describe CarrierWave::Mount do
     describe '#image_cache' do
 
       before do
-        @instance.stub!(:write_uploader)
-        @instance.stub!(:read_uploader).and_return(nil)
+        allow(@instance).to receive(:write_uploader)
+        allow(@instance).to receive(:read_uploader).and_return(nil)
       end
 
       it "should return nil when nothing has been assigned" do
-        @instance.image_cache.should be_nil
+        expect(@instance.image_cache).to be_nil
       end
 
       it "should be nil when a file has been stored" do
         @instance.image = stub_file('test.jpg')
         @instance.image.store!
-        @instance.image_cache.should be_nil
+        expect(@instance.image_cache).to be_nil
       end
 
       it "should be the cache name when a file has been cached" do
         @instance.image = stub_file('test.jpg')
-        @instance.image_cache.should =~ %r(^[\d]+\-[\d]+\-[\d]{4}/test\.jpg$)
+        expect(@instance.image_cache).to match(%r(^[\d]+\-[\d]+\-[\d]{4}/test\.jpg$))
       end
 
     end
@@ -250,30 +250,30 @@ describe CarrierWave::Mount do
     describe '#image_cache=' do
 
       before do
-        @instance.stub!(:write_uploader)
-        @instance.stub!(:read_uploader).and_return(nil)
+        allow(@instance).to receive(:write_uploader)
+        allow(@instance).to receive(:read_uploader).and_return(nil)
         CarrierWave::SanitizedFile.new(file_path('test.jpg')).copy_to(public_path('uploads/tmp/1369894322-123-1234/test.jpg'))
       end
 
       it "should do nothing when nil is assigned" do
         @instance.image_cache = nil
-        @instance.image.should be_blank
+        expect(@instance.image).to be_blank
       end
 
       it "should do nothing when an empty string is assigned" do
         @instance.image_cache = ''
-        @instance.image.should be_blank
+        expect(@instance.image).to be_blank
       end
 
       it "retrieve from cache when a cache name is assigned" do
         @instance.image_cache = '1369894322-123-1234/test.jpg'
-        @instance.image.current_path.should == public_path('uploads/tmp/1369894322-123-1234/test.jpg')
+        expect(@instance.image.current_path).to eq(public_path('uploads/tmp/1369894322-123-1234/test.jpg'))
       end
 
       it "should not write over a previously assigned file" do
         @instance.image = stub_file('test.jpg')
         @instance.image_cache = '1369894322-123-1234/monkey.jpg'
-        @instance.image.current_path.should =~ /test.jpg$/
+        expect(@instance.image.current_path).to match(/test.jpg$/)
       end
     end
 
@@ -290,12 +290,12 @@ describe CarrierWave::Mount do
 
       describe '#remote_image_url' do
         it "should return nil" do
-          @instance.remote_image_url.should be_nil
+          expect(@instance.remote_image_url).to be_nil
         end
 
         it "should return previously cached URL" do
           @instance.remote_image_url = 'http://www.example.com/test.jpg'
-          @instance.remote_image_url.should == 'http://www.example.com/test.jpg'
+          expect(@instance.remote_image_url).to eq('http://www.example.com/test.jpg')
         end
       end
 
@@ -303,23 +303,23 @@ describe CarrierWave::Mount do
 
         it "should do nothing when nil is assigned" do
           @instance.remote_image_url = nil
-          @instance.image.should be_blank
+          expect(@instance.image).to be_blank
         end
 
         it "should do nothing when an empty string is assigned" do
           @instance.remote_image_url = ''
-          @instance.image.should be_blank
+          expect(@instance.image).to be_blank
         end
 
         it "retrieve from cache when a cache name is assigned" do
           @instance.remote_image_url = 'http://www.example.com/test.jpg'
-          @instance.image.current_path.should =~ /test.jpg$/
+          expect(@instance.image.current_path).to match(/test.jpg$/)
         end
 
         it "should write over a previously assigned file" do
           @instance.image = stub_file('portrait.jpg')
           @instance.remote_image_url = 'http://www.example.com/test.jpg'
-          @instance.image.current_path.should =~ /test.jpg$/
+          expect(@instance.image.current_path).to match(/test.jpg$/)
         end
       end
     end
@@ -327,19 +327,19 @@ describe CarrierWave::Mount do
     describe '#store_image!' do
 
       before do
-        @instance.stub!(:write_uploader)
-        @instance.stub!(:read_uploader).and_return(nil)
+        allow(@instance).to receive(:write_uploader)
+        allow(@instance).to receive(:read_uploader).and_return(nil)
       end
 
       it "should do nothing when no file has been uploaded" do
         @instance.store_image!
-        @instance.image.should be_blank
+        expect(@instance.image).to be_blank
       end
 
       it "store an assigned file" do
         @instance.image = stub_file('test.jpg')
         @instance.store_image!
-        @instance.image.current_path.should == public_path('uploads/test.jpg')
+        expect(@instance.image.current_path).to eq(public_path('uploads/test.jpg'))
       end
 
       it "should remove an uploaded file when remove_image? returns true" do
@@ -347,29 +347,29 @@ describe CarrierWave::Mount do
         path = @instance.image.current_path
         @instance.remove_image = true
         @instance.store_image!
-        @instance.image.should be_blank
-        File.exist?(path).should be_false
+        expect(@instance.image).to be_blank
+        expect(File.exist?(path)).to be_false
       end
     end
 
     describe '#remove_image!' do
 
       before do
-        @instance.stub!(:write_uploader)
-        @instance.stub!(:read_uploader).and_return(nil)
+        allow(@instance).to receive(:write_uploader)
+        allow(@instance).to receive(:read_uploader).and_return(nil)
       end
 
       it "should do nothing when no file has been uploaded" do
         @instance.remove_image!
-        @instance.image.should be_blank
+        expect(@instance.image).to be_blank
       end
 
       it "should remove an uploaded file" do
         @instance.image = stub_file('test.jpg')
         path = @instance.image.current_path
         @instance.remove_image!
-        @instance.image.should be_blank
-        File.exist?(path).should be_false
+        expect(@instance.image).to be_blank
+        expect(File.exist?(path)).to be_false
       end
     end
 
@@ -377,7 +377,7 @@ describe CarrierWave::Mount do
 
       it "should store a value" do
         @instance.remove_image = true
-        @instance.remove_image.should be_true
+        expect(@instance.remove_image).to be_true
       end
 
     end
@@ -386,27 +386,27 @@ describe CarrierWave::Mount do
 
       it "should be true when the value is truthy" do
         @instance.remove_image = true
-        @instance.remove_image?.should be_true
+        expect(@instance.remove_image?).to be_true
       end
 
       it "should be false when the value is falsey" do
         @instance.remove_image = false
-        @instance.remove_image?.should be_false
+        expect(@instance.remove_image?).to be_false
       end
 
       it "should be false when the value is ''" do
         @instance.remove_image = ''
-        @instance.remove_image?.should be_false
+        expect(@instance.remove_image?).to be_false
       end
 
       it "should be false when the value is '0'" do
         @instance.remove_image = '0'
-        @instance.remove_image?.should be_false
+        expect(@instance.remove_image?).to be_false
       end
 
       it "should be false when the value is 'false'" do
         @instance.remove_image = 'false'
-        @instance.remove_image?.should be_false
+        expect(@instance.remove_image?).to be_false
       end
 
     end
@@ -414,12 +414,12 @@ describe CarrierWave::Mount do
     describe '#image_integrity_error' do
 
       it "should be nil by default" do
-        @instance.image_integrity_error.should be_nil
+        expect(@instance.image_integrity_error).to be_nil
       end
 
       it "should be nil after a file is cached" do
         @instance.image = stub_file('test.jpg')
-        @instance.image_integrity_error.should be_nil
+        expect(@instance.image_integrity_error).to be_nil
       end
 
       describe "when an integrity check fails" do
@@ -434,8 +434,8 @@ describe CarrierWave::Mount do
         it "should be an error instance if file was cached" do
           @instance.image = stub_file('test.jpg')
           e = @instance.image_integrity_error
-          e.should be_an_instance_of(CarrierWave::IntegrityError)
-          e.message.lines.grep(/^You are not allowed to upload/).should be_true
+          expect(e).to be_an_instance_of(CarrierWave::IntegrityError)
+          expect(e.message.lines.grep(/^You are not allowed to upload/)).to be_true
         end
 
         it "should be an error instance if file was downloaded" do
@@ -444,16 +444,16 @@ describe CarrierWave::Mount do
 
           @instance.remote_image_url = "http://www.example.com/test.jpg"
           e = @instance.image_integrity_error
-          e.should be_an_instance_of(CarrierWave::IntegrityError)
-          e.message.lines.grep(/^You are not allowed to upload/).should be_true
+          expect(e).to be_an_instance_of(CarrierWave::IntegrityError)
+          expect(e.message.lines.grep(/^You are not allowed to upload/)).to be_true
         end
 
         it "should be an error instance when image file is assigned and remote_image_url is blank" do
           @instance.image = stub_file('test.jpg')
           @instance.remote_image_url = ""
           e = @instance.image_integrity_error
-          e.should be_an_instance_of(CarrierWave::IntegrityError)
-          e.message.lines.grep(/^You are not allowed to upload/).should be_true
+          expect(e).to be_an_instance_of(CarrierWave::IntegrityError)
+          expect(e.message.lines.grep(/^You are not allowed to upload/)).to be_true
         end
       end
     end
@@ -461,12 +461,12 @@ describe CarrierWave::Mount do
     describe '#image_processing_error' do
 
       it "should be nil by default" do
-        @instance.image_processing_error.should be_nil
+        expect(@instance.image_processing_error).to be_nil
       end
 
       it "should be nil after a file is cached" do
         @instance.image = stub_file('test.jpg')
-        @instance.image_processing_error.should be_nil
+        expect(@instance.image_processing_error).to be_nil
       end
 
       describe "when an processing error occurs" do
@@ -481,7 +481,7 @@ describe CarrierWave::Mount do
 
         it "should be an error instance if file was cached" do
           @instance.image = stub_file('test.jpg')
-          @instance.image_processing_error.should be_an_instance_of(CarrierWave::ProcessingError)
+          expect(@instance.image_processing_error).to be_an_instance_of(CarrierWave::ProcessingError)
         end
 
         it "should be an error instance if file was downloaded" do
@@ -489,7 +489,7 @@ describe CarrierWave::Mount do
           sham_rack_app.register_resource('/test.jpg', File.read(file_path('test.jpg')), 'image/jpg')
 
           @instance.remote_image_url = "http://www.example.com/test.jpg"
-          @instance.image_processing_error.should be_an_instance_of(CarrierWave::ProcessingError)
+          expect(@instance.image_processing_error).to be_an_instance_of(CarrierWave::ProcessingError)
         end
       end
     end
@@ -501,17 +501,17 @@ describe CarrierWave::Mount do
       end
 
       it "should be nil by default" do
-        @instance.image_download_error.should be_nil
+        expect(@instance.image_download_error).to be_nil
       end
 
       it "should be nil if file download was successful" do
         @instance.remote_image_url = "http://www.example.com/test.jpg"
-        @instance.image_download_error.should be_nil
+        expect(@instance.image_download_error).to be_nil
       end
 
       it "should be an error instance if file could not be found" do
         @instance.remote_image_url = "http://www.example.com/missing.jpg"
-        @instance.image_download_error.should be_an_instance_of(CarrierWave::DownloadError)
+        expect(@instance.image_download_error).to be_an_instance_of(CarrierWave::DownloadError)
       end
     end
 
@@ -522,23 +522,23 @@ describe CarrierWave::Mount do
       end
 
       it "should be nil by default" do
-        @instance.image_download_error.should be_nil
+        expect(@instance.image_download_error).to be_nil
       end
 
       it "should be nil if file download was successful" do
         @instance.remote_image_url = "http://www.example.com/test.jpg"
-        @instance.image_download_error.should be_nil
+        expect(@instance.image_download_error).to be_nil
       end
 
       it "should be an error instance if file could not be found" do
         @instance.remote_image_url = "http://www.example.com/missing.jpg"
-        @instance.image_download_error.should be_an_instance_of(CarrierWave::DownloadError)
+        expect(@instance.image_download_error).to be_an_instance_of(CarrierWave::DownloadError)
       end
     end
 
     describe '#write_image_identifier' do
       it "should write to the column" do
-        @instance.should_receive(:write_uploader).with(:image, "test.jpg")
+        expect(@instance).to receive(:write_uploader).with(:image, "test.jpg")
         @instance.image = stub_file('test.jpg')
         @instance.write_image_identifier
       end
@@ -547,15 +547,15 @@ describe CarrierWave::Mount do
         @instance.image = stub_file('test.jpg')
         @instance.store_image!
         @instance.remove_image = true
-        @instance.should_receive(:write_uploader).with(:image, nil)
+        expect(@instance).to receive(:write_uploader).with(:image, nil)
         @instance.write_image_identifier
       end
     end
 
     describe '#image_identifier' do
       it "should return the identifier from the mounted column" do
-        @instance.should_receive(:read_uploader).with(:image).and_return("test.jpg")
-        @instance.image_identifier.should == 'test.jpg'
+        expect(@instance).to receive(:read_uploader).with(:image).and_return("test.jpg")
+        expect(@instance.image_identifier).to eq('test.jpg')
       end
     end
 
@@ -573,15 +573,15 @@ describe CarrierWave::Mount do
     describe '#image' do
 
       before do
-        @instance.stub!(:read_uploader).and_return('test.jpg')
+        allow(@instance).to receive(:read_uploader).and_return('test.jpg')
       end
 
       it "should return an instance of a subclass of CarrierWave::Uploader::Base" do
-        @instance.image.should be_a(CarrierWave::Uploader::Base)
+        expect(@instance.image).to be_a(CarrierWave::Uploader::Base)
       end
 
       it "should set the path to the store dir" do
-        @instance.image.current_path.should == public_path('uploads/test.jpg')
+        expect(@instance.image.current_path).to eq(public_path('uploads/test.jpg'))
       end
 
     end
@@ -602,11 +602,11 @@ describe CarrierWave::Mount do
       end
 
       it "should return an instance of a subclass of CarrierWave::Uploader::Base" do
-        @instance.image.should be_a(CarrierWave::Uploader::Base)
+        expect(@instance.image).to be_a(CarrierWave::Uploader::Base)
       end
 
       it "should apply any custom modifications" do
-        @instance.image.monkey.should == "blah"
+        expect(@instance.image.monkey).to eq("blah")
       end
     end
 
@@ -628,21 +628,21 @@ describe CarrierWave::Mount do
       end
 
       it "should return an instance of the uploader specified" do
-        @instance.image.should be_a_kind_of(@uploader)
+        expect(@instance.image).to be_a_kind_of(@uploader)
       end
 
       it "should apply any custom modifications to the instance" do
-        @instance.image.fish.should == "blub"
+        expect(@instance.image.fish).to eq("blub")
       end
 
       it "should apply any custom modifications to all defined versions" do
-        @instance.image.thumb.fish.should == "blub"
-        @instance.image.thumb.mini.fish.should == "blub"
-        @instance.image.thumb.maxi.fish.should == "blub"
+        expect(@instance.image.thumb.fish).to eq("blub")
+        expect(@instance.image.thumb.mini.fish).to eq("blub")
+        expect(@instance.image.thumb.maxi.fish).to eq("blub")
       end
 
       it "should not apply any custom modifications to the uploader class" do
-        @uploader.new.should_not respond_to(:fish)
+        expect(@uploader.new).not_to respond_to(:fish)
       end
     end
   end
@@ -666,18 +666,18 @@ describe CarrierWave::Mount do
     end
 
     it "should raise an error if the image fails an integrity check when cached" do
-      running {
+      expect(running {
         @instance.image = stub_file('test.jpg')
-      }.should raise_error(CarrierWave::IntegrityError)
+      }).to raise_error(CarrierWave::IntegrityError)
     end
 
     it "should raise an error if the image fails an integrity check when downloaded" do
       sham_rack_app = ShamRack.at('www.example.com').stub
       sham_rack_app.register_resource('/test.jpg', File.read(file_path('test.jpg')), 'image/jpg')
 
-      running {
+      expect(running {
         @instance.remote_image_url = "http://www.example.com/test.jpg"
-      }.should raise_error(CarrierWave::IntegrityError)
+      }).to raise_error(CarrierWave::IntegrityError)
     end
   end
 
@@ -701,18 +701,18 @@ describe CarrierWave::Mount do
     end
 
     it "should raise an error if the image fails to be processed when cached" do
-      running {
+      expect(running {
         @instance.image = stub_file('test.jpg')
-      }.should raise_error(CarrierWave::ProcessingError)
+      }).to raise_error(CarrierWave::ProcessingError)
     end
 
     it "should raise an error if the image fails to be processed when downloaded" do
       sham_rack_app = ShamRack.at('www.example.com').stub
       sham_rack_app.register_resource('/test.jpg', File.read(file_path('test.jpg')), 'image/jpg')
 
-      running {
+      expect(running {
         @instance.remote_image_url = "http://www.example.com/test.jpg"
-      }.should raise_error(CarrierWave::ProcessingError)
+      }).to raise_error(CarrierWave::ProcessingError)
     end
 
   end
@@ -736,9 +736,9 @@ describe CarrierWave::Mount do
         end
       end
 
-      running {
+      expect(running {
         @instance.remote_image_url = "http://www.example.com/test.jpg"
-      }.should raise_error(CarrierWave::DownloadError)
+      }).to raise_error(CarrierWave::DownloadError)
     end
 
   end
@@ -757,15 +757,15 @@ describe CarrierWave::Mount do
 
     describe '#image' do
       it "should retrieve a file from the storage if a value is stored in the database" do
-        @instance.should_receive(:read_uploader).at_least(:once).with(:monkey).and_return('test.jpg')
-        @instance.image.should be_an_instance_of(@uploader)
-        @instance.image.current_path.should == public_path('uploads/test.jpg')
+        expect(@instance).to receive(:read_uploader).at_least(:once).with(:monkey).and_return('test.jpg')
+        expect(@instance.image).to be_an_instance_of(@uploader)
+        expect(@instance.image.current_path).to eq(public_path('uploads/test.jpg'))
       end
     end
 
     describe '#write_image_identifier' do
       it "should write to the given column" do
-        @instance.should_receive(:write_uploader).with(:monkey, "test.jpg")
+        expect(@instance).to receive(:write_uploader).with(:monkey, "test.jpg")
         @instance.image = stub_file('test.jpg')
         @instance.write_image_identifier
       end
@@ -774,7 +774,7 @@ describe CarrierWave::Mount do
         @instance.image = stub_file('test.jpg')
         @instance.store_image!
         @instance.remove_image = true
-        @instance.should_receive(:write_uploader).with(:monkey, nil)
+        expect(@instance).to receive(:write_uploader).with(:monkey, nil)
         @instance.write_image_identifier
       end
     end

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -379,15 +379,15 @@ describe CarrierWave::ActiveRecord do
 
       it "should return to false after being saved" do
         @event.save!
-        @event.remove_image.should == false
-        @event.remove_image?.should == false
+        expect(@event.remove_image).to eq(false)
+        expect(@event.remove_image?).to eq(false)
       end
     end
 
     describe "remove_image=" do
       it "should mark the image as changed if changed" do
         expect(@event.image_changed?).to be_false
-        @event.remove_image.should be_nil
+        expect(@event.remove_image).to be_nil
         @event.remove_image = "1"
         expect(@event.image_changed?).to be_true
       end
@@ -442,7 +442,7 @@ describe CarrierWave::ActiveRecord do
 
       it "should include the image with url" do
         @event.image = stub_file("test.jpg")
-        @event.serializable_hash["image"].should have_key("url")
+        expect(@event.serializable_hash["image"]).to have_key("url")
       end
 
       it "should include the other columns" do
@@ -524,7 +524,7 @@ describe CarrierWave::ActiveRecord do
               model.name + File.extname(super)
             end
           end
-          @event.stub!(:name).and_return('jonas')
+          allow(@event).to receive(:name).and_return('jonas')
         end
 
         it "should copy the file to the upload directory when a file has been assigned" do
@@ -549,7 +549,7 @@ describe CarrierWave::ActiveRecord do
 
       before do
         @class.validates_presence_of :image
-        @event.stub!(:name).and_return('jonas')
+        allow(@event).to receive(:name).and_return('jonas')
       end
 
       it "should be valid if a file has been cached" do
@@ -567,7 +567,7 @@ describe CarrierWave::ActiveRecord do
 
       before do
         @class.validates_size_of :image, :maximum => 40
-        @event.stub!(:name).and_return('jonas')
+        allow(@event).to receive(:name).and_return('jonas')
       end
 
       it "should be valid if a file has been cached that matches the size criteria" do
@@ -639,7 +639,7 @@ describe CarrierWave::ActiveRecord do
       end
 
       it "should not remove old file if old file had a different path but config is false" do
-        @uploader.stub!(:remove_previously_stored_files_after_update).and_return(false)
+        allow(@uploader).to receive(:remove_previously_stored_files_after_update).and_return(false)
         @event.image = stub_file('new.jpeg')
         expect(@event.save).to be_true
         expect(File.exist?(public_path('uploads/new.jpeg'))).to be_true

--- a/spec/processing/mime_types_spec.rb
+++ b/spec/processing/mime_types_spec.rb
@@ -11,8 +11,8 @@ describe CarrierWave::MimeTypes do
     end
     @instance = @klass.new
     FileUtils.cp(file_path('landscape.jpg'), file_path('landscape_copy.jpg'))
-    @instance.stub(:original_filename).and_return file_path('landscape_copy.jpg')
-    @instance.stub(:file).and_return CarrierWave::SanitizedFile.new(file_path('landscape_copy.jpg'))
+    allow(@instance).to receive(:original_filename).and_return file_path('landscape_copy.jpg')
+    allow(@instance).to receive(:file).and_return CarrierWave::SanitizedFile.new(file_path('landscape_copy.jpg'))
     @file = @instance.file
   end
 
@@ -24,34 +24,34 @@ describe CarrierWave::MimeTypes do
 
     it "does not set content_type if already set" do
       @instance.file.content_type = 'image/jpeg'
-      @instance.file.should_not_receive(:content_type=)
+      expect(@instance.file).not_to receive(:content_type=)
       @instance.set_content_type
     end
 
     it "set content_type if content_type is nil" do
       pending 'This spec is deprecated because Proxy now read content type itself.'
       @instance.file.content_type = nil
-      @instance.file.should_receive(:content_type=).with('image/jpeg')
+      expect(@instance.file).to receive(:content_type=).with('image/jpeg')
       @instance.set_content_type
     end
 
     it "set content_type if content_type is empty" do
       @instance.file.content_type = ''
-      @instance.file.should_receive(:content_type=).with('image/jpeg')
+      expect(@instance.file).to receive(:content_type=).with('image/jpeg')
       @instance.set_content_type
     end
 
     %w[ application/octet-stream binary/octet-stream ].each do |type|
       it "sets content_type if content_type is generic (#{type})" do
         @instance.file.content_type = type
-        @instance.file.should_receive(:content_type=).with('image/jpeg')
+        expect(@instance.file).to receive(:content_type=).with('image/jpeg')
         @instance.set_content_type
       end
     end
 
     it "sets content_type if override is true" do
       @instance.file.content_type = 'image/jpeg'
-      @instance.file.should_receive(:content_type=).with('image/jpeg')
+      expect(@instance.file).to receive(:content_type=).with('image/jpeg')
       @instance.set_content_type(true)
     end
 

--- a/spec/processing/mini_magick_spec.rb
+++ b/spec/processing/mini_magick_spec.rb
@@ -10,8 +10,8 @@ describe CarrierWave::MiniMagick do
     end
     @instance = @klass.new
     FileUtils.cp(file_path('landscape.jpg'), file_path('landscape_copy.jpg'))
-    @instance.stub(:current_path).and_return(file_path('landscape_copy.jpg'))
-    @instance.stub(:cached?).and_return true
+    allow(@instance).to receive(:current_path).and_return(file_path('landscape_copy.jpg'))
+    allow(@instance).to receive(:cached?).and_return true
   end
 
   after do
@@ -22,69 +22,69 @@ describe CarrierWave::MiniMagick do
     it "should convert from one format to another" do
       @instance.convert('png')
       img = ::MiniMagick::Image.open(@instance.current_path)
-      img['format'].should =~ /PNG/
+      expect(img['format']).to match(/PNG/)
     end
   end
 
   describe '#resize_to_fill' do
     it "should resize the image to exactly the given dimensions and maintain file type" do
       @instance.resize_to_fill(200, 200)
-      @instance.should have_dimensions(200, 200)
-      ::MiniMagick::Image.open(@instance.current_path)['format'].should =~ /JPEG/
+      expect(@instance).to have_dimensions(200, 200)
+      expect(::MiniMagick::Image.open(@instance.current_path)['format']).to match(/JPEG/)
     end
 
     it "should resize the image to exactly the given dimensions and maintain updated file type" do
       @instance.convert('png')
       @instance.resize_to_fill(200, 200)
-      @instance.should have_dimensions(200, 200)
-      ::MiniMagick::Image.open(@instance.current_path)['format'].should =~ /PNG/
+      expect(@instance).to have_dimensions(200, 200)
+      expect(::MiniMagick::Image.open(@instance.current_path)['format']).to match(/PNG/)
     end
     
     it "should scale up the image if it smaller than the given dimensions" do
       @instance.resize_to_fill(1000, 1000)
-      @instance.should have_dimensions(1000, 1000)
+      expect(@instance).to have_dimensions(1000, 1000)
     end
   end
 
   describe '#resize_and_pad' do
     it "should resize the image to exactly the given dimensions and maintain file type" do
       @instance.resize_and_pad(200, 200)
-      @instance.should have_dimensions(200, 200)
-      ::MiniMagick::Image.open(@instance.current_path)['format'].should =~ /JPEG/
+      expect(@instance).to have_dimensions(200, 200)
+      expect(::MiniMagick::Image.open(@instance.current_path)['format']).to match(/JPEG/)
     end
 
     it "should resize the image to exactly the given dimensions and maintain updated file type" do
       @instance.convert('png')
       @instance.resize_and_pad(200, 200)
-      @instance.should have_dimensions(200, 200)
-      ::MiniMagick::Image.open(@instance.current_path)['format'].should =~ /PNG/
+      expect(@instance).to have_dimensions(200, 200)
+      expect(::MiniMagick::Image.open(@instance.current_path)['format']).to match(/PNG/)
     end
 
     it "should scale up the image if it smaller than the given dimensions" do
       @instance.resize_and_pad(1000, 1000)
-      @instance.should have_dimensions(1000, 1000)
+      expect(@instance).to have_dimensions(1000, 1000)
     end
 
     it "should pad with white" do
       @instance.resize_and_pad(200, 200)
       color = color_of_pixel(@instance.current_path, 0, 0)
-      color.should include('#FFFFFF')
-      color.should_not include('#FFFFFF00')
+      expect(color).to include('#FFFFFF')
+      expect(color).not_to include('#FFFFFF00')
     end
 
     it "should pad with transparent" do
       @instance.convert('png')
       @instance.resize_and_pad(200, 200, :transparent)
       color = color_of_pixel(@instance.current_path, 0, 0)
-      color.should include('#FFFFFF00')
+      expect(color).to include('#FFFFFF00')
     end
 
     it "should not pad with transparent" do
       @instance.resize_and_pad(200, 200, :transparent)
       @instance.convert('png')
       color = color_of_pixel(@instance.current_path, 0, 0)
-      color.should include('#FFFFFF')
-      color.should_not include('#FFFFFF00')
+      expect(color).to include('#FFFFFF')
+      expect(color).not_to include('#FFFFFF00')
     end
 
   end
@@ -92,40 +92,40 @@ describe CarrierWave::MiniMagick do
   describe '#resize_to_fit' do
     it "should resize the image to fit within the given dimensions and maintain file type" do
       @instance.resize_to_fit(200, 200)
-      @instance.should have_dimensions(200, 150)
-      ::MiniMagick::Image.open(@instance.current_path)['format'].should =~ /JPEG/
+      expect(@instance).to have_dimensions(200, 150)
+      expect(::MiniMagick::Image.open(@instance.current_path)['format']).to match(/JPEG/)
     end
 
     it "should resize the image to fit within the given dimensions and maintain updated file type" do
       @instance.convert('png')
       @instance.resize_to_fit(200, 200)
-      @instance.should have_dimensions(200, 150)
-      ::MiniMagick::Image.open(@instance.current_path)['format'].should =~ /PNG/
+      expect(@instance).to have_dimensions(200, 150)
+      expect(::MiniMagick::Image.open(@instance.current_path)['format']).to match(/PNG/)
     end
 
     it "should scale up the image if it smaller than the given dimensions" do
       @instance.resize_to_fit(1000, 1000)
-      @instance.should have_dimensions(1000, 750)
+      expect(@instance).to have_dimensions(1000, 750)
     end
   end
 
   describe '#resize_to_limit' do
     it "should resize the image to fit within the given dimensions and maintain file type" do
       @instance.resize_to_limit(200, 200)
-      @instance.should have_dimensions(200, 150)
-      ::MiniMagick::Image.open(@instance.current_path)['format'].should =~ /JPEG/
+      expect(@instance).to have_dimensions(200, 150)
+      expect(::MiniMagick::Image.open(@instance.current_path)['format']).to match(/JPEG/)
     end
 
     it "should resize the image to fit within the given dimensions and maintain updated file type" do
       @instance.convert('png')
       @instance.resize_to_limit(200, 200)
-      @instance.should have_dimensions(200, 150)
-      ::MiniMagick::Image.open(@instance.current_path)['format'].should =~ /PNG/
+      expect(@instance).to have_dimensions(200, 150)
+      expect(::MiniMagick::Image.open(@instance.current_path)['format']).to match(/PNG/)
     end
 
     it "should not scale up the image if it smaller than the given dimensions" do
       @instance.resize_to_limit(1000, 1000)
-      @instance.should have_dimensions(640, 480)
+      expect(@instance).to have_dimensions(640, 480)
     end
   end
 
@@ -138,7 +138,7 @@ describe CarrierWave::MiniMagick do
       end
 
       it "should fail to process a non image file" do
-        lambda {@instance.resize_to_limit(200, 200)}.should raise_exception(CarrierWave::ProcessingError, /^Failed to manipulate with MiniMagick, maybe it is not an image\? Original Error:/)
+        expect {@instance.resize_to_limit(200, 200)}.to raise_exception(CarrierWave::ProcessingError, /^Failed to manipulate with MiniMagick, maybe it is not an image\? Original Error:/)
       end
 
       it "should use I18n" do
@@ -147,15 +147,15 @@ describe CarrierWave::MiniMagick do
             :mini_magick_processing_error => "Kon bestand niet met MiniMagick bewerken, misschien is het geen beeld bestand? MiniMagick foutmelding: %{e}"
           }
         }) do
-          lambda {@instance.resize_to_limit(200, 200)}.should raise_exception(CarrierWave::ProcessingError, /^Kon bestand niet met MiniMagick bewerken, misschien is het geen beeld bestand\? MiniMagick foutmelding:/)
+          expect {@instance.resize_to_limit(200, 200)}.to raise_exception(CarrierWave::ProcessingError, /^Kon bestand niet met MiniMagick bewerken, misschien is het geen beeld bestand\? MiniMagick foutmelding:/)
         end
       end
 
       it "should not suppress errors when translation is unavailable" do
         change_locale_and_store_translations(:foo, {}) do
-          lambda do
+          expect do
             @instance.resize_to_limit(200, 200)
-          end.should raise_exception( CarrierWave::ProcessingError, /Not a JPEG/ )
+          end.to raise_exception( CarrierWave::ProcessingError, /Not a JPEG/ )
         end
       end
     end

--- a/spec/processing/rmagick_spec.rb
+++ b/spec/processing/rmagick_spec.rb
@@ -10,8 +10,8 @@ describe CarrierWave::RMagick, :rmagick => true do
     end
     @instance = @klass.new
     FileUtils.cp(file_path('landscape.jpg'), file_path('landscape_copy.jpg'))
-    @instance.stub(:current_path).and_return(file_path('landscape_copy.jpg'))
-    @instance.stub(:cached?).and_return true
+    allow(@instance).to receive(:current_path).and_return(file_path('landscape_copy.jpg'))
+    allow(@instance).to receive(:cached?).and_return true
   end
 
   after do
@@ -21,145 +21,145 @@ describe CarrierWave::RMagick, :rmagick => true do
   describe '#convert' do
     it "should convert the image to the given format" do
       @instance.convert(:png)
-      ::Magick::Image.read(@instance.current_path).first.format.should == 'PNG'
+      expect(::Magick::Image.read(@instance.current_path).first.format).to eq('PNG')
     end
   end
 
   describe '#resize_to_fill' do
     it "should resize the image to exactly the given dimensions and maintain file type" do
       @instance.resize_to_fill(200, 200)
-      @instance.should have_dimensions(200, 200)
-      ::Magick::Image.read(@instance.current_path).first.format.should == 'JPEG'
+      expect(@instance).to have_dimensions(200, 200)
+      expect(::Magick::Image.read(@instance.current_path).first.format).to eq('JPEG')
     end
 
     it "should resize the image to exactly the given dimensions and maintain updated file type" do
       @instance.convert('png')
       @instance.resize_to_fill(200, 200)
-      @instance.should have_dimensions(200, 200)
-      ::Magick::Image.read(@instance.current_path).first.format.should == 'PNG'
+      expect(@instance).to have_dimensions(200, 200)
+      expect(::Magick::Image.read(@instance.current_path).first.format).to eq('PNG')
     end
 
     it "should scale up the image if it smaller than the given dimensions" do
       @instance.resize_to_fill(1000, 1000)
-      @instance.should have_dimensions(1000, 1000)
+      expect(@instance).to have_dimensions(1000, 1000)
     end
   end
 
   describe '#resize_and_pad' do
     it "should resize the image to exactly the given dimensions and maintain file type" do
       @instance.resize_and_pad(200, 200)
-      @instance.should have_dimensions(200, 200)
-      ::Magick::Image.read(@instance.current_path).first.format.should == 'JPEG'
+      expect(@instance).to have_dimensions(200, 200)
+      expect(::Magick::Image.read(@instance.current_path).first.format).to eq('JPEG')
     end
 
     it "should resize the image to exactly the given dimensions and maintain updated file type" do
       @instance.convert('png')
       @instance.resize_and_pad(200, 200)
-      @instance.should have_dimensions(200, 200)
-      ::Magick::Image.read(@instance.current_path).first.format.should == 'PNG'
+      expect(@instance).to have_dimensions(200, 200)
+      expect(::Magick::Image.read(@instance.current_path).first.format).to eq('PNG')
     end
 
     it "should pad with white" do
       @instance.resize_and_pad(200, 200)
       color = color_of_pixel(@instance.current_path, 0, 0)
-      color.should include('#FFFFFF')
-      color.should_not include('#FFFFFF00')
+      expect(color).to include('#FFFFFF')
+      expect(color).not_to include('#FFFFFF00')
     end
 
     it "should pad with transparent" do
       @instance.convert('png')
       @instance.resize_and_pad(200, 200, :transparent)
       color = color_of_pixel(@instance.current_path, 0, 0)
-      color.should include('#FFFFFF00')
+      expect(color).to include('#FFFFFF00')
     end
 
     it "should not pad with transparent" do
       @instance.resize_and_pad(200, 200, :transparent)
       @instance.convert('png')
       color = color_of_pixel(@instance.current_path, 0, 0)
-      color.should include('#FFFFFF')
-      color.should_not include('#FFFFFF00')
+      expect(color).to include('#FFFFFF')
+      expect(color).not_to include('#FFFFFF00')
     end
 
     it "should pad with given color" do
       @instance.resize_and_pad(200, 200, '#888')
       color = color_of_pixel(@instance.current_path, 0, 0)
-      color.should include('#888888')
+      expect(color).to include('#888888')
     end
 
     it "should scale up the image if it smaller than the given dimensions" do
       @instance.resize_and_pad(1000, 1000)
-      @instance.should have_dimensions(1000, 1000)
+      expect(@instance).to have_dimensions(1000, 1000)
     end
   end
 
   describe '#resize_to_fit' do
     it "should resize the image to fit within the given dimensions and maintain file type" do
       @instance.resize_to_fit(200, 200)
-      @instance.should have_dimensions(200, 150)
-      ::Magick::Image.read(@instance.current_path).first.format.should == 'JPEG'
+      expect(@instance).to have_dimensions(200, 150)
+      expect(::Magick::Image.read(@instance.current_path).first.format).to eq('JPEG')
     end
 
     it "should resize the image to fit within the given dimensions and maintain updated file type" do
       @instance.convert('png')
       @instance.resize_to_fit(200, 200)
-      @instance.should have_dimensions(200, 150)
-      ::Magick::Image.read(@instance.current_path).first.format.should == 'PNG'
+      expect(@instance).to have_dimensions(200, 150)
+      expect(::Magick::Image.read(@instance.current_path).first.format).to eq('PNG')
     end
 
     it "should scale up the image if it smaller than the given dimensions" do
       @instance.resize_to_fit(1000, 1000)
-      @instance.should have_dimensions(1000, 750)
+      expect(@instance).to have_dimensions(1000, 750)
     end
   end
 
   describe '#resize_to_limit' do
     it "should resize the image to fit within the given dimensions and maintain file type" do
       @instance.resize_to_limit(200, 200)
-      @instance.should have_dimensions(200, 150)
-      ::Magick::Image.read(@instance.current_path).first.format.should == 'JPEG'
+      expect(@instance).to have_dimensions(200, 150)
+      expect(::Magick::Image.read(@instance.current_path).first.format).to eq('JPEG')
     end
 
     it "should resize the image to fit within the given dimensions and maintain updated file type" do
       @instance.convert('png')
       @instance.resize_to_limit(200, 200)
-      @instance.should have_dimensions(200, 150)
-      ::Magick::Image.read(@instance.current_path).first.format.should == 'PNG'
+      expect(@instance).to have_dimensions(200, 150)
+      expect(::Magick::Image.read(@instance.current_path).first.format).to eq('PNG')
     end
 
     it "should not scale up the image if it smaller than the given dimensions" do
       @instance.resize_to_limit(1000, 1000)
-      @instance.should have_dimensions(640, 480)
+      expect(@instance).to have_dimensions(640, 480)
     end
   end
 
   describe '#resize_to_geometry_string' do
     it "should resize the image to comply with `200x200^` Geometry String spec and maintain file type" do
       @instance.resize_to_geometry_string('200x200^')
-      @instance.should have_dimensions(267, 200)
-      ::Magick::Image.read(@instance.current_path).first.format.should == 'JPEG'
+      expect(@instance).to have_dimensions(267, 200)
+      expect(::Magick::Image.read(@instance.current_path).first.format).to eq('JPEG')
     end
 
     it "should resize the image to comply with `200x200^` Geometry String spec and maintain updated file type" do
       @instance.convert('png')
       @instance.resize_to_geometry_string('200x200^')
-      @instance.should have_dimensions(267, 200)
-      ::Magick::Image.read(@instance.current_path).first.format.should == 'PNG'
+      expect(@instance).to have_dimensions(267, 200)
+      expect(::Magick::Image.read(@instance.current_path).first.format).to eq('PNG')
     end
 
     it "should resize the image to have 125% larger dimensions" do
       @instance.resize_to_geometry_string('125%')
-      @instance.should have_dimensions(800, 600)
+      expect(@instance).to have_dimensions(800, 600)
     end
 
     it "should resize the image to have a given height" do
       @instance.resize_to_geometry_string('x256')
-      @instance.should have_height(256)
+      expect(@instance).to have_height(256)
     end
 
     it "should resize the image to have a given width" do
       @instance.resize_to_geometry_string('256x')
-      @instance.should have_width(256)
+      expect(@instance).to have_width(256)
     end
   end
 
@@ -167,8 +167,8 @@ describe CarrierWave::RMagick, :rmagick => true do
     it 'should support passing write options to RMagick' do
       image = ::Magick::Image.read(file_path('landscape_copy.jpg'))
       ::Magick::Image.stub(:read => image)
-      ::Magick::Image::Info.any_instance.should_receive(:quality=).with(50)
-      ::Magick::Image::Info.any_instance.should_receive(:depth=).with(8)
+      expect_any_instance_of(::Magick::Image::Info).to receive(:quality=).with(50)
+      expect_any_instance_of(::Magick::Image::Info).to receive(:depth=).with(8)
       
       @instance.manipulate! do |image, index, options| 
         options[:write] = {
@@ -180,8 +180,8 @@ describe CarrierWave::RMagick, :rmagick => true do
     end
 
     it 'should support passing read options to RMagick' do
-      ::Magick::Image::Info.any_instance.should_receive(:density=).with(10)
-      ::Magick::Image::Info.any_instance.should_receive(:size=).with("200x200")
+      expect_any_instance_of(::Magick::Image::Info).to receive(:density=).with(10)
+      expect_any_instance_of(::Magick::Image::Info).to receive(:size=).with("200x200")
       
       @instance.manipulate! :read => {
           :density => 10,
@@ -199,7 +199,7 @@ describe CarrierWave::RMagick, :rmagick => true do
       end
 
       it "should fail to process a non image file" do
-        lambda {@instance.resize_to_limit(200, 200)}.should raise_exception(CarrierWave::ProcessingError, /^Failed to manipulate with rmagick, maybe it is not an image\? Original Error:/)
+        expect {@instance.resize_to_limit(200, 200)}.to raise_exception(CarrierWave::ProcessingError, /^Failed to manipulate with rmagick, maybe it is not an image\? Original Error:/)
       end
 
       it "should use I18n" do
@@ -208,15 +208,15 @@ describe CarrierWave::RMagick, :rmagick => true do
             :rmagick_processing_error => "Kon bestand niet met rmagick bewerken, misschien is het geen beeld bestand? rmagick foutmelding: %{e}"
           }
         }) do
-          lambda {@instance.resize_to_limit(200, 200)}.should raise_exception(CarrierWave::ProcessingError, /^Kon bestand niet met rmagick bewerken, misschien is het geen beeld bestand\? rmagick foutmelding:/)
+          expect {@instance.resize_to_limit(200, 200)}.to raise_exception(CarrierWave::ProcessingError, /^Kon bestand niet met rmagick bewerken, misschien is het geen beeld bestand\? rmagick foutmelding:/)
         end
       end
 
       it "should not suppress errors when translation is unavailable" do
         change_locale_and_store_translations(:foo, {}) do
-          lambda do
+          expect do
             @instance.resize_to_limit(200, 200)
-          end.should raise_exception( CarrierWave::ProcessingError, /Not a JPEG/ )
+          end.to raise_exception( CarrierWave::ProcessingError, /Not a JPEG/ )
         end
       end
     end

--- a/spec/sanitized_file_spec.rb
+++ b/spec/sanitized_file_spec.rb
@@ -20,50 +20,50 @@ describe CarrierWave::SanitizedFile do
 
     it "should be empty for nil" do
       @sanitized_file = CarrierWave::SanitizedFile.new(nil)
-      @sanitized_file.should be_empty
+      expect(@sanitized_file).to be_empty
     end
 
     it "should be empty for an empty string" do
       @sanitized_file = CarrierWave::SanitizedFile.new("")
-      @sanitized_file.should be_empty
+      expect(@sanitized_file).to be_empty
     end
 
     it "should be empty for an empty StringIO" do
       @sanitized_file = CarrierWave::SanitizedFile.new(StringIO.new(""))
-      @sanitized_file.should be_empty
+      expect(@sanitized_file).to be_empty
     end
 
   end
 
   describe '#original_filename' do
     it "should default to the original_filename" do
-      file = mock('file', :original_filename => 'llama.jpg')
+      file = double('file', :original_filename => 'llama.jpg')
       sanitized_file = CarrierWave::SanitizedFile.new(file)
-      sanitized_file.original_filename.should == "llama.jpg"
+      expect(sanitized_file.original_filename).to eq("llama.jpg")
     end
 
     it "should defer to the base name of the path if original_filename is unavailable" do
-      file = mock('file', :path => '/path/to/test.jpg')
+      file = double('file', :path => '/path/to/test.jpg')
       sanitized_file = CarrierWave::SanitizedFile.new(file)
-      sanitized_file.original_filename.should == "test.jpg"
+      expect(sanitized_file.original_filename).to eq("test.jpg")
     end
 
     it "should be nil otherwise" do
-      file = mock('file')
+      file = double('file')
       sanitized_file = CarrierWave::SanitizedFile.new(file)
-      sanitized_file.original_filename.should be_nil
+      expect(sanitized_file.original_filename).to be_nil
     end
   end
 
   describe '#basename' do
     it "should return the basename for complicated extensions" do
       @sanitized_file = CarrierWave::SanitizedFile.new(file_path('complex.filename.tar.gz'))
-      @sanitized_file.basename.should == "complex.filename"
+      expect(@sanitized_file.basename).to eq("complex.filename")
     end
 
     it "should be the filename if the file has no extension" do
       @sanitized_file = CarrierWave::SanitizedFile.new(file_path('complex'))
-      @sanitized_file.basename.should == "complex"
+      expect(@sanitized_file.basename).to eq("complex")
     end
   end
 
@@ -71,23 +71,23 @@ describe CarrierWave::SanitizedFile do
     %w[gz bz2 z lz xz].each do |ext|
       it "should return the extension for complicated extensions (tar.#{ext})" do
         @sanitized_file = CarrierWave::SanitizedFile.new(file_path("complex.filename.tar.#{ext}"))
-        @sanitized_file.extension.should == "tar.#{ext}"
+        expect(@sanitized_file.extension).to eq("tar.#{ext}")
       end
     end
 
     it "should return the extension for real-world user file names" do
       @sanitized_file = CarrierWave::SanitizedFile.new(file_path('Photo on 2009-12-01 at 11.12.jpg'))
-      @sanitized_file.extension.should == "jpg"
+      expect(@sanitized_file.extension).to eq("jpg")
     end
 
     it "should return the extension for basic filenames" do
       @sanitized_file = CarrierWave::SanitizedFile.new(file_path('something.png'))
-      @sanitized_file.extension.should == "png"
+      expect(@sanitized_file.extension).to eq("png")
     end
 
     it "should be an empty string if the file has no extension" do
       @sanitized_file = CarrierWave::SanitizedFile.new(file_path('complex'))
-      @sanitized_file.extension.should == ""
+      expect(@sanitized_file.extension).to eq("")
     end
   end
 
@@ -98,38 +98,38 @@ describe CarrierWave::SanitizedFile do
     end
 
     it "should default to the original filename if it is valid" do
-      @sanitized_file.should_receive(:original_filename).at_least(:once).and_return("llama.jpg")
-      @sanitized_file.filename.should == "llama.jpg"
+      expect(@sanitized_file).to receive(:original_filename).at_least(:once).and_return("llama.jpg")
+      expect(@sanitized_file.filename).to eq("llama.jpg")
     end
 
     it "should remove illegal characters from a filename" do
-      @sanitized_file.should_receive(:original_filename).at_least(:once).and_return("test-s,%&m#st?.jpg")
-      @sanitized_file.filename.should == "test-s___m_st_.jpg"
+      expect(@sanitized_file).to receive(:original_filename).at_least(:once).and_return("test-s,%&m#st?.jpg")
+      expect(@sanitized_file.filename).to eq("test-s___m_st_.jpg")
     end
 
     it "should remove slashes from the filename" do
-      @sanitized_file.should_receive(:original_filename).at_least(:once).and_return("../../very_tricky/foo.bar")
-      @sanitized_file.filename.should_not =~ /[\\\/]/
+      expect(@sanitized_file).to receive(:original_filename).at_least(:once).and_return("../../very_tricky/foo.bar")
+      expect(@sanitized_file.filename).not_to match(/[\\\/]/)
     end
 
     it "should remove illegal characters if there is no extension" do
-      @sanitized_file.should_receive(:original_filename).at_least(:once).and_return('`*foo')
-      @sanitized_file.filename.should == "__foo"
+      expect(@sanitized_file).to receive(:original_filename).at_least(:once).and_return('`*foo')
+      expect(@sanitized_file.filename).to eq("__foo")
     end
 
     it "should remove the path prefix on Windows" do
-      @sanitized_file.should_receive(:original_filename).at_least(:once).and_return('c:\temp\foo.txt')
-      @sanitized_file.filename.should == "foo.txt"
+      expect(@sanitized_file).to receive(:original_filename).at_least(:once).and_return('c:\temp\foo.txt')
+      expect(@sanitized_file.filename).to eq("foo.txt")
     end
 
     it "should make sure the *nix directory thingies can't be used as filenames" do
-      @sanitized_file.should_receive(:original_filename).at_least(:once).and_return(".")
-      @sanitized_file.filename.should == "_."
+      expect(@sanitized_file).to receive(:original_filename).at_least(:once).and_return(".")
+      expect(@sanitized_file.filename).to eq("_.")
     end
 
     it "should maintain uppercase filenames" do
-      @sanitized_file.should_receive(:original_filename).at_least(:once).and_return("DSC4056.JPG")
-      @sanitized_file.filename.should == "DSC4056.JPG"
+      expect(@sanitized_file).to receive(:original_filename).at_least(:once).and_return("DSC4056.JPG")
+      expect(@sanitized_file.filename).to eq("DSC4056.JPG")
     end
 
   end
@@ -138,17 +138,17 @@ describe CarrierWave::SanitizedFile do
 
     before do
       @sanitized_file = CarrierWave::SanitizedFile.new(nil)
-      @sanitized_file.stub(:sanitize_regexp).and_return(/[^a-zA-Z\.\-\+_]/)
+      allow(@sanitized_file).to receive(:sanitize_regexp).and_return(/[^a-zA-Z\.\-\+_]/)
     end
 
     it "should default to the original filename if it is valid" do
-      @sanitized_file.should_receive(:original_filename).at_least(:once).and_return("llama.jpg")
-      @sanitized_file.filename.should == "llama.jpg"
+      expect(@sanitized_file).to receive(:original_filename).at_least(:once).and_return("llama.jpg")
+      expect(@sanitized_file.filename).to eq("llama.jpg")
     end
 
     it "should remove illegal characters from a filename" do
-      @sanitized_file.should_receive(:original_filename).at_least(:once).and_return("123.jpg")
-      @sanitized_file.filename.should == "___.jpg"
+      expect(@sanitized_file).to receive(:original_filename).at_least(:once).and_return("123.jpg")
+      expect(@sanitized_file.filename).to eq("___.jpg")
     end
 
   end
@@ -158,22 +158,22 @@ describe CarrierWave::SanitizedFile do
     before do
       @sanitized_file = CarrierWave::SanitizedFile.new(nil)
       regexp = RUBY_VERSION >= '1.9' ? Regexp.new('[^[:word:]\.\-\+]') : /[^éôёЁа-яА-Яa-zA-Zà-üÀ-Ü0-9\.\-\+_]/u
-      @sanitized_file.stub(:sanitize_regexp).and_return(regexp)
+      allow(@sanitized_file).to receive(:sanitize_regexp).and_return(regexp)
     end
 
     it "should default to the original filename if it is valid" do
-      @sanitized_file.should_receive(:original_filename).at_least(:once).and_return("тестовый.jpg")
-      @sanitized_file.filename.should == "тестовый.jpg"
+      expect(@sanitized_file).to receive(:original_filename).at_least(:once).and_return("тестовый.jpg")
+      expect(@sanitized_file.filename).to eq("тестовый.jpg")
     end
 
     it "should downcase characters properly" do
-      @sanitized_file.should_receive(:original_filename).at_least(:once).and_return("ТестоВый Ёжик.jpg")
-      @sanitized_file.filename.should == "ТестоВый_Ёжик.jpg"
+      expect(@sanitized_file).to receive(:original_filename).at_least(:once).and_return("ТестоВый Ёжик.jpg")
+      expect(@sanitized_file.filename).to eq("ТестоВый_Ёжик.jpg")
     end
 
     it "should remove illegal characters from a filename" do
-      @sanitized_file.should_receive(:original_filename).at_least(:once).and_return("⟲«Du côté des chars lourds»_123.doc")
-      @sanitized_file.filename.should == "__Du_côté_des_chars_lourds__123.doc"
+      expect(@sanitized_file).to receive(:original_filename).at_least(:once).and_return("⟲«Du côté des chars lourds»_123.doc")
+      expect(@sanitized_file.filename).to eq("__Du_côté_des_chars_lourds__123.doc")
     end
 
   end
@@ -181,21 +181,21 @@ describe CarrierWave::SanitizedFile do
   describe "#content_type" do
     it "preserves file's content_type" do
       @sanitized_file = CarrierWave::SanitizedFile.new(:content_type => 'image/png')
-      @sanitized_file.content_type.should == 'image/png'
+      expect(@sanitized_file.content_type).to eq('image/png')
     end
 
     it "should handle Mime::Type object" do
       @file = File.open(file_path('sponsored.doc'))
-      @file.stub!(:content_type).and_return(MIME::Type.new('application/msword'))
+      allow(@file).to receive(:content_type).and_return(MIME::Type.new('application/msword'))
       @sanitized_file = CarrierWave::SanitizedFile.new(@file)
-      @sanitized_file.stub!(:file).and_return(@file)
-      lambda { @sanitized_file.content_type }.should_not raise_error
-      @sanitized_file.content_type.should == 'application/msword'
+      allow(@sanitized_file).to receive(:file).and_return(@file)
+      expect { @sanitized_file.content_type }.not_to raise_error
+      expect(@sanitized_file.content_type).to eq('application/msword')
     end
 
     it 'should read content type from path if missing' do
       @sanitized_file = CarrierWave::SanitizedFile.new('llama.jpg')
-      @sanitized_file.content_type.should == 'image/jpeg'
+      expect(@sanitized_file.content_type).to eq('image/jpeg')
     end
   end
 
@@ -203,7 +203,7 @@ describe CarrierWave::SanitizedFile do
     it "sets content_type" do
       @sanitized_file = CarrierWave::SanitizedFile.new(:content_type => 'image/png')
       @sanitized_file.content_type = 'text/html'
-      @sanitized_file.content_type.should == 'text/html'
+      expect(@sanitized_file.content_type).to eq('text/html')
     end
   end
 
@@ -211,43 +211,43 @@ describe CarrierWave::SanitizedFile do
 
     describe '#empty?' do
       it "should not be empty" do
-        @sanitized_file.should_not be_empty
+        expect(@sanitized_file).not_to be_empty
       end
     end
 
     describe '#original_filename' do
       it "should return the original filename" do
-        @sanitized_file.original_filename.should == "llama.jpg"
+        expect(@sanitized_file.original_filename).to eq("llama.jpg")
       end
     end
 
     describe '#filename' do
       it "should return the filename" do
-        @sanitized_file.filename.should == "llama.jpg"
+        expect(@sanitized_file.filename).to eq("llama.jpg")
       end
     end
 
     describe '#basename' do
       it "should return the basename" do
-        @sanitized_file.basename.should == "llama"
+        expect(@sanitized_file.basename).to eq("llama")
       end
     end
 
     describe '#extension' do
       it "should return the extension" do
-        @sanitized_file.extension.should == "jpg"
+        expect(@sanitized_file.extension).to eq("jpg")
       end
     end
 
     describe "#read" do
       it "should return the contents of the file" do
-        @sanitized_file.read.should == "this is stuff"
+        expect(@sanitized_file.read).to eq("this is stuff")
       end
     end
 
     describe "#size" do
       it "should return the size of the file" do
-        @sanitized_file.size.should == 13
+        expect(@sanitized_file.size).to eq(13)
       end
     end
 
@@ -260,42 +260,42 @@ describe CarrierWave::SanitizedFile do
       it "should be moved to the correct location" do
         @sanitized_file.move_to(file_path('gurr.png'))
 
-        File.exist?( file_path('gurr.png') ).should be_true
+        expect(File.exist?( file_path('gurr.png') )).to be_true
       end
 
       it "should have changed its path when moved" do
         @sanitized_file.move_to(file_path('gurr.png'))
-        @sanitized_file.path.should == file_path('gurr.png')
+        expect(@sanitized_file.path).to eq(file_path('gurr.png'))
       end
 
       it "should have changed its filename when moved" do
         @sanitized_file.move_to(file_path('gurr.png'))
-        @sanitized_file.filename.should == 'gurr.png'
+        expect(@sanitized_file.filename).to eq('gurr.png')
       end
 
       it "should have changed its basename when moved" do
         @sanitized_file.move_to(file_path('gurr.png'))
-        @sanitized_file.basename.should == 'gurr'
+        expect(@sanitized_file.basename).to eq('gurr')
       end
 
       it "should have changed its extension when moved" do
         @sanitized_file.move_to(file_path('gurr.png'))
-        @sanitized_file.extension.should == 'png'
+        expect(@sanitized_file.extension).to eq('png')
       end
 
       it "should set the right permissions" do
         @sanitized_file.move_to(file_path('gurr.png'), 0755)
-        @sanitized_file.should have_permissions(0755)
+        expect(@sanitized_file).to have_permissions(0755)
       end
 
       it "should set the right directory permissions" do
         @sanitized_file.move_to(file_path('new_dir','gurr.png'), nil, 0775)
-        @sanitized_file.should have_directory_permissions(0775)
+        expect(@sanitized_file).to have_directory_permissions(0775)
         FileUtils.rm_rf(file_path('new_dir'))
       end
 
       it "should return itself" do
-        @sanitized_file.move_to(file_path('gurr.png')).should == @sanitized_file
+        expect(@sanitized_file.move_to(file_path('gurr.png'))).to eq(@sanitized_file)
       end
 
     end
@@ -309,58 +309,58 @@ describe CarrierWave::SanitizedFile do
       it "should be copied to the correct location" do
         @sanitized_file.copy_to(file_path('gurr.png'))
 
-        File.exist?( file_path('gurr.png') ).should be_true
+        expect(File.exist?( file_path('gurr.png') )).to be_true
 
-        file_path('gurr.png').should be_identical_to(file_path('llama.jpg'))
+        expect(file_path('gurr.png')).to be_identical_to(file_path('llama.jpg'))
       end
 
       it "should not have changed its path when copied" do
-        running { @sanitized_file.copy_to(file_path('gurr.png')) }.should_not change(@sanitized_file, :path)
+        expect(running { @sanitized_file.copy_to(file_path('gurr.png')) }).not_to change(@sanitized_file, :path)
       end
 
       it "should not have changed its filename when copied" do
-        running { @sanitized_file.copy_to(file_path('gurr.png')) }.should_not change(@sanitized_file, :filename)
+        expect(running { @sanitized_file.copy_to(file_path('gurr.png')) }).not_to change(@sanitized_file, :filename)
       end
 
       it "should return an object of the same class when copied" do
         new_file = @sanitized_file.copy_to(file_path('gurr.png'))
-        new_file.should be_an_instance_of(@sanitized_file.class)
+        expect(new_file).to be_an_instance_of(@sanitized_file.class)
       end
 
       it "should adjust the path of the object that is returned when copied" do
         new_file = @sanitized_file.copy_to(file_path('gurr.png'))
-        new_file.path.should == file_path('gurr.png')
+        expect(new_file.path).to eq(file_path('gurr.png'))
       end
 
       it "should adjust the filename of the object that is returned when copied" do
         new_file = @sanitized_file.copy_to(file_path('gurr.png'))
-        new_file.filename.should == 'gurr.png'
+        expect(new_file.filename).to eq('gurr.png')
       end
 
       it "should adjust the basename of the object that is returned when copied" do
         new_file = @sanitized_file.copy_to(file_path('gurr.png'))
-        new_file.basename.should == 'gurr'
+        expect(new_file.basename).to eq('gurr')
       end
 
       it "should adjust the extension of the object that is returned when copied" do
         new_file = @sanitized_file.copy_to(file_path('gurr.png'))
-        new_file.extension.should == 'png'
+        expect(new_file.extension).to eq('png')
       end
 
       it "should set the right permissions" do
         new_file = @sanitized_file.copy_to(file_path('gurr.png'), 0755)
-        new_file.should have_permissions(0755)
+        expect(new_file).to have_permissions(0755)
       end
 
       it "should set the right directory permissions" do
         new_file = @sanitized_file.copy_to(file_path('new_dir', 'gurr.png'), nil, 0755)
-        new_file.should have_directory_permissions(0755)
+        expect(new_file).to have_directory_permissions(0755)
         FileUtils.rm_rf(file_path('new_dir'))
       end
 
       it "should preserve the file's content type" do
         new_file = @sanitized_file.copy_to(file_path('gurr.png'))
-        new_file.content_type.should == @sanitized_file.content_type
+        expect(new_file.content_type).to eq(@sanitized_file.content_type)
       end
 
     end
@@ -370,56 +370,56 @@ describe CarrierWave::SanitizedFile do
   shared_examples_for "all valid sanitized files that are stored on disk" do
     describe '#move_to' do
       it "should not raise an error when moved to its own location" do
-        running { @sanitized_file.move_to(@sanitized_file.path) }.should_not raise_error
+        expect(running { @sanitized_file.move_to(@sanitized_file.path) }).not_to raise_error
       end
 
       it "should remove the original file" do
         original_path = @sanitized_file.path
         @sanitized_file.move_to(public_path('blah.txt'))
-        File.exist?(original_path).should be_false
+        expect(File.exist?(original_path)).to be_false
       end
     end
 
     describe '#copy_to' do
       it "should return a new instance when copied to its own location" do
-        running {
+        expect(running {
           new_file = @sanitized_file.copy_to(@sanitized_file.path)
-          new_file.should be_an_instance_of(@sanitized_file.class)
-        }.should_not raise_error
+          expect(new_file).to be_an_instance_of(@sanitized_file.class)
+        }).not_to raise_error
       end
 
       it "should not remove the original file" do
         new_file = @sanitized_file.copy_to(public_path('blah.txt'))
-        File.exist?(@sanitized_file.path).should be_true
-        File.exist?(new_file.path).should be_true
+        expect(File.exist?(@sanitized_file.path)).to be_true
+        expect(File.exist?(new_file.path)).to be_true
       end
     end
 
     describe '#exists?' do
       it "should be true" do
-        @sanitized_file.exists?.should be_true
+        expect(@sanitized_file.exists?).to be_true
       end
     end
 
     describe '#delete' do
       it "should remove it from the filesystem" do
-        File.exist?(@sanitized_file.path).should be_true
+        expect(File.exist?(@sanitized_file.path)).to be_true
         @sanitized_file.delete
-        File.exist?(@sanitized_file.path).should be_false
+        expect(File.exist?(@sanitized_file.path)).to be_false
       end
     end
 
     describe '#to_file' do
       it "should return a File object" do
-        @sanitized_file.to_file.should be_a(File)
+        expect(@sanitized_file.to_file).to be_a(File)
       end
 
       it "should have the same path as the SanitizedFile" do
-        @sanitized_file.to_file.path.should == @sanitized_file.path
+        expect(@sanitized_file.to_file.path).to eq(@sanitized_file.path)
       end
 
       it "should have the same contents as the SantizedFile" do
-        @sanitized_file.to_file.read.should == @sanitized_file.read
+        expect(@sanitized_file.to_file.read).to eq(@sanitized_file.read)
       end
     end
   end
@@ -428,12 +428,12 @@ describe CarrierWave::SanitizedFile do
 
     describe '#read' do
       it "should have an open IO object" do
-        @sanitized_file.instance_variable_get(:@file).closed?.should be_false
+        expect(@sanitized_file.instance_variable_get(:@file).closed?).to be_false
       end
 
       it "should close the IO object after reading" do
         @sanitized_file.read
-        @sanitized_file.instance_variable_get(:@file).closed?.should be_true
+        expect(@sanitized_file.instance_variable_get(:@file).closed?).to be_true
       end
     end
   end
@@ -456,14 +456,14 @@ describe CarrierWave::SanitizedFile do
 
     describe '#path' do
       it "should return the path of the tempfile" do
-        @sanitized_file.path.should_not be_nil
-        @sanitized_file.path.should == @hash["tempfile"].path
+        expect(@sanitized_file.path).not_to be_nil
+        expect(@sanitized_file.path).to eq(@hash["tempfile"].path)
       end
     end
 
     describe '#is_path?' do
       it "should be false" do
-        @sanitized_file.is_path?.should be_false
+        expect(@sanitized_file.is_path?).to be_false
       end
     end
 
@@ -483,14 +483,14 @@ describe CarrierWave::SanitizedFile do
 
     describe '#is_path?' do
       it "should be false" do
-        @sanitized_file.is_path?.should be_false
+        expect(@sanitized_file.is_path?).to be_false
       end
     end
 
     describe '#path' do
       it "should return the path of the tempfile" do
-        @sanitized_file.path.should_not be_nil
-        @sanitized_file.path.should == @tempfile.path
+        expect(@sanitized_file.path).not_to be_nil
+        expect(@sanitized_file.path).to eq(@tempfile.path)
       end
     end
 
@@ -507,31 +507,31 @@ describe CarrierWave::SanitizedFile do
 
     describe '#exists?' do
       it "should be false" do
-        @sanitized_file.exists?.should be_false
+        expect(@sanitized_file.exists?).to be_false
       end
     end
 
     describe '#is_path?' do
       it "should be false" do
-        @sanitized_file.is_path?.should be_false
+        expect(@sanitized_file.is_path?).to be_false
       end
     end
 
     describe '#path' do
       it "should be nil" do
-        @sanitized_file.path.should be_nil
+        expect(@sanitized_file.path).to be_nil
       end
     end
 
     describe '#delete' do
       it "should not raise an error" do
-        running { @sanitized_file.delete }.should_not raise_error
+        expect(running { @sanitized_file.delete }).not_to raise_error
       end
     end
 
     describe '#to_file' do
       it "should be nil" do
-        @sanitized_file.to_file.should be_nil
+        expect(@sanitized_file.to_file).to be_nil
       end
     end
 
@@ -541,7 +541,7 @@ describe CarrierWave::SanitizedFile do
     before do
       FileUtils.cp(file_path('test.jpg'), file_path('llama.jpg'))
       @sanitized_file = CarrierWave::SanitizedFile.new(stub_file('llama.jpg', 'image/jpeg'))
-      @sanitized_file.should_not be_empty
+      expect(@sanitized_file).not_to be_empty
     end
 
     it_should_behave_like "all valid sanitized files"
@@ -552,14 +552,14 @@ describe CarrierWave::SanitizedFile do
 
     describe '#is_path?' do
       it "should be false" do
-        @sanitized_file.is_path?.should be_false
+        expect(@sanitized_file.is_path?).to be_false
       end
     end
 
     describe '#path' do
       it "should return the path of the file" do
-        @sanitized_file.path.should_not be_nil
-        @sanitized_file.path.should == file_path('llama.jpg')
+        expect(@sanitized_file.path).not_to be_nil
+        expect(@sanitized_file.path).to eq(file_path('llama.jpg'))
       end
     end
 
@@ -571,7 +571,7 @@ describe CarrierWave::SanitizedFile do
       FileUtils.rm file_path('llama.jpg')
       FileUtils.touch file_path('llama.jpg')
       @sanitized_file = CarrierWave::SanitizedFile.new(stub_file('llama.jpg', 'image/jpeg'))
-      @sanitized_file.should_not be_empty
+      expect(@sanitized_file).not_to be_empty
     end
 
     it_should_behave_like "all valid sanitized files that are stored on disk"
@@ -580,14 +580,14 @@ describe CarrierWave::SanitizedFile do
 
     describe '#is_path?' do
       it "should be false" do
-        @sanitized_file.is_path?.should be_false
+        expect(@sanitized_file.is_path?).to be_false
       end
     end
 
     describe '#path' do
       it "should return the path of the file" do
-        @sanitized_file.path.should_not be_nil
-        @sanitized_file.path.should == file_path('llama.jpg')
+        expect(@sanitized_file.path).not_to be_nil
+        expect(@sanitized_file.path).to eq(file_path('llama.jpg'))
       end
     end
 
@@ -597,7 +597,7 @@ describe CarrierWave::SanitizedFile do
     before do
       FileUtils.cp(file_path('test.jpg'), file_path('llama.jpg'))
       @sanitized_file = CarrierWave::SanitizedFile.new(file_path('llama.jpg'))
-      @sanitized_file.should_not be_empty
+      expect(@sanitized_file).not_to be_empty
     end
 
     it_should_behave_like "all valid sanitized files"
@@ -606,14 +606,14 @@ describe CarrierWave::SanitizedFile do
 
     describe '#is_path?' do
       it "should be true" do
-        @sanitized_file.is_path?.should be_true
+        expect(@sanitized_file.is_path?).to be_true
       end
     end
 
     describe '#path' do
       it "should return the path of the file" do
-        @sanitized_file.path.should_not be_nil
-        @sanitized_file.path.should == file_path('llama.jpg')
+        expect(@sanitized_file.path).not_to be_nil
+        expect(@sanitized_file.path).to eq(file_path('llama.jpg'))
       end
     end
 
@@ -623,7 +623,7 @@ describe CarrierWave::SanitizedFile do
     before do
       FileUtils.copy_file(file_path('test.jpg'), file_path('llama.jpg'))
       @sanitized_file = CarrierWave::SanitizedFile.new(Pathname.new(file_path('llama.jpg')))
-      @sanitized_file.should_not be_empty
+      expect(@sanitized_file).not_to be_empty
     end
 
     it_should_behave_like "all valid sanitized files"
@@ -632,14 +632,14 @@ describe CarrierWave::SanitizedFile do
 
     describe '#is_path?' do
       it "should be true" do
-        @sanitized_file.is_path?.should be_true
+        expect(@sanitized_file.is_path?).to be_true
       end
     end
 
     describe '#path' do
       it "should return the path of the file" do
-        @sanitized_file.path.should_not be_nil
-        @sanitized_file.path.should == file_path('llama.jpg')
+        expect(@sanitized_file.path).not_to be_nil
+        expect(@sanitized_file.path).to eq(file_path('llama.jpg'))
       end
     end
 
@@ -652,67 +652,67 @@ describe CarrierWave::SanitizedFile do
 
     describe '#empty?' do
       it "should be true" do
-        @empty.should be_empty
+        expect(@empty).to be_empty
       end
     end
 
     describe '#exists?' do
       it "should be false" do
-        @empty.exists?.should be_false
+        expect(@empty.exists?).to be_false
       end
     end
 
     describe '#is_path?' do
       it "should be false" do
-        @empty.is_path?.should be_false
+        expect(@empty.is_path?).to be_false
       end
     end
 
     describe '#size' do
       it "should be zero" do
-        @empty.size.should be_zero
+        expect(@empty.size).to be_zero
       end
     end
 
     describe '#path' do
       it "should be nil" do
-        @empty.path.should be_nil
+        expect(@empty.path).to be_nil
       end
     end
 
     describe '#original_filename' do
       it "should be nil" do
-        @empty.original_filename.should be_nil
+        expect(@empty.original_filename).to be_nil
       end
     end
 
     describe '#filename' do
       it "should be nil" do
-        @empty.filename.should be_nil
+        expect(@empty.filename).to be_nil
       end
     end
 
     describe '#basename' do
       it "should be nil" do
-        @empty.basename.should be_nil
+        expect(@empty.basename).to be_nil
       end
     end
 
     describe '#extension' do
       it "should be nil" do
-        @empty.extension.should be_nil
+        expect(@empty.extension).to be_nil
       end
     end
 
     describe '#delete' do
       it "should not raise an error" do
-        running { @empty.delete }.should_not raise_error
+        expect(running { @empty.delete }).not_to raise_error
       end
     end
 
     describe '#to_file' do
       it "should be nil" do
-        @empty.to_file.should be_nil
+        expect(@empty.to_file).to be_nil
       end
     end
   end
@@ -724,67 +724,67 @@ describe CarrierWave::SanitizedFile do
 
     describe '#empty?' do
       it "should be true" do
-        @empty.should be_empty
+        expect(@empty).to be_empty
       end
     end
 
     describe '#exists?' do
       it "should be false" do
-        @empty.exists?.should be_false
+        expect(@empty.exists?).to be_false
       end
     end
 
     describe '#is_path?' do
       it "should be false" do
-        @empty.is_path?.should be_false
+        expect(@empty.is_path?).to be_false
       end
     end
 
     describe '#size' do
       it "should be zero" do
-        @empty.size.should be_zero
+        expect(@empty.size).to be_zero
       end
     end
 
     describe '#path' do
       it "should be nil" do
-        @empty.path.should be_nil
+        expect(@empty.path).to be_nil
       end
     end
 
     describe '#original_filename' do
       it "should be nil" do
-        @empty.original_filename.should be_nil
+        expect(@empty.original_filename).to be_nil
       end
     end
 
     describe '#filename' do
       it "should be nil" do
-        @empty.filename.should be_nil
+        expect(@empty.filename).to be_nil
       end
     end
 
     describe '#basename' do
       it "should be nil" do
-        @empty.basename.should be_nil
+        expect(@empty.basename).to be_nil
       end
     end
 
     describe '#extension' do
       it "should be nil" do
-        @empty.extension.should be_nil
+        expect(@empty.extension).to be_nil
       end
     end
 
     describe '#delete' do
       it "should not raise an error" do
-        running { @empty.delete }.should_not raise_error
+        expect(running { @empty.delete }).not_to raise_error
       end
     end
 
     describe '#to_file' do
       it "should be nil" do
-        @empty.to_file.should be_nil
+        expect(@empty.to_file).to be_nil
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,8 +49,8 @@ module CarrierWave
   module Test
     module MockStorage
       def mock_storage(kind)
-        storage = mock("storage for #{kind} uploader")
-        storage.stub!(:setup!)
+        storage = double("storage for #{kind} uploader")
+        allow(storage).to receive(:setup!)
         storage
       end
     end
@@ -87,7 +87,7 @@ module CarrierWave
         else
           t = StringIO.new
         end
-        t.stub!(:local_path => "",
+        t.stub(:local_path => "",
                 :original_filename => filename || fake_name,
                 :content_type => mime_type)
         return t

--- a/spec/storage/file_spec.rb
+++ b/spec/storage/file_spec.rb
@@ -29,12 +29,12 @@ describe CarrierWave::Storage::File do
 
       it "should not delete the old cache_id" do
         @uploader.store!
-        File.should be_directory(@cache_id_dir)
+        expect(File).to be_directory(@cache_id_dir)
       end
 
       it "should not delete other existing files in old cache_id dir" do
         @uploader.store!
-        File.should exist @existing_file
+        expect(File).to exist @existing_file
       end
     end
   end
@@ -57,21 +57,21 @@ describe CarrierWave::Storage::File do
       Timecop.freeze(Time.at(1370261522)) do
         @uploader_class.clean_cached_files!
       end
-      Dir.glob("#{@cache_dir}/*").size.should == 1
+      expect(Dir.glob("#{@cache_dir}/*").size).to eq(1)
     end
 
     it "should permit to set since how many seconds delete the cached files" do
       Timecop.freeze(Time.at(1370261522)) do
         @uploader_class.clean_cached_files!(60*60*24*4)
       end
-      Dir.glob("#{@cache_dir}/*").size.should == 2
+      expect(Dir.glob("#{@cache_dir}/*").size).to eq(2)
     end
 
     it "should be aliased on the CarrierWave module" do
       Timecop.freeze(Time.at(1370261522)) do
         CarrierWave.clean_cached_files!
       end
-      Dir.glob("#{@cache_dir}/*").size.should == 1
+      expect(Dir.glob("#{@cache_dir}/*").size).to eq(1)
     end
   end
 end

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -1,9 +1,7 @@
 def fog_tests(fog_credentials)
-  describe CarrierWave::Storage::Fog do
-    describe fog_credentials[:provider] do
-
-      shared_examples_for "#{fog_credentials[:provider]} storage" do
-
+  shared_examples_for "#{fog_credentials[:provider]} storage" do
+    describe CarrierWave::Storage::Fog do
+      describe fog_credentials[:provider] do
         before do
           CarrierWave.configure do |config|
             config.reset_config
@@ -15,17 +13,17 @@ def fog_tests(fog_credentials)
             config.cache_storage = :fog
           end
 
-          eval <<-RUBY
-class FogSpec#{fog_credentials[:provider]}Uploader < CarrierWave::Uploader::Base
-  storage :fog
-end
+          eval <<-RUBY.strip_heredoc.chomp
+            class FogSpec#{fog_credentials[:provider]}Uploader < CarrierWave::Uploader::Base
+              storage :fog
+            end
           RUBY
 
           @provider = fog_credentials[:provider]
 
           # @uploader = FogSpecUploader.new
           @uploader = eval("FogSpec#{@provider}Uploader")
-          @uploader.stub!(:store_path).and_return('uploads/test.jpg')
+          allow(@uploader).to receive(:store_path).and_return('uploads/test.jpg')
 
           @storage = CarrierWave::Storage::Fog.new(@uploader)
           @directory = @storage.connection.directories.get(CARRIERWAVE_DIRECTORY) || @storage.connection.directories.create(:key => CARRIERWAVE_DIRECTORY, :public => true)
@@ -41,7 +39,7 @@ end
           it "should cache_stored_file! after store!" do
             uploader = @uploader.new
             uploader.store!(file)
-            lambda { uploader.cache_stored_file! }.should_not raise_error
+            expect { uploader.cache_stored_file! }.not_to raise_error
           end
         end
 
@@ -50,77 +48,77 @@ end
           let(:store_path) { 'uploads/test+.jpg' }
 
           before do
-            @uploader.stub!(:store_path).and_return(store_path)
+            allow(@uploader).to receive(:store_path).and_return(store_path)
             @fog_file = @storage.store!(file)
           end
 
           it "should upload the file" do
-            @directory.files.get(store_path).body.should == 'this is stuff'
+            expect(@directory.files.get(store_path).body).to eq('this is stuff')
           end
 
           it "should have a path" do
-            @fog_file.path.should == store_path
+            expect(@fog_file.path).to eq(store_path)
           end
 
           it "should have a content_type" do
-            @fog_file.content_type.should == 'image/jpeg'
-            @directory.files.get(store_path).content_type.should == 'image/jpeg'
+            expect(@fog_file.content_type).to eq('image/jpeg')
+            expect(@directory.files.get(store_path).content_type).to eq('image/jpeg')
           end
 
           it "should have an extension" do
-            @fog_file.extension.should == "jpg"
+            expect(@fog_file.extension).to eq("jpg")
           end
 
           context "without asset_host" do
             it "should have a public_url" do
               unless fog_credentials[:provider] == 'Local'
-                @fog_file.public_url.should_not be_nil
+                expect(@fog_file.public_url).not_to be_nil
               end
             end
 
             it "should have a url" do
               unless fog_credentials[:provider] == 'Local'
-                @fog_file.url.should_not be_nil
+                expect(@fog_file.url).not_to be_nil
               end
             end
 
             it "should use a subdomain URL for AWS if the directory is a valid subdomain" do
               if @provider == 'AWS'
-                @uploader.stub(:fog_directory).and_return('assets.site.com')
-                @fog_file.public_url.should include('https://assets.site.com.s3.amazonaws.com')
+                allow(@uploader).to receive(:fog_directory).and_return('assets.site.com')
+                expect(@fog_file.public_url).to include('https://assets.site.com.s3.amazonaws.com')
               end
             end
 
             it "should not use a subdomain URL for AWS if the directory is not a valid subdomain" do
               if @provider == 'AWS'
-                @uploader.stub(:fog_directory).and_return('SiteAssets')
-                @fog_file.public_url.should include('https://s3.amazonaws.com/SiteAssets')
+                allow(@uploader).to receive(:fog_directory).and_return('SiteAssets')
+                expect(@fog_file.public_url).to include('https://s3.amazonaws.com/SiteAssets')
               end
             end
 
             it "should use https as a default protocol" do
               if @provider == 'AWS'
-                @fog_file.public_url.should start_with 'https://'
+                expect(@fog_file.public_url).to start_with 'https://'
               end
             end
 
             it "should use https as a default protocol" do
               if @provider == 'AWS'
-                @uploader.stub(:fog_use_ssl_for_aws).and_return(false)
-                @fog_file.public_url.should start_with 'http://'
+                allow(@uploader).to receive(:fog_use_ssl_for_aws).and_return(false)
+                expect(@fog_file.public_url).to start_with 'http://'
               end
             end
           end
 
           context "with asset_host" do
-            before { @uploader.stub(:asset_host).and_return(asset_host) }
+            before { allow(@uploader).to receive(:asset_host).and_return(asset_host) }
 
             context "when a asset_host is a proc" do
 
               let(:asset_host) { proc { "http://foo.bar" } }
 
               describe "args passed to proc" do
-                let(:asset_host) { proc { |storage| storage.should be_instance_of ::CarrierWave::Storage::Fog::File } }
+                let(:asset_host) { proc { |storage| expect(storage).to be_instance_of ::CarrierWave::Storage::Fog::File } }
 
                 it "should be the uploader" do
                   @fog_file.public_url
@@ -128,20 +126,20 @@ end
               end
 
               it "should have a asset_host rooted public_url" do
-                @fog_file.public_url.should == 'http://foo.bar/uploads/test%2B.jpg'
+                expect(@fog_file.public_url).to eq('http://foo.bar/uploads/test%2B.jpg')
               end
 
               it "should have a asset_host rooted url" do
-                @fog_file.url.should == 'http://foo.bar/uploads/test%2B.jpg'
+                expect(@fog_file.url).to eq('http://foo.bar/uploads/test%2B.jpg')
               end
 
               it "should always have the same asset_host rooted url" do
-                @fog_file.url.should == 'http://foo.bar/uploads/test%2B.jpg'
-                @fog_file.url.should == 'http://foo.bar/uploads/test%2B.jpg'
+                expect(@fog_file.url).to eq('http://foo.bar/uploads/test%2B.jpg')
+                expect(@fog_file.url).to eq('http://foo.bar/uploads/test%2B.jpg')
               end
 
               it 'should retrieve file name' do
-                @fog_file.filename.should == 'test+.jpg'
+                expect(@fog_file.filename).to eq('test+.jpg')
               end
             end
 
@@ -149,16 +147,16 @@ end
               let(:asset_host) { "http://foo.bar" }
 
               it "should have a asset_host rooted public_url" do
-                @fog_file.public_url.should == 'http://foo.bar/uploads/test%2B.jpg'
+                expect(@fog_file.public_url).to eq('http://foo.bar/uploads/test%2B.jpg')
               end
 
               it "should have a asset_host rooted url" do
-                @fog_file.url.should == 'http://foo.bar/uploads/test%2B.jpg'
+                expect(@fog_file.url).to eq('http://foo.bar/uploads/test%2B.jpg')
               end
 
               it "should always have the same asset_host rooted url" do
-                @fog_file.url.should == 'http://foo.bar/uploads/test%2B.jpg'
-                @fog_file.url.should == 'http://foo.bar/uploads/test%2B.jpg'
+                expect(@fog_file.url).to eq('http://foo.bar/uploads/test%2B.jpg')
+                expect(@fog_file.url).to eq('http://foo.bar/uploads/test%2B.jpg')
               end
             end
 
@@ -169,78 +167,78 @@ end
             let(:store_path) { 'uploads/test' }
 
             it "should have no extension" do
-              @fog_file.extension.should be_nil
+              expect(@fog_file.extension).to be_nil
             end
 
           end
 
           it "should return filesize" do
-            @fog_file.size.should == 13
+            expect(@fog_file.size).to eq(13)
           end
 
           it "should be deletable" do
             @fog_file.delete
-            @directory.files.head(store_path).should == nil
+            expect(@directory.files.head(store_path)).to eq(nil)
           end
         end
 
         describe '#retrieve!' do
           before do
             @directory.files.create(:key => 'uploads/test.jpg', :body => 'A test, 1234', :public => true)
-            @uploader.stub!(:store_path).with('test.jpg').and_return('uploads/test.jpg')
+            allow(@uploader).to receive(:store_path).with('test.jpg').and_return('uploads/test.jpg')
             @fog_file = @storage.retrieve!('test.jpg')
           end
 
           it "should retrieve the file contents" do
-            @fog_file.read.chomp.should == "A test, 1234"
+            expect(@fog_file.read.chomp).to eq("A test, 1234")
           end
 
           it "should have a path" do
-            @fog_file.path.should == 'uploads/test.jpg'
+            expect(@fog_file.path).to eq('uploads/test.jpg')
           end
 
           it "should have a public url" do
             unless fog_credentials[:provider] == 'Local'
-              @fog_file.public_url.should_not be_nil
+              expect(@fog_file.public_url).not_to be_nil
             end
           end
 
           it "should return filesize" do
-            @fog_file.size.should == 12
+            expect(@fog_file.size).to eq(12)
           end
 
           it "should be deletable" do
             @fog_file.delete
-            @directory.files.head('uploads/test.jpg').should == nil
+            expect(@directory.files.head('uploads/test.jpg')).to eq(nil)
           end
         end
 
         describe '#cache!' do
           before do
-            @uploader.stub!(:cache_path).and_return('uploads/tmp/test+.jpg')
+            allow(@uploader).to receive(:cache_path).and_return('uploads/tmp/test+.jpg')
             @fog_file = @storage.cache!(file)
           end
 
           it "should upload the file" do
-            @directory.files.get('uploads/tmp/test+.jpg').body.should == 'this is stuff'
+            expect(@directory.files.get('uploads/tmp/test+.jpg').body).to eq('this is stuff')
           end
         end
 
         describe '#retrieve_from_cache!' do
           before do
             @directory.files.create(:key => 'uploads/tmp/test.jpg', :body => 'A test, 1234', :public => true)
-            @uploader.stub!(:cache_path).with('test.jpg').and_return('uploads/tmp/test.jpg')
+            allow(@uploader).to receive(:cache_path).with('test.jpg').and_return('uploads/tmp/test.jpg')
             @fog_file = @storage.retrieve_from_cache!('test.jpg')
           end
 
           it "should retrieve the file contents" do
-            @fog_file.read.chomp.should == "A test, 1234"
+            expect(@fog_file.read.chomp).to eq("A test, 1234")
           end
         end
 
         describe '#delete_dir' do
           it "should do nothing" do
-            running{ @storage.delete_dir!('foobar') }.should_not raise_error
+            expect(running{ @storage.delete_dir!('foobar') }).not_to raise_error
           end
         end
 
@@ -263,21 +261,21 @@ end
             Timecop.freeze(Time.at(now)) do
               @uploader.clean_cached_files!
             end
-            @directory.files.all(:prefix => 'uploads/tmp').size.should == 1
+            expect(@directory.files.all(:prefix => 'uploads/tmp').size).to eq(1)
           end
 
           it "should permit to set since how many seconds delete the cached files" do
             Timecop.freeze(Time.at(now)) do
               @uploader.clean_cached_files!(60*60*24*4)
             end
-            @directory.files.all(:prefix => 'uploads/tmp').size.should == 2
+            expect(@directory.files.all(:prefix => 'uploads/tmp').size).to eq(2)
           end
 
           it "should be aliased on the CarrierWave module" do
             Timecop.freeze(Time.at(now)) do
               CarrierWave.clean_cached_files!
             end
-            @directory.files.all(:prefix => 'uploads/tmp').size.should == 1
+            expect(@directory.files.all(:prefix => 'uploads/tmp').size).to eq(1)
           end
         end
 
@@ -287,8 +285,8 @@ end
             before do
               directory_key = "#{CARRIERWAVE_DIRECTORY}public"
               @directory = @storage.connection.directories.create(:key => directory_key, :public => true)
-              @uploader.stub!(:fog_directory).and_return(directory_key)
-              @uploader.stub!(:store_path).and_return('uploads/public.txt')
+              allow(@uploader).to receive(:fog_directory).and_return(directory_key)
+              allow(@uploader).to receive(:store_path).and_return('uploads/public.txt')
               @fog_file = @storage.store!(file)
             end
 
@@ -300,7 +298,7 @@ end
 
             it "should be available at public URL" do
               unless Fog.mocking? || fog_credentials[:provider] == 'Local'
-                open(@fog_file.public_url).read.should == 'this is stuff'
+                expect(open(@fog_file.public_url).read).to eq('this is stuff')
               end
             end
           end
@@ -309,9 +307,9 @@ end
             before do
               directory_key = "#{CARRIERWAVE_DIRECTORY}private"
               @directory = @storage.connection.directories.create(:key => directory_key, :public => true)
-              @uploader.stub!(:fog_directory).and_return(directory_key)
-              @uploader.stub!(:fog_public).and_return(false)
-              @uploader.stub!(:store_path).and_return('uploads/private.txt')
+              allow(@uploader).to receive(:fog_directory).and_return(directory_key)
+              allow(@uploader).to receive(:fog_public).and_return(false)
+              allow(@uploader).to receive(:store_path).and_return('uploads/private.txt')
               @fog_file = @storage.store!(file)
             end
 
@@ -323,24 +321,24 @@ end
 
             it "should not be available at public URL" do
               unless Fog.mocking? || fog_credentials[:provider] == 'Local'
-                running{ open(@fog_file.public_url) }.should raise_error
+                expect(running{ open(@fog_file.public_url) }).to raise_error
               end
             end
 
             it "should have an authenticated_url" do
               if ['AWS', 'Rackspace', 'Google', 'OpenStack'].include?(@provider)
-                @fog_file.authenticated_url.should_not be_nil
+                expect(@fog_file.authenticated_url).not_to be_nil
               end
             end
 
             it 'should generate correct filename' do
-              @fog_file.filename.should == 'private.txt'
+              expect(@fog_file.filename).to eq('private.txt')
             end
 
             it "should handle query params" do
               if @provider == 'AWS' && !Fog.mocking?
                 headers = Excon.get(@fog_file.url(:query => {"response-content-disposition" => "attachment"})).headers
-                headers["Content-Disposition"].should == "attachment"
+                expect(headers["Content-Disposition"]).to eq("attachment")
               end
             end
           end
@@ -412,6 +410,5 @@ end
 
       it_should_behave_like "#{fog_credentials[:provider]} storage"
     end
-
   end
 end

--- a/spec/storage/fog_spec.rb
+++ b/spec/storage/fog_spec.rb
@@ -12,21 +12,21 @@ describe CarrierWave::Storage::Fog::File do
 
     context "with normal url" do
       before do
-        subject.stub!(:url).and_return{ 'http://example.com/path/to/foo.txt' }
+        allow(subject).to receive(:url){ 'http://example.com/path/to/foo.txt' }
       end
 
       it "should extract filename from url" do
-        subject.filename.should == 'foo.txt'
+        expect(subject.filename).to eq('foo.txt')
       end
     end
 
     context "when url contains '/' in query string" do
       before do
-        subject.stub!(:url).and_return{ 'http://example.com/path/to/foo.txt?bar=baz/fubar' }
+        allow(subject).to receive(:url){ 'http://example.com/path/to/foo.txt?bar=baz/fubar' }
       end
 
       it "should extract correct part" do
-        subject.filename.should == 'foo.txt'
+        expect(subject.filename).to eq('foo.txt')
       end
     end
   end

--- a/spec/uploader/cache_spec.rb
+++ b/spec/uploader/cache_spec.rb
@@ -16,57 +16,57 @@ describe CarrierWave::Uploader do
 
   describe '#cache_dir' do
     it "should default to the config option" do
-      @uploader.cache_dir.should == 'uploads/tmp'
+      expect(@uploader.cache_dir).to eq('uploads/tmp')
     end
   end
 
   describe '#cache!' do
 
     before do
-      CarrierWave.stub!(:generate_cache_id).and_return('1369894322-345-2255')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
     end
 
     it "should cache a file" do
       @uploader.cache!(File.open(file_path('test.jpg')))
-      @uploader.file.should be_an_instance_of(CarrierWave::SanitizedFile)
+      expect(@uploader.file).to be_an_instance_of(CarrierWave::SanitizedFile)
     end
 
     it "should be cached" do
       @uploader.cache!(File.open(file_path('test.jpg')))
-      @uploader.should be_cached
+      expect(@uploader).to be_cached
     end
 
     it "should store the cache name" do
       @uploader.cache!(File.open(file_path('test.jpg')))
-      @uploader.cache_name.should == '1369894322-345-2255/test.jpg'
+      expect(@uploader.cache_name).to eq('1369894322-345-2255/test.jpg')
     end
 
     it "should set the filename to the file's sanitized filename" do
       @uploader.cache!(File.open(file_path('test.jpg')))
-      @uploader.filename.should == 'test.jpg'
+      expect(@uploader.filename).to eq('test.jpg')
     end
 
     it "should move it to the tmp dir" do
       @uploader.cache!(File.open(file_path('test.jpg')))
-      @uploader.file.path.should == public_path('uploads/tmp/1369894322-345-2255/test.jpg')
-      @uploader.file.exists?.should be_true
+      expect(@uploader.file.path).to eq(public_path('uploads/tmp/1369894322-345-2255/test.jpg'))
+      expect(@uploader.file.exists?).to be_true
     end
 
     it "should set the url" do
       @uploader.cache!(File.open(file_path('test.jpg')))
-      @uploader.url.should == '/uploads/tmp/1369894322-345-2255/test.jpg'
+      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-2255/test.jpg')
     end
 
     it "should raise an error when trying to cache a string" do
-      running {
+      expect(running {
         @uploader.cache!(file_path('test.jpg'))
-      }.should raise_error(CarrierWave::FormNotMultipart)
+      }).to raise_error(CarrierWave::FormNotMultipart)
     end
 
     it "should raise an error when trying to cache a pathname" do
-      running {
+      expect(running {
         @uploader.cache!(Pathname.new(file_path('test.jpg')))
-      }.should raise_error(CarrierWave::FormNotMultipart)
+      }).to raise_error(CarrierWave::FormNotMultipart)
     end
 
     it "should do nothing when trying to cache an empty file" do
@@ -77,14 +77,14 @@ describe CarrierWave::Uploader do
       @uploader_class.permissions = 0777
 
       @uploader.cache!(File.open(file_path('test.jpg')))
-      @uploader.should have_permissions(0777)
+      expect(@uploader).to have_permissions(0777)
     end
 
     it "should set directory permissions if options are given" do
       @uploader_class.directory_permissions = 0777
 
       @uploader.cache!(File.open(file_path('test.jpg')))
-      @uploader.should have_directory_permissions(0777)
+      expect(@uploader).to have_directory_permissions(0777)
     end
 
     describe "with ensuring multipart form deactivated" do
@@ -96,15 +96,15 @@ describe CarrierWave::Uploader do
       end
 
       it "should not raise an error when trying to cache a string" do
-        running {
+        expect(running {
           @uploader.cache!(file_path('test.jpg'))
-        }.should_not raise_error(CarrierWave::FormNotMultipart)
+        }).not_to raise_error
       end
 
       it "should raise an error when trying to cache a pathname and " do
-        running {
+        expect(running {
           @uploader.cache!(Pathname.new(file_path('test.jpg')))
-        }.should_not raise_error(CarrierWave::FormNotMultipart)
+        }).not_to raise_error
       end
 
     end
@@ -120,7 +120,7 @@ describe CarrierWave::Uploader do
         @tmpfile = File.open(tmpfile)
 
         ## stub
-        CarrierWave.stub!(:generate_cache_id).and_return('1369894322-345-2255')
+        allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
 
         @cached_path = public_path('uploads/tmp/1369894322-345-2255/test_move.jpeg')
         @workfile_path = tmp_path('1369894322-345-2255/test_move.jpeg')
@@ -140,20 +140,20 @@ describe CarrierWave::Uploader do
         it "should move it from the upload dir to the tmp dir" do
           original_path = @tmpfile.path
           @uploader.cache!(@tmpfile)
-          @uploader.file.path.should == @cached_path
-          File.exist?(@cached_path).should be_true
-          File.exist?(original_path).should be_false
+          expect(@uploader.file.path).to eq(@cached_path)
+          expect(File.exist?(@cached_path)).to be_true
+          expect(File.exist?(original_path)).to be_false
         end
 
         it "should use move_to() during cache!()" do
           moved_file = double('moved file').as_null_object
-          CarrierWave::SanitizedFile.any_instance.should_receive(:move_to).with(@workfile_path, 0777, 0777).and_return(moved_file)
-          moved_file.should_receive(:move_to).with(@cached_path, 0777, 0777, true)
+          expect_any_instance_of(CarrierWave::SanitizedFile).to receive(:move_to).with(@workfile_path, 0777, 0777).and_return(moved_file)
+          expect(moved_file).to receive(:move_to).with(@cached_path, 0777, 0777, true)
           @uploader.cache!(@tmpfile)
         end
 
         it "should not use copy_to() during cache!()" do
-          CarrierWave::SanitizedFile.any_instance.should_not_receive(:copy_to)
+          expect_any_instance_of(CarrierWave::SanitizedFile).not_to receive(:copy_to)
           @uploader.cache!(@tmpfile)
         end
       end
@@ -166,20 +166,20 @@ describe CarrierWave::Uploader do
         it "should copy it from the upload dir to the tmp dir" do
           original_path = @tmpfile.path
           @uploader.cache!(@tmpfile)
-          @uploader.file.path.should == @cached_path
-          File.exist?(@cached_path).should be_true
-          File.exist?(original_path).should be_true
+          expect(@uploader.file.path).to eq(@cached_path)
+          expect(File.exist?(@cached_path)).to be_true
+          expect(File.exist?(original_path)).to be_true
         end
 
         it "should use copy_to() during cache!()" do
           moved_file = double('moved file').as_null_object
-          CarrierWave::SanitizedFile.any_instance.should_receive(:copy_to).with(@workfile_path, 0777, 0777).and_return(moved_file)
-          moved_file.should_receive(:move_to).with(@cached_path, 0777, 0777, true)
+          expect_any_instance_of(CarrierWave::SanitizedFile).to receive(:copy_to).with(@workfile_path, 0777, 0777).and_return(moved_file)
+          expect(moved_file).to receive(:move_to).with(@cached_path, 0777, 0777, true)
           @uploader.cache!(@tmpfile)
         end
 
         it "should not use move_to() in moving to temporary location during cache!()" do
-          CarrierWave::SanitizedFile.any_instance.should_not_receive(:move_to).with(@workfile_path, 0777, 0777)
+          expect_any_instance_of(CarrierWave::SanitizedFile).not_to receive(:move_to).with(@workfile_path, 0777, 0777)
           @uploader.cache!(@tmpfile)
         end
       end
@@ -190,61 +190,61 @@ describe CarrierWave::Uploader do
   describe '#retrieve_from_cache!' do
     it "should cache a file" do
       @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpeg')
-      @uploader.file.should be_an_instance_of(CarrierWave::SanitizedFile)
+      expect(@uploader.file).to be_an_instance_of(CarrierWave::SanitizedFile)
     end
 
     it "should be cached" do
       @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpeg')
-      @uploader.should be_cached
+      expect(@uploader).to be_cached
     end
 
     it "should set the path to the tmp dir" do
       @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpeg')
-      @uploader.current_path.should == public_path('uploads/tmp/1369894322-345-2255/test.jpeg')
+      expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/test.jpeg'))
     end
 
     it "should overwrite a file that has already been cached" do
       @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpeg')
       @uploader.retrieve_from_cache!('1369894322-345-2255/bork.txt')
-      @uploader.current_path.should == public_path('uploads/tmp/1369894322-345-2255/bork.txt')
+      expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/bork.txt'))
     end
 
     it "should store the cache_name" do
       @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpeg')
-      @uploader.cache_name.should == '1369894322-345-2255/test.jpeg'
+      expect(@uploader.cache_name).to eq('1369894322-345-2255/test.jpeg')
     end
 
     it "should store the filename" do
       @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpeg')
-      @uploader.filename.should == 'test.jpeg'
+      expect(@uploader.filename).to eq('test.jpeg')
     end
 
     it "should set the url" do
       @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpeg')
-      @uploader.url.should == '/uploads/tmp/1369894322-345-2255/test.jpeg'
+      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-2255/test.jpeg')
     end
 
     it "should raise an error when the cache_id has an invalid format" do
-      running {
+      expect(running {
         @uploader.retrieve_from_cache!('12345/test.jpeg')
-      }.should raise_error(CarrierWave::InvalidParameter)
+      }).to raise_error(CarrierWave::InvalidParameter)
 
-      @uploader.file.should be_nil
-      @uploader.filename.should be_nil
-      @uploader.cache_name.should be_nil
+      expect(@uploader.file).to be_nil
+      expect(@uploader.filename).to be_nil
+      expect(@uploader.cache_name).to be_nil
     end
 
     it "should raise an error when the original_filename contains invalid characters" do
-      running {
+      expect(running {
         @uploader.retrieve_from_cache!('1369894322-345-2255/te/st.jpeg')
-      }.should raise_error(CarrierWave::InvalidParameter)
-      running {
+      }).to raise_error(CarrierWave::InvalidParameter)
+      expect(running {
         @uploader.retrieve_from_cache!('1369894322-345-2255/te??%st.jpeg')
-      }.should raise_error(CarrierWave::InvalidParameter)
+      }).to raise_error(CarrierWave::InvalidParameter)
 
-      @uploader.file.should be_nil
-      @uploader.filename.should be_nil
-      @uploader.cache_name.should be_nil
+      expect(@uploader.file).to be_nil
+      expect(@uploader.filename).to be_nil
+      expect(@uploader.cache_name).to be_nil
     end
   end
 
@@ -260,37 +260,37 @@ describe CarrierWave::Uploader do
     describe '#cache!' do
 
       before do
-        CarrierWave.stub!(:generate_cache_id).and_return('1369894322-345-2255')
+        allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
       end
 
       it "should set the filename to the file's reversed filename" do
         @uploader.cache!(File.open(file_path('test.jpg')))
-        @uploader.filename.should == "gpj.tset"
+        expect(@uploader.filename).to eq("gpj.tset")
       end
 
       it "should move it to the tmp dir with the filename unreversed" do
         @uploader.cache!(File.open(file_path('test.jpg')))
-        @uploader.current_path.should == public_path('uploads/tmp/1369894322-345-2255/test.jpg')
-        @uploader.file.exists?.should be_true
+        expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/test.jpg'))
+        expect(@uploader.file.exists?).to be_true
       end
     end
 
     describe '#retrieve_from_cache!' do
       it "should set the path to the tmp dir" do
         @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpg')
-        @uploader.current_path.should == public_path('uploads/tmp/1369894322-345-2255/test.jpg')
+        expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/test.jpg'))
       end
 
       it "should set the filename to the reversed name of the file" do
         @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpg')
-        @uploader.filename.should == "gpj.tset"
+        expect(@uploader.filename).to eq("gpj.tset")
       end
     end
   end
   describe '.generate_cache_id' do
     it 'should generate dir name bsed on UTC time' do
       Timecop.travel(Time.at(1369896000)) do
-        CarrierWave.generate_cache_id.should match(/\A1369896000-\d+-\d+\Z/)
+        expect(CarrierWave.generate_cache_id).to match(/\A1369896000-\d+-\d+\Z/)
       end
     end
   end

--- a/spec/uploader/callback_spec.rb
+++ b/spec/uploader/callback_spec.rb
@@ -8,16 +8,16 @@ describe CarrierWave::Uploader do
     @uploader_class_1 = Class.new(CarrierWave::Uploader::Base)
 
     # First Uploader only has default before-callback
-    @uploader_class_1._before_callbacks[:cache].should == [:check_whitelist!, :check_blacklist!, :process!]
+    expect(@uploader_class_1._before_callbacks[:cache]).to eq([:check_whitelist!, :check_blacklist!, :process!])
 
     @uploader_class_2 = Class.new(CarrierWave::Uploader::Base)
     @uploader_class_2.before :cache, :before_cache_callback
 
     # Second Uploader defined with another callback
-    @uploader_class_2._before_callbacks[:cache].should == [:check_whitelist!, :check_blacklist!, :process!, :before_cache_callback]
+    expect(@uploader_class_2._before_callbacks[:cache]).to eq([:check_whitelist!, :check_blacklist!, :process!, :before_cache_callback])
 
     # Make sure the first Uploader doesn't inherit the same callback
-    @uploader_class_1._before_callbacks[:cache].should == [:check_whitelist!, :check_blacklist!, :process!]
+    expect(@uploader_class_1._before_callbacks[:cache]).to eq([:check_whitelist!, :check_blacklist!, :process!])
   end
 
 

--- a/spec/uploader/configuration_spec.rb
+++ b/spec/uploader/configuration_spec.rb
@@ -14,7 +14,7 @@ describe CarrierWave do
       CarrierWave.configure do |config|
         config.test_config = "foo"
       end
-      CarrierWave::Uploader::Base.test_config.should == 'foo'
+      expect(CarrierWave::Uploader::Base.test_config).to eq('foo')
     end
   end
 end
@@ -30,38 +30,38 @@ describe CarrierWave::Uploader::Base do
       @uploader_class.configure do |config|
         config.foo_bar = "monkey"
       end
-      @uploader_class.foo_bar.should == 'monkey'
+      expect(@uploader_class.foo_bar).to eq('monkey')
     end
   end
 
   describe ".storage" do
     it "should set the storage if an argument is given" do
-      storage = mock('some kind of storage')
+      storage = double('some kind of storage')
       @uploader_class.storage storage
-      @uploader_class.storage.should == storage
+      expect(@uploader_class.storage).to eq(storage)
     end
 
     it "should default to file" do
-      @uploader_class.storage.should == CarrierWave::Storage::File
+      expect(@uploader_class.storage).to eq(CarrierWave::Storage::File)
     end
 
     it "should set the storage from the configured shortcuts if a symbol is given" do
       @uploader_class.storage :file
-      @uploader_class.storage.should == CarrierWave::Storage::File
+      expect(@uploader_class.storage).to eq(CarrierWave::Storage::File)
     end
 
     it "should remember the storage when inherited" do
       @uploader_class.storage :fog
       subclass = Class.new(@uploader_class)
-      subclass.storage.should == CarrierWave::Storage::Fog
+      expect(subclass.storage).to eq(CarrierWave::Storage::Fog)
     end
 
     it "should be changeable when inherited" do
       @uploader_class.storage :fog
       subclass = Class.new(@uploader_class)
-      subclass.storage.should == CarrierWave::Storage::Fog
+      expect(subclass.storage).to eq(CarrierWave::Storage::Fog)
       subclass.storage :file
-      subclass.storage.should == CarrierWave::Storage::File
+      expect(subclass.storage).to eq(CarrierWave::Storage::File)
     end
   end
 
@@ -70,7 +70,7 @@ describe CarrierWave::Uploader::Base do
     it "should add a class level accessor" do
       @uploader_class.add_config :foo_bar
       @uploader_class.foo_bar = 'foo'
-      @uploader_class.foo_bar.should == 'foo'
+      expect(@uploader_class.foo_bar).to eq('foo')
     end
 
     ['foo', :foo, 45, ['foo', :bar]].each do |val|
@@ -79,13 +79,13 @@ describe CarrierWave::Uploader::Base do
         @child_class = Class.new(@uploader_class)
 
         @uploader_class.foo_bar = val
-        @uploader_class.foo_bar.should == val
-        @child_class.foo_bar.should == val
+        expect(@uploader_class.foo_bar).to eq(val)
+        expect(@child_class.foo_bar).to eq(val)
 
         @child_class.foo_bar = "bar"
-        @child_class.foo_bar.should == "bar"
+        expect(@child_class.foo_bar).to eq("bar")
 
-        @uploader_class.foo_bar.should == val
+        expect(@uploader_class.foo_bar).to eq(val)
       end
     end
 
@@ -93,13 +93,13 @@ describe CarrierWave::Uploader::Base do
     it "should add an instance level accessor" do
       @uploader_class.add_config :foo_bar
       @uploader_class.foo_bar = 'foo'
-      @uploader_class.new.foo_bar.should == 'foo'
+      expect(@uploader_class.new.foo_bar).to eq('foo')
     end
 
     it "should add a convenient in-class setter" do
       @uploader_class.add_config :foo_bar
       @uploader_class.foo_bar "monkey"
-      @uploader_class.foo_bar.should == "monkey"
+      expect(@uploader_class.foo_bar).to eq("monkey")
     end
 
     describe "assigning a proc to a config attribute" do
@@ -112,12 +112,12 @@ describe CarrierWave::Uploader::Base do
         let(:this_proc) { proc { "a return value" } }
 
         it "calls the proc without arguments" do
-          @uploader_class.new.hoobatz.should == "a return value"
+          expect(@uploader_class.new.hoobatz).to eq("a return value")
         end
       end
 
       context "when the proc accepts one argument" do
-        let(:this_proc) { proc { |arg1| arg1.should be_an_instance_of(@uploader_class) } }
+        let(:this_proc) { proc { |arg1| expect(arg1).to be_an_instance_of(@uploader_class) } }
 
         it "calls the proc with an instance of the uploader" do
           @uploader_class.new.hoobatz

--- a/spec/uploader/default_url_spec.rb
+++ b/spec/uploader/default_url_spec.rb
@@ -26,56 +26,56 @@ describe CarrierWave::Uploader do
 
     describe '#blank?' do
       it "should be true by default" do
-        @uploader.should be_blank
+        expect(@uploader).to be_blank
       end
     end
 
     describe '#current_path' do
       it "should return nil" do
-        @uploader.current_path.should be_nil
+        expect(@uploader.current_path).to be_nil
       end
     end
 
     describe '#url' do
       it "should return the default url" do
-        @uploader.url.should == 'http://someurl.example.com'
+        expect(@uploader.url).to eq('http://someurl.example.com')
       end
 
       it "should return the default url with version when given" do
-        @uploader.url(:thumb).should == 'http://someurl.example.com/thumb'
+        expect(@uploader.url(:thumb)).to eq('http://someurl.example.com/thumb')
       end
     end
 
     describe '#cache!' do
 
       before do
-        CarrierWave.stub!(:generate_cache_id).and_return('1369894322-345-2255')
+        allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
       end
 
       it "should cache a file" do
         @uploader.cache!(File.open(file_path('test.jpg')))
-        @uploader.file.should be_an_instance_of(CarrierWave::SanitizedFile)
+        expect(@uploader.file).to be_an_instance_of(CarrierWave::SanitizedFile)
       end
 
       it "should be cached" do
         @uploader.cache!(File.open(file_path('test.jpg')))
-        @uploader.should be_cached
+        expect(@uploader).to be_cached
       end
 
       it "should no longer be blank" do
         @uploader.cache!(File.open(file_path('test.jpg')))
-        @uploader.should_not be_blank
+        expect(@uploader).not_to be_blank
       end
 
       it "should set the current_path" do
         @uploader.cache!(File.open(file_path('test.jpg')))
-        @uploader.current_path.should == public_path('uploads/tmp/1369894322-345-2255/test.jpg')
+        expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/test.jpg'))
       end
 
       it "should set the url" do
         @uploader.cache!(File.open(file_path('test.jpg')))
-        @uploader.url.should_not == 'http://someurl.example.com'
-        @uploader.url.should == '/uploads/tmp/1369894322-345-2255/test.jpg'
+        expect(@uploader.url).not_to eq('http://someurl.example.com')
+        expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-2255/test.jpg')
       end
 
     end

--- a/spec/uploader/download_spec.rb
+++ b/spec/uploader/download_spec.rb
@@ -16,7 +16,7 @@ describe CarrierWave::Uploader::Download do
   describe '#download!' do
 
     before do
-      CarrierWave.stub!(:generate_cache_id).and_return('1369894322-345-2255')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
 
       sham_rack_app = ShamRack.at('www.example.com').stub
       sham_rack_app.register_resource('/test.jpg', File.read(file_path('test.jpg')), 'image/jpg')
@@ -39,79 +39,79 @@ describe CarrierWave::Uploader::Download do
 
     it "should cache a file" do
       @uploader.download!('http://www.example.com/test.jpg')
-      @uploader.file.should be_an_instance_of(CarrierWave::SanitizedFile)
+      expect(@uploader.file).to be_an_instance_of(CarrierWave::SanitizedFile)
     end
 
     it "should be cached" do
       @uploader.download!('http://www.example.com/test.jpg')
-      @uploader.should be_cached
+      expect(@uploader).to be_cached
     end
 
     it "should store the cache name" do
       @uploader.download!('http://www.example.com/test.jpg')
-      @uploader.cache_name.should == '1369894322-345-2255/test.jpg'
+      expect(@uploader.cache_name).to eq('1369894322-345-2255/test.jpg')
     end
 
     it "should set the filename to the file's sanitized filename" do
       @uploader.download!('http://www.example.com/test.jpg')
-      @uploader.filename.should == 'test.jpg'
+      expect(@uploader.filename).to eq('test.jpg')
     end
 
     it "should move it to the tmp dir" do
       @uploader.download!('http://www.example.com/test.jpg')
-      @uploader.file.path.should == public_path('uploads/tmp/1369894322-345-2255/test.jpg')
-      @uploader.file.exists?.should be_true
+      expect(@uploader.file.path).to eq(public_path('uploads/tmp/1369894322-345-2255/test.jpg'))
+      expect(@uploader.file.exists?).to be_true
     end
 
     it "should set the url" do
       @uploader.download!('http://www.example.com/test.jpg')
-      @uploader.url.should == '/uploads/tmp/1369894322-345-2255/test.jpg'
+      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-2255/test.jpg')
     end
 
     it "should set permissions if options are given" do
       @uploader_class.permissions = 0777
 
       @uploader.download!('http://www.example.com/test.jpg')
-      @uploader.should have_permissions(0777)
+      expect(@uploader).to have_permissions(0777)
     end
 
     it "should set directory permissions if options are given" do
       @uploader_class.directory_permissions = 0777
 
       @uploader.download!('http://www.example.com/test.jpg')
-      @uploader.should have_directory_permissions(0777)
+      expect(@uploader).to have_directory_permissions(0777)
     end
 
     it "should raise an error when trying to download a local file" do
-      running {
+      expect(running {
         @uploader.download!('/etc/passwd')
-      }.should raise_error(CarrierWave::DownloadError)
+      }).to raise_error(CarrierWave::DownloadError)
     end
 
     it "should raise an error when trying to download a missing file" do
-      running {
+      expect(running {
         @uploader.download!('http://www.example.com/missing.jpg')
-      }.should raise_error(CarrierWave::DownloadError)
+      }).to raise_error(CarrierWave::DownloadError)
     end
 
     it "should accept spaces in the url" do
       @uploader.download!('http://www.example.com/test with spaces/test.jpg')
-      @uploader.url.should == '/uploads/tmp/1369894322-345-2255/test.jpg'
+      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-2255/test.jpg')
     end
 
     it "should follow redirects" do
       @uploader.download!('http://www.redirect.com/')
-      @uploader.url.should == '/uploads/tmp/1369894322-345-2255/test.jpg'
+      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-2255/test.jpg')
     end
 
     it "should read content-disposition headers" do
       @uploader.download!('http://www.example.com/content-disposition')
-      @uploader.url.should == '/uploads/tmp/1369894322-345-2255/another_test.jpg'
+      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-2255/another_test.jpg')
     end
 
     it 'should set file extension based on content-type if missing' do
       @uploader.download!('http://www.example.com/test-with-no-extension/test')
-      @uploader.url.should == '/uploads/tmp/1369894322-345-2255/test.jpeg'
+      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-2255/test.jpeg')
     end
 
     it 'should not obscure original exception message' do
@@ -130,15 +130,15 @@ describe CarrierWave::Uploader::Download do
       end
 
       it "should follow redirects but still respect the extension_white_list" do
-        running {
+        expect(running {
           @uploader.download!('http://www.redirect.com/')
-        }.should raise_error(CarrierWave::IntegrityError)
+        }).to raise_error(CarrierWave::IntegrityError)
       end
 
       it "should read content-disposition header but still respect the extension_white_list" do
-        running {
+        expect(running {
           @uploader.download!('http://www.example.com/content-disposition')
-        }.should raise_error(CarrierWave::IntegrityError)
+        }).to raise_error(CarrierWave::IntegrityError)
       end
     end
 
@@ -152,15 +152,15 @@ describe CarrierWave::Uploader::Download do
       end
 
       it "should follow redirects but still respect the extension_black_list" do
-        running {
+        expect(running {
           @uploader.download!('http://www.redirect.com/')
-        }.should raise_error(CarrierWave::IntegrityError)
+        }).to raise_error(CarrierWave::IntegrityError)
       end
 
       it "should read content-disposition header but still respect the extension_black_list" do
-        running {
+        expect(running {
           @uploader.download!('http://www.example.com/content-disposition')
-        }.should raise_error(CarrierWave::IntegrityError)
+        }).to raise_error(CarrierWave::IntegrityError)
       end
     end
   end
@@ -175,9 +175,9 @@ describe CarrierWave::Uploader::Download do
     end
 
     it "should allow overriding the process_uri method" do
-      running {
+      expect(running {
         @uploader.download!('http://www.example.com/test.jpg')
-      }.should raise_error(CarrierWave::DownloadError)
+      }).to raise_error(CarrierWave::DownloadError)
     end
   end
 
@@ -185,29 +185,29 @@ describe CarrierWave::Uploader::Download do
     it "should parse but not escape already escaped uris" do
       uri = 'http://example.com/%5B.jpg'
       processed = @uploader.process_uri(uri)
-      processed.class.should == URI::HTTP
-      processed.to_s.should == uri
+      expect(processed.class).to eq(URI::HTTP)
+      expect(processed.to_s).to eq(uri)
     end
 
     it "should parse but not escape uris with query-string-only characters not needing escaping" do
       uri = 'http://example.com/?foo[]=bar'
       processed = @uploader.process_uri(uri)
-      processed.class.should == URI::HTTP
-      processed.to_s.should == uri
+      expect(processed.class).to eq(URI::HTTP)
+      expect(processed.to_s).to eq(uri)
     end
 
     it "should escape and parse unescaped uris" do
       uri = 'http://example.com/ %[].jpg'
       processed = @uploader.process_uri(uri)
-      processed.class.should == URI::HTTP
-      processed.to_s.should == 'http://example.com/%20%25%5B%5D.jpg'
+      expect(processed.class).to eq(URI::HTTP)
+      expect(processed.to_s).to eq('http://example.com/%20%25%5B%5D.jpg')
     end
 
     it "should escape and parse brackets in uri paths without harming the query string" do
       uri = 'http://example.com/].jpg?test[]'
       processed = @uploader.process_uri(uri)
-      processed.class.should == URI::HTTP
-      processed.to_s.should == 'http://example.com/%5D.jpg?test[]'
+      expect(processed.class).to eq(URI::HTTP)
+      expect(processed.to_s).to eq('http://example.com/%5D.jpg?test[]')
     end
 
     it "should throw an exception on bad uris" do

--- a/spec/uploader/extension_blacklist_spec.rb
+++ b/spec/uploader/extension_blacklist_spec.rb
@@ -15,63 +15,63 @@ describe CarrierWave::Uploader do
   describe '#cache!' do
 
     before do
-      CarrierWave.stub!(:generate_cache_id).and_return('1369894322-345-2255')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
     end
 
     it "should not raise an integrity error if there is no black list" do
-      @uploader.stub!(:extension_black_list).and_return(nil)
-      running {
+      allow(@uploader).to receive(:extension_black_list).and_return(nil)
+      expect(running {
         @uploader.cache!(File.open(file_path('test.jpg')))
-      }.should_not raise_error(CarrierWave::IntegrityError)
+      }).not_to raise_error
     end
 
     it "should raise an integrity error if there is a black list and the file is on it" do
-      @uploader.stub!(:extension_black_list).and_return(%w(jpg gif png))
-      running {
+      allow(@uploader).to receive(:extension_black_list).and_return(%w(jpg gif png))
+      expect(running {
         @uploader.cache!(File.open(file_path('test.jpg')))
-      }.should raise_error(CarrierWave::IntegrityError)
+      }).to raise_error(CarrierWave::IntegrityError)
     end
 
     it "should not raise an integrity error if there is a black list and the file is not on it" do
-      @uploader.stub!(:extension_black_list).and_return(%w(txt doc xls))
-      running {
+      allow(@uploader).to receive(:extension_black_list).and_return(%w(txt doc xls))
+      expect(running {
         @uploader.cache!(File.open(file_path('test.jpg')))
-      }.should_not raise_error(CarrierWave::IntegrityError)
+      }).not_to raise_error
     end
 
     it "should not raise an integrity error if there is a black list and the file is not on it, using start of string matcher" do
-      @uploader.stub!(:extension_black_list).and_return(%w(txt))
-      running {
+      allow(@uploader).to receive(:extension_black_list).and_return(%w(txt))
+      expect(running {
         @uploader.cache!(File.open(file_path('bork.ttxt')))
-      }.should_not raise_error(CarrierWave::IntegrityError)
+      }).not_to raise_error
     end
 
     it "should not raise an integrity error if there is a black list and the file is not on it, using end of string matcher" do
-      @uploader.stub!(:extension_black_list).and_return(%w(txt))
-      running {
+      allow(@uploader).to receive(:extension_black_list).and_return(%w(txt))
+      expect(running {
         @uploader.cache!(File.open(file_path('bork.txtt')))
-      }.should_not raise_error(CarrierWave::IntegrityError)
+      }).not_to raise_error
     end
 
     it "should compare black list in a case insensitive manner when capitalized extension provided" do
-      @uploader.stub!(:extension_black_list).and_return(%w(jpg gif png))
-      running {
+      allow(@uploader).to receive(:extension_black_list).and_return(%w(jpg gif png))
+      expect(running {
         @uploader.cache!(File.open(file_path('case.JPG')))
-      }.should raise_error(CarrierWave::IntegrityError)
+      }).to raise_error(CarrierWave::IntegrityError)
     end
 
     it "should compare black list in a case insensitive manner when lowercase extension provided" do
-      @uploader.stub!(:extension_black_list).and_return(%w(JPG GIF PNG))
-      running {
+      allow(@uploader).to receive(:extension_black_list).and_return(%w(JPG GIF PNG))
+      expect(running {
         @uploader.cache!(File.open(file_path('test.jpg')))
-      }.should raise_error(CarrierWave::IntegrityError)
+      }).to raise_error(CarrierWave::IntegrityError)
     end
 
     it "should accept and check regular expressions" do
-      @uploader.stub!(:extension_black_list).and_return([/jpe?g/, 'gif', 'png'])
-      running {
+      allow(@uploader).to receive(:extension_black_list).and_return([/jpe?g/, 'gif', 'png'])
+      expect(running {
         @uploader.cache!(File.open(file_path('test.jpeg')))
-      }.should raise_error(CarrierWave::IntegrityError)
+      }).to raise_error(CarrierWave::IntegrityError)
     end
   end
 

--- a/spec/uploader/extension_whitelist_spec.rb
+++ b/spec/uploader/extension_whitelist_spec.rb
@@ -16,63 +16,63 @@ describe CarrierWave::Uploader do
   describe '#cache!' do
 
     before do
-      CarrierWave.stub!(:generate_cache_id).and_return('1369894322-345-2255')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
     end
 
     it "should not raise an integrity error if there is no white list" do
-      @uploader.stub!(:extension_white_list).and_return(nil)
-      running {
+      allow(@uploader).to receive(:extension_white_list).and_return(nil)
+      expect(running {
         @uploader.cache!(File.open(file_path('test.jpg')))
-      }.should_not raise_error(CarrierWave::IntegrityError)
+      }).not_to raise_error
     end
 
     it "should not raise an integrity error if there is a white list and the file is on it" do
-      @uploader.stub!(:extension_white_list).and_return(%w(jpg gif png))
-      running {
+      allow(@uploader).to receive(:extension_white_list).and_return(%w(jpg gif png))
+      expect(running {
         @uploader.cache!(File.open(file_path('test.jpg')))
-      }.should_not raise_error(CarrierWave::IntegrityError)
+      }).not_to raise_error
     end
 
     it "should raise an integrity error if there is a white list and the file is not on it" do
-      @uploader.stub!(:extension_white_list).and_return(%w(txt doc xls))
-      running {
+      allow(@uploader).to receive(:extension_white_list).and_return(%w(txt doc xls))
+      expect(running {
         @uploader.cache!(File.open(file_path('test.jpg')))
-      }.should raise_error(CarrierWave::IntegrityError)
+      }).to raise_error(CarrierWave::IntegrityError)
     end
 
     it "should raise an integrity error if there is a white list and the file is not on it, using start of string matcher" do
-      @uploader.stub!(:extension_white_list).and_return(%w(txt))
-      running {
+      allow(@uploader).to receive(:extension_white_list).and_return(%w(txt))
+      expect(running {
         @uploader.cache!(File.open(file_path('bork.ttxt')))
-      }.should raise_error(CarrierWave::IntegrityError)
+      }).to raise_error(CarrierWave::IntegrityError)
     end
 
     it "should raise an integrity error if there is a white list and the file is not on it, using end of string matcher" do
-      @uploader.stub!(:extension_white_list).and_return(%w(txt))
-      running {
+      allow(@uploader).to receive(:extension_white_list).and_return(%w(txt))
+      expect(running {
         @uploader.cache!(File.open(file_path('bork.txtt')))
-      }.should raise_error(CarrierWave::IntegrityError)
+      }).to raise_error(CarrierWave::IntegrityError)
     end
 
     it "should compare white list in a case insensitive manner when capitalized extension provided" do
-      @uploader.stub!(:extension_white_list).and_return(%w(jpg gif png))
-      running {
+      allow(@uploader).to receive(:extension_white_list).and_return(%w(jpg gif png))
+      expect(running {
         @uploader.cache!(File.open(file_path('case.JPG')))
-      }.should_not raise_error(CarrierWave::IntegrityError)
+      }).not_to raise_error
     end
 
     it "should compare white list in a case insensitive manner when lowercase extension provided" do
-      @uploader.stub!(:extension_white_list).and_return(%w(JPG GIF PNG))
-      running {
+      allow(@uploader).to receive(:extension_white_list).and_return(%w(JPG GIF PNG))
+      expect(running {
         @uploader.cache!(File.open(file_path('test.jpg')))
-      }.should_not raise_error(CarrierWave::IntegrityError)
+      }).not_to raise_error
     end
 
     it "should accept and check regular expressions" do
-      @uploader.stub!(:extension_white_list).and_return([/jpe?g/, 'gif', 'png'])
-      running {
+      allow(@uploader).to receive(:extension_white_list).and_return([/jpe?g/, 'gif', 'png'])
+      expect(running {
         @uploader.cache!(File.open(file_path('test.jpeg')))
-      }.should_not raise_error(CarrierWave::IntegrityError)
+      }).not_to raise_error
     end
   end
 

--- a/spec/uploader/mountable_spec.rb
+++ b/spec/uploader/mountable_spec.rb
@@ -15,18 +15,18 @@ describe CarrierWave::Uploader do
 
   describe '#model' do
     it "should be remembered from initialization" do
-      model = mock('a model object')
+      model = double('a model object')
       @uploader = @uploader_class.new(model)
-      @uploader.model.should == model
+      expect(@uploader.model).to eq(model)
     end
   end
 
   describe '#mounted_as' do
     it "should be remembered from initialization" do
-      model = mock('a model object')
+      model = double('a model object')
       @uploader = @uploader_class.new(model, :llama)
-      @uploader.model.should == model
-      @uploader.mounted_as.should == :llama
+      expect(@uploader.model).to eq(model)
+      expect(@uploader.mounted_as).to eq(:llama)
     end
   end
 

--- a/spec/uploader/overrides_spec.rb
+++ b/spec/uploader/overrides_spec.rb
@@ -31,39 +31,39 @@ describe CarrierWave::Uploader do
 
   describe 'fog_credentials' do
     it 'should reflect the standard value if no override done' do
-      @uploader.fog_credentials.should be_a(Hash)
-      @uploader.fog_credentials[:provider].should be_eql('AWS')
-      @uploader.fog_credentials[:aws_access_key_id].should be_eql('XXXX')
-      @uploader.fog_credentials[:aws_secret_access_key].should be_eql('YYYY')
-      @uploader.fog_credentials[:region].should be_eql('us-east-1')
+      expect(@uploader.fog_credentials).to be_a(Hash)
+      expect(@uploader.fog_credentials[:provider]).to be_eql('AWS')
+      expect(@uploader.fog_credentials[:aws_access_key_id]).to be_eql('XXXX')
+      expect(@uploader.fog_credentials[:aws_secret_access_key]).to be_eql('YYYY')
+      expect(@uploader.fog_credentials[:region]).to be_eql('us-east-1')
     end
 
     it 'should reflect the new values in uploader class with override' do
-      @uploader_overridden.fog_credentials.should be_a(Hash)
-      @uploader_overridden.fog_credentials[:provider].should be_eql('AWS')
-      @uploader_overridden.fog_credentials[:aws_access_key_id].should be_eql('ZZZZ')
-      @uploader_overridden.fog_credentials[:aws_secret_access_key].should be_eql('AAAA')
-      @uploader_overridden.fog_credentials[:region].should be_eql('us-east-2')
+      expect(@uploader_overridden.fog_credentials).to be_a(Hash)
+      expect(@uploader_overridden.fog_credentials[:provider]).to be_eql('AWS')
+      expect(@uploader_overridden.fog_credentials[:aws_access_key_id]).to be_eql('ZZZZ')
+      expect(@uploader_overridden.fog_credentials[:aws_secret_access_key]).to be_eql('AAAA')
+      expect(@uploader_overridden.fog_credentials[:region]).to be_eql('us-east-2')
     end
   end
 
   describe 'fog_directory' do
     it 'should reflect the standard value if no override done' do
-      @uploader.fog_directory.should be_eql('defaultbucket')
+      expect(@uploader.fog_directory).to be_eql('defaultbucket')
     end
 
     it 'should reflect the standard value in overridden object because property is not overridden' do
-      @uploader_overridden.fog_directory.should be_eql('defaultbucket')
+      expect(@uploader_overridden.fog_directory).to be_eql('defaultbucket')
     end
   end
 
   describe 'fog_public' do
     it 'should reflect the standard value if no override done' do
-      @uploader.fog_public.should be_eql(true)
+      expect(@uploader.fog_public).to be_eql(true)
     end
 
     it 'should reflect the standard value in overridden object because property is not overridden' do
-      @uploader_overridden.fog_public.should be_eql(false)
+      expect(@uploader_overridden.fog_public).to be_eql(false)
     end
   end
 end

--- a/spec/uploader/paths_spec.rb
+++ b/spec/uploader/paths_spec.rb
@@ -18,9 +18,9 @@ describe CarrierWave::Uploader do
 
   describe '#root' do
     it "should default to the current value of CarrierWave.root" do
-      @uploader.root.should be_nil
+      expect(@uploader.root).to be_nil
       CarrierWave.root = public_path
-      @uploader.root.should == public_path
+      expect(@uploader.root).to eq(public_path)
     end
   end
 

--- a/spec/uploader/processing_spec.rb
+++ b/spec/uploader/processing_spec.rb
@@ -16,70 +16,70 @@ describe CarrierWave::Uploader do
   describe '.process' do
     it "should add a single processor when a symbol is given" do
       @uploader_class.process :sepiatone
-      @uploader.should_receive(:sepiatone)
+      expect(@uploader).to receive(:sepiatone)
       @uploader.process!
     end
 
     it "should add multiple processors when an array of symbols is given" do
       @uploader_class.process :sepiatone, :desaturate, :invert
-      @uploader.should_receive(:sepiatone)
-      @uploader.should_receive(:desaturate)
-      @uploader.should_receive(:invert)
+      expect(@uploader).to receive(:sepiatone)
+      expect(@uploader).to receive(:desaturate)
+      expect(@uploader).to receive(:invert)
       @uploader.process!
     end
 
     it "should add a single processor with an argument when a hash is given" do
       @uploader_class.process :format => 'png'
-      @uploader.should_receive(:format).with('png')
+      expect(@uploader).to receive(:format).with('png')
       @uploader.process!
     end
 
     it "should add a single processor with several argument when a hash is given" do
       @uploader_class.process :resize => [200, 300]
-      @uploader.should_receive(:resize).with(200, 300)
+      expect(@uploader).to receive(:resize).with(200, 300)
       @uploader.process!
     end
 
     it "should add multiple processors when an hash with multiple keys is given" do
       @uploader_class.process :resize => [200, 300], :format => 'png'
-      @uploader.should_receive(:resize).with(200, 300)
-      @uploader.should_receive(:format).with('png')
+      expect(@uploader).to receive(:resize).with(200, 300)
+      expect(@uploader).to receive(:format).with('png')
       @uploader.process!
     end
 
     it "should call the processor if the condition method returns true" do
       @uploader_class.process :resize => [200, 300], :if => :true?
       @uploader_class.process :fancy, :if => :true?
-      @uploader.should_receive(:true?).with("test.jpg").twice.and_return(true)
-      @uploader.should_receive(:resize).with(200, 300)
-      @uploader.should_receive(:fancy).with()
+      expect(@uploader).to receive(:true?).with("test.jpg").twice.and_return(true)
+      expect(@uploader).to receive(:resize).with(200, 300)
+      expect(@uploader).to receive(:fancy).with()
       @uploader.process!("test.jpg")
     end
 
     it "should not call the processor if the condition method returns false" do
       @uploader_class.process :resize => [200, 300], :if => :false?
       @uploader_class.process :fancy, :if => :false?
-      @uploader.should_receive(:false?).with("test.jpg").twice.and_return(false)
-      @uploader.should_not_receive(:resize)
-      @uploader.should_not_receive(:fancy)
+      expect(@uploader).to receive(:false?).with("test.jpg").twice.and_return(false)
+      expect(@uploader).not_to receive(:resize)
+      expect(@uploader).not_to receive(:fancy)
       @uploader.process!("test.jpg")
     end
 
     it "should call the processor if the condition block returns true" do
       @uploader_class.process :resize => [200, 300], :if => lambda{|record, args| record.true?(args[:file])}
       @uploader_class.process :fancy, :if => :true?
-      @uploader.should_receive(:true?).with("test.jpg").twice.and_return(true)
-      @uploader.should_receive(:resize).with(200, 300)
-      @uploader.should_receive(:fancy).with()
+      expect(@uploader).to receive(:true?).with("test.jpg").twice.and_return(true)
+      expect(@uploader).to receive(:resize).with(200, 300)
+      expect(@uploader).to receive(:fancy).with()
       @uploader.process!("test.jpg")
     end
 
     it "should not call the processor if the condition block returns false" do
       @uploader_class.process :resize => [200, 300], :if => lambda{|record, args| record.false?(args[:file])}
       @uploader_class.process :fancy, :if => :false?
-      @uploader.should_receive(:false?).with("test.jpg").twice.and_return(false)
-      @uploader.should_not_receive(:resize)
-      @uploader.should_not_receive(:fancy)
+      expect(@uploader).to receive(:false?).with("test.jpg").twice.and_return(false)
+      expect(@uploader).not_to receive(:resize)
+      expect(@uploader).not_to receive(:fancy)
       @uploader.process!("test.jpg")
     end
 
@@ -128,9 +128,9 @@ describe CarrierWave::Uploader do
       it "should not do any processing" do
         @uploader_class.enable_processing = false
         @uploader_class.process :sepiatone, :desaturate, :invert
-        @uploader.should_not_receive(:sepiatone)
-        @uploader.should_not_receive(:desaturate)
-        @uploader.should_not_receive(:invert)
+        expect(@uploader).not_to receive(:sepiatone)
+        expect(@uploader).not_to receive(:desaturate)
+        expect(@uploader).not_to receive(:invert)
         @uploader.process!
       end
     end
@@ -138,23 +138,23 @@ describe CarrierWave::Uploader do
 
   describe '#cache!' do
     before do
-      CarrierWave.stub!(:generate_cache_id).and_return('1369894322-345-2255')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
     end
 
     it "should trigger a process!" do
-      @uploader.should_receive(:process!)
+      expect(@uploader).to receive(:process!)
       @uploader.cache!(File.open(file_path('test.jpg')))
     end
   end
 
   describe '#recreate_versions!' do
     before do
-      CarrierWave.stub!(:generate_cache_id).and_return('1369894322-345-2255')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
     end
 
     it "should trigger a process!" do
       @uploader.store!(File.open(file_path('test.jpg')))
-      @uploader.should_receive(:process!)
+      expect(@uploader).to receive(:process!)
       @uploader.recreate_versions!
     end
   end

--- a/spec/uploader/proxy_spec.rb
+++ b/spec/uploader/proxy_spec.rb
@@ -15,55 +15,55 @@ describe CarrierWave::Uploader do
 
   describe '#blank?' do
     it "should be true when nothing has been done" do
-      @uploader.should be_blank
+      expect(@uploader).to be_blank
     end
 
     it "should not be true when the file is empty" do
       @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpeg')
-      @uploader.should be_blank
+      expect(@uploader).to be_blank
     end
 
     it "should not be true when a file has been cached" do
       @uploader.cache!(File.open(file_path('test.jpg')))
-      @uploader.should_not be_blank
+      expect(@uploader).not_to be_blank
     end
   end
 
   describe '#read' do
     it "should be nil by default" do
-      @uploader.read.should be_nil
+      expect(@uploader.read).to be_nil
     end
 
     it "should read the contents of a cached file" do
       @uploader.cache!(File.open(file_path('test.jpg')))
-      @uploader.read.should == "this is stuff"
+      expect(@uploader.read).to eq("this is stuff")
     end
   end
 
   describe '#size' do
     it "should be zero by default" do
-      @uploader.size.should == 0
+      expect(@uploader.size).to eq(0)
     end
 
     it "should get the size of a cached file" do
       @uploader.cache!(File.open(file_path('test.jpg')))
-      @uploader.size.should == 13
+      expect(@uploader.size).to eq(13)
     end
   end
 
   describe '#content_type' do
     it "should be nil when nothing has been done" do
-      @uploader.content_type.should be_nil
+      expect(@uploader.content_type).to be_nil
     end
 
     it "should get the content type when the file has been cached" do
       @uploader.cache!(File.open(file_path('test.jpg')))
-      @uploader.content_type.should == 'image/jpeg'
+      expect(@uploader.content_type).to eq('image/jpeg')
     end
 
     it "should get the content type when the file is empty" do
       @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpeg')
-      @uploader.content_type.should == 'image/jpeg'
+      expect(@uploader.content_type).to eq('image/jpeg')
     end
   end
 

--- a/spec/uploader/remove_spec.rb
+++ b/spec/uploader/remove_spec.rb
@@ -17,60 +17,60 @@ describe CarrierWave::Uploader do
     before do
       @file = File.open(file_path('test.jpg'))
 
-      CarrierWave.stub!(:generate_cache_id).and_return('1390890634-26112-2122')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1390890634-26112-2122')
 
-      @cached_file = mock('a cached file')
-      @cached_file.stub!(:delete)
+      @cached_file = double('a cached file')
+      allow(@cached_file).to receive(:delete)
 
-      @stored_file = mock('a stored file')
-      @stored_file.stub!(:path).and_return('/path/to/somewhere')
-      @stored_file.stub!(:url).and_return('http://www.example.com')
-      @stored_file.stub!(:identifier).and_return('this-is-me')
-      @stored_file.stub!(:delete)
+      @stored_file = double('a stored file')
+      allow(@stored_file).to receive(:path).and_return('/path/to/somewhere')
+      allow(@stored_file).to receive(:url).and_return('http://www.example.com')
+      allow(@stored_file).to receive(:identifier).and_return('this-is-me')
+      allow(@stored_file).to receive(:delete)
 
-      @storage = mock('a storage engine')
-      @storage.stub!(:store!).and_return(@stored_file)
-      @storage.stub!(:cache!).and_return(@cached_file)
-      @storage.stub!(:delete_dir!).with("uploads/tmp/#{CarrierWave.generate_cache_id}")
+      @storage = double('a storage engine')
+      allow(@storage).to receive(:store!).and_return(@stored_file)
+      allow(@storage).to receive(:cache!).and_return(@cached_file)
+      allow(@storage).to receive(:delete_dir!).with("uploads/tmp/#{CarrierWave.generate_cache_id}")
 
-      @uploader_class.storage.stub!(:new).and_return(@storage)
+      allow(@uploader_class.storage).to receive(:new).and_return(@storage)
       @uploader.store!(@file)
     end
 
     it "should reset the current path" do
       @uploader.remove!
-      @uploader.current_path.should be_nil
+      expect(@uploader.current_path).to be_nil
     end
 
     it "should not be cached" do
       @uploader.remove!
-      @uploader.should_not be_cached
+      expect(@uploader).not_to be_cached
     end
 
     it "should reset the url" do
       @uploader.cache!(@file)
       @uploader.remove!
-      @uploader.url.should be_nil
+      expect(@uploader.url).to be_nil
     end
 
     it "should reset the identifier" do
       @uploader.remove!
-      @uploader.identifier.should be_nil
+      expect(@uploader.identifier).to be_nil
     end
 
     it "should delete the file" do
-      @stored_file.should_receive(:delete)
+      expect(@stored_file).to receive(:delete)
       @uploader.remove!
     end
 
     it "should reset the cache_name" do
       @uploader.cache!(@file)
       @uploader.remove!
-      @uploader.cache_name.should be_nil
+      expect(@uploader.cache_name).to be_nil
     end
 
     it "should do nothing when trying to remove an empty file" do
-      running { @uploader.remove! }.should_not raise_error
+      expect(running { @uploader.remove! }).not_to raise_error
     end
   end
 

--- a/spec/uploader/store_spec.rb
+++ b/spec/uploader/store_spec.rb
@@ -15,13 +15,13 @@ describe CarrierWave::Uploader do
 
   describe '#store_dir' do
     it "should default to the config option" do
-      @uploader.store_dir.should == 'uploads'
+      expect(@uploader.store_dir).to eq('uploads')
     end
   end
 
   describe '#filename' do
     it "should default to nil" do
-      @uploader.filename.should be_nil
+      expect(@uploader.filename).to be_nil
     end
   end
 
@@ -29,76 +29,76 @@ describe CarrierWave::Uploader do
     before do
       @file = File.open(file_path('test.jpg'))
 
-      CarrierWave.stub!(:generate_cache_id).and_return('1390890634-26112-2122')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1390890634-26112-2122')
 
-      @cached_file = mock('a cached file')
-      @cached_file.stub!(:delete)
+      @cached_file = double('a cached file')
+      allow(@cached_file).to receive(:delete)
 
-      @stored_file = mock('a stored file')
-      @stored_file.stub!(:path).and_return('/path/to/somewhere')
-      @stored_file.stub!(:url).and_return('http://www.example.com')
+      @stored_file = double('a stored file')
+      allow(@stored_file).to receive(:path).and_return('/path/to/somewhere')
+      allow(@stored_file).to receive(:url).and_return('http://www.example.com')
 
-      @storage = mock('a storage engine')
-      @storage.stub!(:cache!).and_return(@cached_file)
-      @storage.stub!(:retrieve_from_cache!).and_return(@cached_file)
-      @storage.stub!(:store!).and_return(@stored_file)
-      @storage.stub!(:identifier).and_return('this-is-me')
-      @storage.stub!(:delete_dir!).with("uploads/tmp/#{CarrierWave.generate_cache_id}")
+      @storage = double('a storage engine')
+      allow(@storage).to receive(:cache!).and_return(@cached_file)
+      allow(@storage).to receive(:retrieve_from_cache!).and_return(@cached_file)
+      allow(@storage).to receive(:store!).and_return(@stored_file)
+      allow(@storage).to receive(:identifier).and_return('this-is-me')
+      allow(@storage).to receive(:delete_dir!).with("uploads/tmp/#{CarrierWave.generate_cache_id}")
 
-      @uploader_class.storage.stub!(:new).with(@uploader).and_return(@storage)
+      allow(@uploader_class.storage).to receive(:new).with(@uploader).and_return(@storage)
     end
 
     it "should set the current path" do
       @uploader.store!(@file)
-      @uploader.current_path.should == '/path/to/somewhere'
+      expect(@uploader.current_path).to eq('/path/to/somewhere')
     end
 
     it "should not be cached" do
       @uploader.store!(@file)
-      @uploader.should_not be_cached
+      expect(@uploader).not_to be_cached
     end
 
     it "should set the url" do
       @uploader.store!(@file)
-      @uploader.url.should == 'http://www.example.com'
+      expect(@uploader.url).to eq('http://www.example.com')
     end
 
     it "should set the identifier" do
       @uploader.store!(@file)
-      @uploader.identifier.should == 'this-is-me'
+      expect(@uploader.identifier).to eq('this-is-me')
     end
 
     it "should, if a file is given as argument, cache that file" do
-      @uploader.should_receive(:cache!).with(@file)
+      expect(@uploader).to receive(:cache!).with(@file)
       @uploader.store!(@file)
     end
 
     it "should use a previously cached file if no argument is given" do
       @uploader.cache!(File.open(file_path('test.jpg')))
-      @uploader.should_not_receive(:cache!)
+      expect(@uploader).not_to receive(:cache!)
       @uploader.store!
     end
 
     it "should instruct the storage engine to store the file" do
       @uploader.cache!(@file)
-      @storage.should_receive(:store!).with(@uploader.file).and_return(:monkey)
+      expect(@storage).to receive(:store!).with(@uploader.file).and_return(:monkey)
       @uploader.store!
     end
 
     it "should reset the cache_name" do
       @uploader.cache!(@file)
       @uploader.store!
-      @uploader.cache_name.should be_nil
+      expect(@uploader.cache_name).to be_nil
     end
 
     it "should cache the result given by the storage engine" do
       @uploader.store!(@file)
-      @uploader.file.should == @stored_file
+      expect(@uploader.file).to eq(@stored_file)
     end
 
     it "should delete the old file" do
       @uploader.cache!(@file)
-      @uploader.file.should_receive(:delete).and_return(true)
+      expect(@uploader.file).to receive(:delete).and_return(true)
       @uploader.store!
     end
 
@@ -109,14 +109,14 @@ describe CarrierWave::Uploader do
 
       it "should not delete the old file" do
         @uploader.cache!(@file)
-        @uploader.file.should_not_receive(:delete)
+        expect(@uploader.file).not_to receive(:delete)
         @uploader.store!
       end
 
       it "should not delete the old cache_id" do
         @uploader.cache!(@file)
 
-        @storage.should_not_receive(:delete_dir!)
+        expect(@storage).not_to receive(:delete_dir!)
         @uploader.store!
       end
     end
@@ -124,7 +124,7 @@ describe CarrierWave::Uploader do
     it "should delete the old cache_id" do
       @uploader.cache!(@file)
 
-      @storage.should_receive(:delete_dir!)
+      expect(@storage).to receive(:delete_dir!)
       @uploader.store!
     end
 
@@ -133,10 +133,10 @@ describe CarrierWave::Uploader do
     end
 
     it "should not re-store a retrieved file" do
-      @stored_file = mock('a stored file')
-      @storage.stub!(:retrieve!).and_return(@stored_file)
+      @stored_file = double('a stored file')
+      allow(@storage).to receive(:retrieve!).and_return(@stored_file)
 
-      @uploader_class.storage.should_not_receive(:store!)
+      expect(@uploader_class.storage).not_to receive(:store!)
       @uploader.retrieve_from_store!('monkey.txt')
       @uploader.store!
     end
@@ -144,51 +144,51 @@ describe CarrierWave::Uploader do
 
   describe '#retrieve_from_store!' do
     before do
-      @cached_file = mock('a cached file')
-      @cached_file.stub!(:delete)
+      @cached_file = double('a cached file')
+      allow(@cached_file).to receive(:delete)
 
-      @stored_file = mock('a stored file')
-      @stored_file.stub!(:path).and_return('/path/to/somewhere')
-      @stored_file.stub!(:url).and_return('http://www.example.com')
+      @stored_file = double('a stored file')
+      allow(@stored_file).to receive(:path).and_return('/path/to/somewhere')
+      allow(@stored_file).to receive(:url).and_return('http://www.example.com')
 
-      @storage = mock('a storage engine')
-      @storage.stub!(:retrieve_from_cache!).and_return(@cached_file)
-      @storage.stub!(:retrieve!).and_return(@stored_file)
-      @storage.stub!(:identifier).and_return('this-is-me')
+      @storage = double('a storage engine')
+      allow(@storage).to receive(:retrieve_from_cache!).and_return(@cached_file)
+      allow(@storage).to receive(:retrieve!).and_return(@stored_file)
+      allow(@storage).to receive(:identifier).and_return('this-is-me')
 
-      @uploader_class.storage.stub!(:new).with(@uploader).and_return(@storage)
+      allow(@uploader_class.storage).to receive(:new).with(@uploader).and_return(@storage)
     end
 
     it "should set the current path" do
       @uploader.retrieve_from_store!('monkey.txt')
-      @uploader.current_path.should == '/path/to/somewhere'
+      expect(@uploader.current_path).to eq('/path/to/somewhere')
     end
 
     it "should not be cached" do
       @uploader.retrieve_from_store!('monkey.txt')
-      @uploader.should_not be_cached
+      expect(@uploader).not_to be_cached
     end
 
     it "should set the url" do
       @uploader.retrieve_from_store!('monkey.txt')
-      @uploader.url.should == 'http://www.example.com'
+      expect(@uploader.url).to eq('http://www.example.com')
     end
 
     it "should set the identifier" do
       @uploader.retrieve_from_store!('monkey.txt')
-      @uploader.identifier.should == 'this-is-me'
+      expect(@uploader.identifier).to eq('this-is-me')
     end
 
     it "should instruct the storage engine to retrieve the file and store the result" do
-      @storage.should_receive(:retrieve!).with('monkey.txt').and_return(@stored_file)
+      expect(@storage).to receive(:retrieve!).with('monkey.txt').and_return(@stored_file)
       @uploader.retrieve_from_store!('monkey.txt')
-      @uploader.file.should == @stored_file
+      expect(@uploader.file).to eq(@stored_file)
     end
 
     it "should overwrite a file that has already been cached" do
       @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpeg')
       @uploader.retrieve_from_store!('bork.txt')
-      @uploader.file.should == @stored_file
+      expect(@uploader.file).to eq(@stored_file)
     end
   end
 
@@ -203,13 +203,13 @@ describe CarrierWave::Uploader do
       @file = File.open(file_path('test.jpg'))
       @uploader.store!(@file)
       @path = ::File.expand_path(@uploader.store_path, @uploader.root)
-      File.exist?(@path).should be_true
+      expect(File.exist?(@path)).to be_true
     end
 
     it "should not create new files if there is no file" do
       @uploader.store!(nil)
       @path = ::File.expand_path(@uploader.store_path, @uploader.root)
-      File.exist?(@path).should be_false
+      expect(File.exist?(@path)).to be_false
     end
   end
 
@@ -224,8 +224,8 @@ describe CarrierWave::Uploader do
       @file = File.open(file_path('test.jpg'))
       @uploader.store!(@file)
       @path = ::File.expand_path(@uploader.store_path, @uploader.root)
-      File.exist?(@path).should be_true
-      @uploader.url.should == '/test.jpg'
+      expect(File.exist?(@path)).to be_true
+      expect(@uploader.url).to eq('/test.jpg')
     end
   end
 
@@ -242,71 +242,71 @@ describe CarrierWave::Uploader do
       before do
         @file = File.open(file_path('test.jpg'))
 
-        CarrierWave.stub!(:generate_cache_id).and_return('1390890634-26112-2122')
+        allow(CarrierWave).to receive(:generate_cache_id).and_return('1390890634-26112-2122')
 
-        @cached_file = mock('a cached file')
-        @cached_file.stub!(:delete)
+        @cached_file = double('a cached file')
+        allow(@cached_file).to receive(:delete)
 
-        @stored_file = mock('a stored file')
-        @stored_file.stub!(:path).and_return('/path/to/somewhere')
-        @stored_file.stub!(:url).and_return('http://www.example.com')
+        @stored_file = double('a stored file')
+        allow(@stored_file).to receive(:path).and_return('/path/to/somewhere')
+        allow(@stored_file).to receive(:url).and_return('http://www.example.com')
 
-        @storage = mock('a storage engine')
-        @storage.stub!(:cache!).and_return(@cached_file)
-        @storage.stub!(:store!).and_return(@stored_file)
-        @storage.stub!(:delete_dir!).with("uploads/tmp/#{CarrierWave.generate_cache_id}")
+        @storage = double('a storage engine')
+        allow(@storage).to receive(:cache!).and_return(@cached_file)
+        allow(@storage).to receive(:store!).and_return(@stored_file)
+        allow(@storage).to receive(:delete_dir!).with("uploads/tmp/#{CarrierWave.generate_cache_id}")
 
-        @uploader_class.storage.stub!(:new).with(@uploader).and_return(@storage)
+        allow(@uploader_class.storage).to receive(:new).with(@uploader).and_return(@storage)
       end
 
       it "should set the current path" do
         @uploader.store!(@file)
-        @uploader.current_path.should == '/path/to/somewhere'
+        expect(@uploader.current_path).to eq('/path/to/somewhere')
       end
 
       it "should set the url" do
         @uploader.store!(@file)
-        @uploader.url.should == 'http://www.example.com'
+        expect(@uploader.url).to eq('http://www.example.com')
       end
 
       it "should, if a file is given as argument, reverse the filename" do
         @uploader.store!(@file)
-        @uploader.filename.should == 'gpj.tset'
+        expect(@uploader.filename).to eq('gpj.tset')
       end
 
     end
 
     describe '#retrieve_from_store!' do
       before do
-        @stored_file = mock('a stored file')
-        @stored_file.stub!(:path).and_return('/path/to/somewhere')
-        @stored_file.stub!(:url).and_return('http://www.example.com')
+        @stored_file = double('a stored file')
+        allow(@stored_file).to receive(:path).and_return('/path/to/somewhere')
+        allow(@stored_file).to receive(:url).and_return('http://www.example.com')
 
-        @storage = mock('a storage engine')
-        @storage.stub!(:retrieve!).and_return(@stored_file)
+        @storage = double('a storage engine')
+        allow(@storage).to receive(:retrieve!).and_return(@stored_file)
 
-        @uploader_class.storage.stub!(:new).with(@uploader).and_return(@storage)
+        allow(@uploader_class.storage).to receive(:new).with(@uploader).and_return(@storage)
       end
 
       it "should set the current path" do
         @uploader.retrieve_from_store!('monkey.txt')
-        @uploader.current_path.should == '/path/to/somewhere'
+        expect(@uploader.current_path).to eq('/path/to/somewhere')
       end
 
       it "should set the url" do
         @uploader.retrieve_from_store!('monkey.txt')
-        @uploader.url.should == 'http://www.example.com'
+        expect(@uploader.url).to eq('http://www.example.com')
       end
 
       it "should pass the identifier to the storage engine" do
-        @storage.should_receive(:retrieve!).with('monkey.txt').and_return(@stored_file)
+        expect(@storage).to receive(:retrieve!).with('monkey.txt').and_return(@stored_file)
         @uploader.retrieve_from_store!('monkey.txt')
-        @uploader.file.should == @stored_file
+        expect(@uploader.file).to eq(@stored_file)
       end
 
       it "should not set the filename" do
         @uploader.retrieve_from_store!('monkey.txt')
-        @uploader.filename.should be_nil
+        expect(@uploader.filename).to be_nil
       end
     end
 
@@ -318,7 +318,7 @@ describe CarrierWave::Uploader do
       @file = File.open(file_path('test.jpg'))
       @uploader_class.permissions = 0777
       @uploader_class.directory_permissions = 0777
-      CarrierWave.stub!(:generate_cache_id).and_return('1369894322-345-2255')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
     end
 
     context "set to true" do
@@ -332,22 +332,22 @@ describe CarrierWave::Uploader do
         @cached_path = @uploader.file.path
         @stored_path = ::File.expand_path(@uploader.store_path, @uploader.root)
 
-        @cached_path.should == public_path('uploads/tmp/1369894322-345-2255/test.jpg')
-        File.exist?(@cached_path).should be_true
-        File.exist?(@stored_path).should be_false
+        expect(@cached_path).to eq(public_path('uploads/tmp/1369894322-345-2255/test.jpg'))
+        expect(File.exist?(@cached_path)).to be_true
+        expect(File.exist?(@stored_path)).to be_false
 
         @uploader.store!
 
-        File.exist?(@cached_path).should be_false
-        File.exist?(@stored_path).should be_true
+        expect(File.exist?(@cached_path)).to be_false
+        expect(File.exist?(@stored_path)).to be_true
       end
 
       it "should use move_to() during store!()" do
         @uploader.cache!(@file)
         @stored_path = ::File.expand_path(@uploader.store_path, @uploader.root)
 
-        @uploader.file.should_receive(:move_to).with(@stored_path, 0777, 0777)
-        @uploader.file.should_not_receive(:copy_to)
+        expect(@uploader.file).to receive(:move_to).with(@stored_path, 0777, 0777)
+        expect(@uploader.file).not_to receive(:copy_to)
 
         @uploader.store!
       end
@@ -362,8 +362,8 @@ describe CarrierWave::Uploader do
         @uploader.cache!(@file)
         @stored_path = ::File.expand_path(@uploader.store_path, @uploader.root)
 
-        @uploader.file.should_receive(:copy_to).with(@stored_path, 0777, 0777)
-        @uploader.file.should_not_receive(:move_to)
+        expect(@uploader.file).to receive(:copy_to).with(@stored_path, 0777, 0777)
+        expect(@uploader.file).not_to receive(:move_to)
 
         @uploader.store!
       end

--- a/spec/uploader/url_spec.rb
+++ b/spec/uploader/url_spec.rb
@@ -17,41 +17,41 @@ describe CarrierWave::Uploader do
 
   describe '#url' do
     before do
-      CarrierWave.stub!(:generate_cache_id).and_return('1369894322-345-2255')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
     end
 
     it "should default to nil" do
-      @uploader.url.should be_nil
+      expect(@uploader.url).to be_nil
     end
 
     it "should raise ArgumentError when version doesn't exist" do
-      lambda { @uploader.url(:thumb) }.should raise_error(ArgumentError)
+      expect { @uploader.url(:thumb) }.to raise_error(ArgumentError)
     end
 
     it "should not raise exception when hash specified as argument" do
-      lambda { @uploader.url({}) }.should_not raise_error
+      expect { @uploader.url({}) }.not_to raise_error
     end
 
     it "should not raise ArgumentError when storage's File#url method doesn't get params" do
       module StorageX; class File; def url; true; end; end; end
-      @uploader.stub!(:file).and_return(StorageX::File.new)
-      lambda { @uploader.url }.should_not raise_error
+      allow(@uploader).to receive(:file).and_return(StorageX::File.new)
+      expect { @uploader.url }.not_to raise_error
     end
 
     it "should not raise ArgumentError when versions version exists" do
       MyCoolUploader.version(:thumb)
-      lambda { @uploader.url(:thumb) }.should_not raise_error(ArgumentError)
+      expect { @uploader.url(:thumb) }.not_to raise_error
     end
 
     it "should get the directory relative to public, prepending a slash" do
       @uploader.cache!(File.open(file_path('test.jpg')))
-      @uploader.url.should == '/uploads/tmp/1369894322-345-2255/test.jpg'
+      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-2255/test.jpg')
     end
 
     it "should get the directory relative to public for a specific version" do
       MyCoolUploader.version(:thumb)
       @uploader.cache!(File.open(file_path('test.jpg')))
-      @uploader.url(:thumb).should == '/uploads/tmp/1369894322-345-2255/thumb_test.jpg'
+      expect(@uploader.url(:thumb)).to eq('/uploads/tmp/1369894322-345-2255/thumb_test.jpg')
     end
 
     it "should get the directory relative to public for a nested version" do
@@ -59,7 +59,7 @@ describe CarrierWave::Uploader do
         version(:mini)
       end
       @uploader.cache!(File.open(file_path('test.jpg')))
-      @uploader.url(:thumb, :mini).should == '/uploads/tmp/1369894322-345-2255/thumb_mini_test.jpg'
+      expect(@uploader.url(:thumb, :mini)).to eq('/uploads/tmp/1369894322-345-2255/thumb_mini_test.jpg')
     end
 
     it "should prepend the config option 'asset_host', if set and a string" do
@@ -68,7 +68,7 @@ describe CarrierWave::Uploader do
         config.asset_host = "http://foo.bar"
       end
       @uploader.cache!(File.open(file_path('test.jpg')))
-      @uploader.url(:thumb).should == 'http://foo.bar/uploads/tmp/1369894322-345-2255/thumb_test.jpg'
+      expect(@uploader.url(:thumb)).to eq('http://foo.bar/uploads/tmp/1369894322-345-2255/thumb_test.jpg')
     end
 
     it "should prepend the result of the config option 'asset_host', if set and a proc" do
@@ -77,7 +77,7 @@ describe CarrierWave::Uploader do
         config.asset_host = proc { "http://foo.bar" }
       end
       @uploader.cache!(File.open(file_path('test.jpg')))
-      @uploader.url(:thumb).should == 'http://foo.bar/uploads/tmp/1369894322-345-2255/thumb_test.jpg'
+      expect(@uploader.url(:thumb)).to eq('http://foo.bar/uploads/tmp/1369894322-345-2255/thumb_test.jpg')
     end
 
     it "should prepend the config option 'base_path', if set and 'asset_host' is not set" do
@@ -87,24 +87,24 @@ describe CarrierWave::Uploader do
         config.asset_host = nil
       end
       @uploader.cache!(File.open(file_path('test.jpg')))
-      @uploader.url(:thumb).should == '/base_path/uploads/tmp/1369894322-345-2255/thumb_test.jpg'
+      expect(@uploader.url(:thumb)).to eq('/base_path/uploads/tmp/1369894322-345-2255/thumb_test.jpg')
     end
 
     it "should return file#url if available" do
       @uploader.cache!(File.open(file_path('test.jpg')))
-      @uploader.file.stub!(:url).and_return('http://www.example.com/someurl.jpg')
-      @uploader.url.should == 'http://www.example.com/someurl.jpg'
+      allow(@uploader.file).to receive(:url).and_return('http://www.example.com/someurl.jpg')
+      expect(@uploader.url).to eq('http://www.example.com/someurl.jpg')
     end
 
     it "should get the directory relative to public, if file#url is blank" do
       @uploader.cache!(File.open(file_path('test.jpg')))
-      @uploader.file.stub!(:url).and_return('')
-      @uploader.url.should == '/uploads/tmp/1369894322-345-2255/test.jpg'
+      allow(@uploader.file).to receive(:url).and_return('')
+      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-2255/test.jpg')
     end
 
     it "should uri encode the path of a file without an asset host" do
       @uploader.cache!(File.open(file_path('test+.jpg')))
-      @uploader.url.should == '/uploads/tmp/1369894322-345-2255/test%2B.jpg'
+      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-2255/test%2B.jpg')
     end
 
     it "should uri encode the path of a file with a string asset host" do
@@ -113,7 +113,7 @@ describe CarrierWave::Uploader do
         config.asset_host = "http://foo.bar"
       end
       @uploader.cache!(File.open(file_path('test+.jpg')))
-      @uploader.url(:thumb).should == 'http://foo.bar/uploads/tmp/1369894322-345-2255/thumb_test%2B.jpg'
+      expect(@uploader.url(:thumb)).to eq('http://foo.bar/uploads/tmp/1369894322-345-2255/thumb_test%2B.jpg')
     end
 
     it "should uri encode the path of a file with a proc asset host" do
@@ -122,97 +122,96 @@ describe CarrierWave::Uploader do
         config.asset_host = proc { "http://foo.bar" }
       end
       @uploader.cache!(File.open(file_path('test+.jpg')))
-      @uploader.url(:thumb).should == 'http://foo.bar/uploads/tmp/1369894322-345-2255/thumb_test%2B.jpg'
+      expect(@uploader.url(:thumb)).to eq('http://foo.bar/uploads/tmp/1369894322-345-2255/thumb_test%2B.jpg')
     end
 
     it "shouldn't double-encode the path of an available file#url" do
       url = 'http://www.example.com/directory%2Bname/another%2Bdirectory/some%2Burl.jpg'
       @uploader.cache!(File.open(file_path('test.jpg')))
-      @uploader.file.stub!(:url).and_return(url)
-      @uploader.url.should == url
+      allow(@uploader.file).to receive(:url).and_return(url)
+      expect(@uploader.url).to eq(url)
     end
   end
 
   describe '#to_json' do
     before do
-      CarrierWave.stub!(:generate_cache_id).and_return('1369894322-345-2255')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
     end
 
     it "should return a hash with a nil URL" do
       MyCoolUploader.version(:thumb)
       hash = JSON.parse(@uploader.to_json)
-      hash.keys.should
-      hash.keys.should include("uploader")
-      hash["uploader"].keys.should include("url")
-      hash["uploader"].keys.should include("thumb")
-      hash["uploader"]["url"].should be_nil
-      hash["uploader"]["thumb"].keys.should include("url")
-      hash["uploader"]["thumb"]["url"].should be_nil
+      expect(hash.keys).to include("uploader")
+      expect(hash["uploader"].keys).to include("url")
+      expect(hash["uploader"].keys).to include("thumb")
+      expect(hash["uploader"]["url"]).to be_nil
+      expect(hash["uploader"]["thumb"].keys).to include("url")
+      expect(hash["uploader"]["thumb"]["url"]).to be_nil
     end
 
     it "should return a hash including a cached URL" do
       @uploader.cache!(File.open(file_path("test.jpg")))
-      JSON.parse(@uploader.to_json).should == {"uploader" => {"url" => "/uploads/tmp/1369894322-345-2255/test.jpg"}}
+      expect(JSON.parse(@uploader.to_json)).to eq({"uploader" => {"url" => "/uploads/tmp/1369894322-345-2255/test.jpg"}})
     end
 
     it "should return a hash including a cached URL of a version" do
       MyCoolUploader.version(:thumb)
       @uploader.cache!(File.open(file_path("test.jpg")))
       hash = JSON.parse(@uploader.to_json)["uploader"]
-      hash.keys.should include "thumb"
-      hash["thumb"].should == {"url" => "/uploads/tmp/1369894322-345-2255/thumb_test.jpg"}
+      expect(hash.keys).to include "thumb"
+      expect(hash["thumb"]).to eq({"url" => "/uploads/tmp/1369894322-345-2255/thumb_test.jpg"})
     end
 
     it "should allow an options parameter to be passed in" do
-      lambda { @uploader.to_json({:some => 'options'}) }.should_not raise_error
+      expect { @uploader.to_json({:some => 'options'}) }.not_to raise_error
     end
   end
 
   describe '#to_xml' do
     before do
-      CarrierWave.stub!(:generate_cache_id).and_return('1369894322-345-2255')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
     end
 
     it "should return a hash with a blank URL" do
-      Hash.from_xml(@uploader.to_xml).should == {"uploader" => {"url" => nil}}
+      expect(Hash.from_xml(@uploader.to_xml)).to eq({"uploader" => {"url" => nil}})
     end
 
     it "should return a hash including a cached URL" do
       @uploader.cache!(File.open(file_path("test.jpg")))
-      Hash.from_xml(@uploader.to_xml).should == {"uploader" => {"url" => "/uploads/tmp/1369894322-345-2255/test.jpg"}}
+      expect(Hash.from_xml(@uploader.to_xml)).to eq({"uploader" => {"url" => "/uploads/tmp/1369894322-345-2255/test.jpg"}})
     end
 
     it "should return a hash including a cached URL of a version" do
       MyCoolUploader.version(:thumb)
       @uploader.cache!(File.open(file_path("test.jpg")))
-      Hash.from_xml(@uploader.to_xml)["uploader"]["thumb"].should == {"url" => "/uploads/tmp/1369894322-345-2255/thumb_test.jpg"}
+      expect(Hash.from_xml(@uploader.to_xml)["uploader"]["thumb"]).to eq({"url" => "/uploads/tmp/1369894322-345-2255/thumb_test.jpg"})
     end
 
     it "should return a hash including an array with a cached URL" do
       @uploader.cache!(File.open(file_path("test.jpg")))
       hash = Hash.from_xml([@uploader].to_xml)
-      hash.should have_value([{"url"=>"/uploads/tmp/1369894322-345-2255/test.jpg"}])
+      expect(hash).to have_value([{"url"=>"/uploads/tmp/1369894322-345-2255/test.jpg"}])
     end
   end
 
   describe '#to_s' do
     before do
-      CarrierWave.stub!(:generate_cache_id).and_return('1369894322-345-2255')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
     end
 
     it "should default to empty space" do
-      @uploader.to_s.should == ''
+      expect(@uploader.to_s).to eq('')
     end
 
     it "should get the directory relative to public, prepending a slash" do
       @uploader.cache!(File.open(file_path('test.jpg')))
-      @uploader.to_s.should == '/uploads/tmp/1369894322-345-2255/test.jpg'
+      expect(@uploader.to_s).to eq('/uploads/tmp/1369894322-345-2255/test.jpg')
     end
 
     it "should return file#url if available" do
       @uploader.cache!(File.open(file_path('test.jpg')))
-      @uploader.file.stub!(:url).and_return('http://www.example.com/someurl.jpg')
-      @uploader.to_s.should == 'http://www.example.com/someurl.jpg'
+      allow(@uploader.file).to receive(:url).and_return('http://www.example.com/someurl.jpg')
+      expect(@uploader.to_s).to eq('http://www.example.com/someurl.jpg')
     end
   end
 

--- a/spec/uploader/versions_spec.rb
+++ b/spec/uploader/versions_spec.rb
@@ -16,8 +16,8 @@ describe CarrierWave::Uploader do
   describe '.version' do
     it "should add it to .versions" do
       @uploader_class.version :thumb
-      @uploader_class.versions[:thumb].should be_a(Class)
-      @uploader_class.versions[:thumb].ancestors.should include(@uploader_class)
+      expect(@uploader_class.versions[:thumb]).to be_a(Class)
+      expect(@uploader_class.versions[:thumb].ancestors).to include(@uploader_class)
     end
 
     it "should only assign versions to parent" do
@@ -27,44 +27,44 @@ describe CarrierWave::Uploader do
           version :micro
         end
       end
-      @uploader_class.versions.should have(2).versions
-      @uploader_class.versions.should include :large
-      @uploader_class.versions.should include :thumb
-      @uploader.large.versions.should be_empty
-      @uploader.thumb.versions.keys.should == [:mini]
-      @uploader.thumb.mini.versions.keys.should == [:micro]
-      @uploader.thumb.mini.micro.versions.should be_empty
+      expect(@uploader_class.versions.size).to eq(2)
+      expect(@uploader_class.versions).to include :large
+      expect(@uploader_class.versions).to include :thumb
+      expect(@uploader.large.versions).to be_empty
+      expect(@uploader.thumb.versions.keys).to eq([:mini])
+      expect(@uploader.thumb.mini.versions.keys).to eq([:micro])
+      expect(@uploader.thumb.mini.micro.versions).to be_empty
     end
 
     it "should add an accessor which returns the version" do
       @uploader_class.version :thumb
-      @uploader.thumb.should be_a(@uploader_class)
+      expect(@uploader.thumb).to be_a(@uploader_class)
     end
 
     it "should add it to #versions which returns the version" do
       @uploader_class.version :thumb
-      @uploader.versions[:thumb].should be_a(@uploader_class)
+      expect(@uploader.versions[:thumb]).to be_a(@uploader_class)
     end
 
     it "should set the version name" do
       @uploader_class.version :thumb
-      @uploader.version_name.should == nil
-      @uploader.thumb.version_name.should == :thumb
+      expect(@uploader.version_name).to eq(nil)
+      expect(@uploader.thumb.version_name).to eq(:thumb)
     end
 
     it "should set the version names on the class" do
       @uploader_class.version :thumb
-      @uploader.class.version_names.should == []
-      @uploader.thumb.class.version_names.should == [:thumb]
+      expect(@uploader.class.version_names).to eq([])
+      expect(@uploader.thumb.class.version_names).to eq([:thumb])
     end
 
     it "should remember mount options" do
-      model = mock('a model')
+      model = double('a model')
       @uploader_class.version :thumb
       @uploader = @uploader_class.new(model, :gazelle)
 
-      @uploader.thumb.model.should == model
-      @uploader.thumb.mounted_as.should == :gazelle
+      expect(@uploader.thumb.model).to eq(model)
+      expect(@uploader.thumb.mounted_as).to eq(:gazelle)
     end
 
     it "should apply any overrides given in a block" do
@@ -73,26 +73,26 @@ describe CarrierWave::Uploader do
           public_path('monkey/apache')
         end
       end
-      @uploader.store_dir.should == 'uploads'
-      @uploader.thumb.store_dir.should == public_path('monkey/apache')
+      expect(@uploader.store_dir).to eq('uploads')
+      expect(@uploader.thumb.store_dir).to eq(public_path('monkey/apache'))
     end
 
     it "should not initially have a value for enable processing" do
       thumb = (@uploader_class.version :thumb)
-      thumb.instance_variable_get('@enable_processing').should be_nil
+      expect(thumb.instance_variable_get('@enable_processing')).to be_nil
     end
 
     it "should return the enable processing value of the parent" do
       @uploader_class.enable_processing = false
       thumb = (@uploader_class.version :thumb)
-      thumb.enable_processing.should be_false
+      expect(thumb.enable_processing).to be_false
     end
 
     it "should return its own value for enable processing if set" do
       @uploader_class.enable_processing = false
       thumb = @uploader_class.version :thumb
       thumb.enable_processing = true
-      thumb.enable_processing.should be_true
+      expect(thumb.enable_processing).to be_true
     end
 
     it "should reopen the same class when called multiple times" do
@@ -106,13 +106,13 @@ describe CarrierWave::Uploader do
           "llama"
         end
       end
-      @uploader_class.version(:thumb).monkey.should == "monkey"
-      @uploader_class.version(:thumb).llama.should == "llama"
+      expect(@uploader_class.version(:thumb).monkey).to eq("monkey")
+      expect(@uploader_class.version(:thumb).llama).to eq("llama")
     end
 
     it "should accept option :from_version" do
       @uploader_class.version :small_thumb, :from_version => :thumb
-      @uploader_class.version(:small_thumb).version_options[:from_version].should == :thumb
+      expect(@uploader_class.version(:small_thumb).version_options[:from_version]).to eq(:thumb)
     end
 
     describe 'with nested versions' do
@@ -124,17 +124,17 @@ describe CarrierWave::Uploader do
       end
 
       it "should add an array of version names" do
-        @uploader.class.version_names.should == []
-        @uploader.thumb.class.version_names.should == [:thumb]
-        @uploader.thumb.mini.class.version_names.should == [:thumb, :mini]
-        @uploader.thumb.micro.class.version_names.should == [:thumb, :micro]
+        expect(@uploader.class.version_names).to eq([])
+        expect(@uploader.thumb.class.version_names).to eq([:thumb])
+        expect(@uploader.thumb.mini.class.version_names).to eq([:thumb, :mini])
+        expect(@uploader.thumb.micro.class.version_names).to eq([:thumb, :micro])
       end
 
       it "should set the version name for the instances" do
-        @uploader.version_name.should be_nil
-        @uploader.thumb.version_name.should == :thumb
-        @uploader.thumb.mini.version_name.should == :thumb_mini
-        @uploader.thumb.micro.version_name.should == :thumb_micro
+        expect(@uploader.version_name).to be_nil
+        expect(@uploader.thumb.version_name).to eq(:thumb)
+        expect(@uploader.thumb.mini.version_name).to eq(:thumb_mini)
+        expect(@uploader.thumb.micro.version_name).to eq(:thumb_micro)
       end
 
       it "should process nested versions" do
@@ -158,9 +158,9 @@ describe CarrierWave::Uploader do
         }
         @uploader.cache! File.open(file_path('portrait.jpg'))
 
-        @uploader.should have_dimensions(233, 337)
-        @uploader.rotated.should have_dimensions(337, 233)
-        @uploader.rotated.boxed.should have_dimensions(200, 138)
+        expect(@uploader).to have_dimensions(233, 337)
+        expect(@uploader.rotated).to have_dimensions(337, 233)
+        expect(@uploader.rotated.boxed).to have_dimensions(200, 138)
       end
     end
 
@@ -174,38 +174,38 @@ describe CarrierWave::Uploader do
     describe '#cache!' do
 
       before do
-        CarrierWave.stub!(:generate_cache_id).and_return('1369894322-345-2255')
+        allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
       end
 
       it "should set store_path with versions" do
-        CarrierWave.should_receive(:generate_cache_id).once
+        expect(CarrierWave).to receive(:generate_cache_id).once
         @uploader.cache!(File.open(file_path('test.jpg')))
-        @uploader.store_path.should == 'uploads/test.jpg'
-        @uploader.thumb.store_path.should == 'uploads/thumb_test.jpg'
-        @uploader.thumb.store_path('kebab.png').should == 'uploads/thumb_kebab.png'
+        expect(@uploader.store_path).to eq('uploads/test.jpg')
+        expect(@uploader.thumb.store_path).to eq('uploads/thumb_test.jpg')
+        expect(@uploader.thumb.store_path('kebab.png')).to eq('uploads/thumb_kebab.png')
       end
 
       it "should move it to the tmp dir with the filename prefixed" do
-        CarrierWave.should_receive(:generate_cache_id).once
+        expect(CarrierWave).to receive(:generate_cache_id).once
         @uploader.cache!(File.open(file_path('test.jpg')))
-        @uploader.current_path.should == public_path('uploads/tmp/1369894322-345-2255/test.jpg')
-        @uploader.thumb.current_path.should == public_path('uploads/tmp/1369894322-345-2255/thumb_test.jpg')
-        @uploader.file.exists?.should be_true
-        @uploader.thumb.file.exists?.should be_true
+        expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/test.jpg'))
+        expect(@uploader.thumb.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/thumb_test.jpg'))
+        expect(@uploader.file.exists?).to be_true
+        expect(@uploader.thumb.file.exists?).to be_true
       end
 
       it "should cache the files based on the parent" do
-        CarrierWave.should_receive(:generate_cache_id).once
+        expect(CarrierWave).to receive(:generate_cache_id).once
         @uploader.cache!(File.open(file_path('bork.txt')))
 
-        File.read(public_path(@uploader.to_s)).should == File.read(public_path(@uploader.thumb.to_s))
+        expect(File.read(public_path(@uploader.to_s))).to eq(File.read(public_path(@uploader.thumb.to_s)))
       end
     end
 
     describe "version with move_to_cache set" do
       before do
         FileUtils.cp(file_path('test.jpg'), file_path('test_copy.jpg'))
-        CarrierWave.stub!(:generate_cache_id).and_return('1369894322-345-2255')
+        allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
         @uploader_class.send(:define_method, :move_to_cache) do
           true
         end
@@ -218,10 +218,10 @@ describe CarrierWave::Uploader do
       it "should copy the parent file when creating the version" do
         @uploader_class.version(:thumb)
         @uploader.cache!(File.open(file_path('test.jpg')))
-        @uploader.current_path.should == public_path('uploads/tmp/1369894322-345-2255/test.jpg')
-        @uploader.thumb.current_path.should == public_path('uploads/tmp/1369894322-345-2255/thumb_test.jpg')
-        @uploader.file.exists?.should be_true
-        @uploader.thumb.file.exists?.should be_true
+        expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/test.jpg'))
+        expect(@uploader.thumb.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/thumb_test.jpg'))
+        expect(@uploader.file.exists?).to be_true
+        expect(@uploader.thumb.file.exists?).to be_true
       end
 
       it "should allow overriding move_to_cache on versions" do
@@ -231,25 +231,25 @@ describe CarrierWave::Uploader do
           end
         end
         @uploader.cache!(File.open(file_path('test.jpg')))
-        @uploader.current_path.should == public_path('uploads/tmp/1369894322-345-2255/test.jpg')
-        @uploader.thumb.current_path.should == public_path('uploads/tmp/1369894322-345-2255/thumb_test.jpg')
-        @uploader.file.exists?.should be_false
-        @uploader.thumb.file.exists?.should be_true
+        expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/test.jpg'))
+        expect(@uploader.thumb.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/thumb_test.jpg'))
+        expect(@uploader.file.exists?).to be_false
+        expect(@uploader.thumb.file.exists?).to be_true
       end
     end
 
     describe '#retrieve_from_cache!' do
       it "should set the path to the tmp dir" do
         @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpg')
-        @uploader.current_path.should == public_path('uploads/tmp/1369894322-345-2255/test.jpg')
-        @uploader.thumb.current_path.should == public_path('uploads/tmp/1369894322-345-2255/thumb_test.jpg')
+        expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/test.jpg'))
+        expect(@uploader.thumb.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/thumb_test.jpg'))
       end
 
       it "should set store_path with versions" do
         @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpg')
-        @uploader.store_path.should == 'uploads/test.jpg'
-        @uploader.thumb.store_path.should == 'uploads/thumb_test.jpg'
-        @uploader.thumb.store_path('kebab.png').should == 'uploads/thumb_kebab.png'
+        expect(@uploader.store_path).to eq('uploads/test.jpg')
+        expect(@uploader.thumb.store_path).to eq('uploads/thumb_test.jpg')
+        expect(@uploader.thumb.store_path('kebab.png')).to eq('uploads/thumb_kebab.png')
       end
     end
 
@@ -261,100 +261,100 @@ describe CarrierWave::Uploader do
 
         @file = File.open(file_path('test.jpg'))
 
-        @base_stored_file = mock('a stored file')
-        @base_stored_file.stub!(:path).and_return('/path/to/somewhere')
-        @base_stored_file.stub!(:url).and_return('http://www.example.com')
+        @base_stored_file = double('a stored file')
+        allow(@base_stored_file).to receive(:path).and_return('/path/to/somewhere')
+        allow(@base_stored_file).to receive(:url).and_return('http://www.example.com')
 
-        @thumb_stored_file = mock('a thumb version of a stored file')
-        @thumb_stored_file.stub!(:path).and_return('/path/to/somewhere/thumb')
-        @thumb_stored_file.stub!(:url).and_return('http://www.example.com/thumb')
+        @thumb_stored_file = double('a thumb version of a stored file')
+        allow(@thumb_stored_file).to receive(:path).and_return('/path/to/somewhere/thumb')
+        allow(@thumb_stored_file).to receive(:url).and_return('http://www.example.com/thumb')
 
-        @preview_stored_file = mock('a preview version of a stored file')
-        @preview_stored_file.stub!(:path).and_return('/path/to/somewhere/preview')
-        @preview_stored_file.stub!(:url).and_return('http://www.example.com/preview')
+        @preview_stored_file = double('a preview version of a stored file')
+        allow(@preview_stored_file).to receive(:path).and_return('/path/to/somewhere/preview')
+        allow(@preview_stored_file).to receive(:url).and_return('http://www.example.com/preview')
 
-        @storage = mock('a storage engine')
-        @storage.stub!(:store!).and_return(@base_stored_file)
+        @storage = double('a storage engine')
+        allow(@storage).to receive(:store!).and_return(@base_stored_file)
 
-        @thumb_storage = mock('a storage engine for thumbnails')
-        @thumb_storage.stub!(:store!).and_return(@thumb_stored_file)
+        @thumb_storage = double('a storage engine for thumbnails')
+        allow(@thumb_storage).to receive(:store!).and_return(@thumb_stored_file)
 
-        @preview_storage = mock('a storage engine for previews')
-        @preview_storage.stub!(:store!).and_return(@preview_stored_file)
+        @preview_storage = double('a storage engine for previews')
+        allow(@preview_storage).to receive(:store!).and_return(@preview_stored_file)
 
-        @uploader_class.storage.stub!(:new).with(@uploader).and_return(@storage)
-        @uploader_class.version(:thumb).storage.stub!(:new).and_return(@thumb_storage)
-        @uploader_class.version(:preview).storage.stub!(:new).and_return(@preview_storage)
+        allow(@uploader_class.storage).to receive(:new).with(@uploader).and_return(@storage)
+        allow(@uploader_class.version(:thumb).storage).to receive(:new).and_return(@thumb_storage)
+        allow(@uploader_class.version(:preview).storage).to receive(:new).and_return(@preview_storage)
       end
 
       it "should set the current path for the version" do
         @uploader.store!(@file)
-        @uploader.current_path.should == '/path/to/somewhere'
-        @uploader.thumb.current_path.should == '/path/to/somewhere/thumb'
+        expect(@uploader.current_path).to eq('/path/to/somewhere')
+        expect(@uploader.thumb.current_path).to eq('/path/to/somewhere/thumb')
       end
 
       it "should set the url" do
         @uploader.store!(@file)
-        @uploader.url.should == 'http://www.example.com'
-        @uploader.thumb.url.should == 'http://www.example.com/thumb'
+        expect(@uploader.url).to eq('http://www.example.com')
+        expect(@uploader.thumb.url).to eq('http://www.example.com/thumb')
       end
 
       it "should, if a file is given as argument, set the store_path" do
         @uploader.store!(@file)
-        @uploader.store_path.should == 'uploads/test.jpg'
-        @uploader.thumb.store_path.should == 'uploads/thumb_test.jpg'
-        @uploader.thumb.store_path('kebab.png').should == 'uploads/thumb_kebab.png'
+        expect(@uploader.store_path).to eq('uploads/test.jpg')
+        expect(@uploader.thumb.store_path).to eq('uploads/thumb_test.jpg')
+        expect(@uploader.thumb.store_path('kebab.png')).to eq('uploads/thumb_kebab.png')
       end
 
       it "should instruct the storage engine to store the file and its version" do
         @uploader.cache!(@file)
-        @storage.should_receive(:store!).with(@uploader.file).and_return(:monkey)
-        @thumb_storage.should_receive(:store!).with(@uploader.thumb.file).and_return(:gorilla)
+        expect(@storage).to receive(:store!).with(@uploader.file).and_return(:monkey)
+        expect(@thumb_storage).to receive(:store!).with(@uploader.thumb.file).and_return(:gorilla)
         @uploader.store!
       end
 
       it "should process conditional versions if the condition method returns true" do
         @uploader_class.version(:preview).version_options[:if] = :true?
-        @uploader.should_receive(:true?).at_least(:once).and_return(true)
+        expect(@uploader).to receive(:true?).at_least(:once).and_return(true)
         @uploader.store!(@file)
-        @uploader.thumb.should be_present
-        @uploader.preview.should be_present
+        expect(@uploader.thumb).to be_present
+        expect(@uploader.preview).to be_present
       end
 
       it "should not process conditional versions if the condition method returns false" do
         @uploader_class.version(:preview).version_options[:if] = :false?
-        @uploader.should_receive(:false?).at_least(:once).and_return(false)
+        expect(@uploader).to receive(:false?).at_least(:once).and_return(false)
         @uploader.store!(@file)
-        @uploader.thumb.should be_present
-        @uploader.preview.should be_blank
+        expect(@uploader.thumb).to be_present
+        expect(@uploader.preview).to be_blank
       end
 
       it "should process conditional version if the condition block returns true" do
         @uploader_class.version(:preview).version_options[:if] = lambda{|record, args| record.true?(args[:file])}
-        @uploader.should_receive(:true?).at_least(:once).and_return(true)
+        expect(@uploader).to receive(:true?).at_least(:once).and_return(true)
         @uploader.store!(@file)
-        @uploader.thumb.should be_present
-        @uploader.preview.should be_present
+        expect(@uploader.thumb).to be_present
+        expect(@uploader.preview).to be_present
       end
 
       it "should not process conditional versions if the condition block returns false" do
         @uploader_class.version(:preview).version_options[:if] = lambda{|record, args| record.false?(args[:file])}
-        @uploader.should_receive(:false?).at_least(:once).and_return(false)
+        expect(@uploader).to receive(:false?).at_least(:once).and_return(false)
         @uploader.store!(@file)
-        @uploader.thumb.should be_present
-        @uploader.preview.should be_blank
+        expect(@uploader.thumb).to be_present
+        expect(@uploader.preview).to be_blank
       end
 
       it "should not cache file twice when store! called with a file" do
         @uploader_class.process :banana
         @uploader.thumb.class.process :banana
 
-        @uploader.should_receive(:banana).at_least(:once).at_most(:once).and_return(true)
-        @uploader.thumb.should_receive(:banana).at_least(:once).at_most(:once).and_return(true)
+        expect(@uploader).to receive(:banana).at_least(:once).at_most(:once).and_return(true)
+        expect(@uploader.thumb).to receive(:banana).at_least(:once).at_most(:once).and_return(true)
 
         @uploader.store!(@file)
-        @uploader.store_path.should == 'uploads/test.jpg'
-        @uploader.thumb.store_path.should == 'uploads/thumb_test.jpg'
+        expect(@uploader.store_path).to eq('uploads/test.jpg')
+        expect(@uploader.thumb.store_path).to eq('uploads/thumb_test.jpg')
       end
     end
 
@@ -367,21 +367,21 @@ describe CarrierWave::Uploader do
         @uploader.store!(@file)
 
         File.open(@uploader.path, 'w') { |f| f.write "Contents changed" }
-        File.read(@uploader.thumb.path).should_not == "Contents changed"
+        expect(File.read(@uploader.thumb.path)).not_to eq("Contents changed")
         @uploader.recreate_versions!
-        File.read(@uploader.thumb.path).should == "Contents changed"
+        expect(File.read(@uploader.thumb.path)).to eq("Contents changed")
       end
 
       it "should recreate all versions if any are missing" do
         @uploader.store!(@file)
 
-        File.exist?(@uploader.thumb.path).should == true
+        expect(File.exist?(@uploader.thumb.path)).to eq(true)
         FileUtils.rm(@uploader.thumb.path)
-        File.exist?(@uploader.thumb.path).should == false
+        expect(File.exist?(@uploader.thumb.path)).to eq(false)
 
         @uploader.recreate_versions!
 
-        File.exist?(@uploader.thumb.path).should == true
+        expect(File.exist?(@uploader.thumb.path)).to eq(true)
       end
 
       it "should recreate only specified versions if passed as args" do
@@ -389,40 +389,40 @@ describe CarrierWave::Uploader do
         @uploader_class.version(:maxi)
         @uploader.store!(@file)
 
-        File.exist?(@uploader.thumb.path).should == true
-        File.exist?(@uploader.mini.path).should == true
-        File.exist?(@uploader.maxi.path).should == true
+        expect(File.exist?(@uploader.thumb.path)).to eq(true)
+        expect(File.exist?(@uploader.mini.path)).to eq(true)
+        expect(File.exist?(@uploader.maxi.path)).to eq(true)
         FileUtils.rm(@uploader.thumb.path)
-        File.exist?(@uploader.thumb.path).should == false
+        expect(File.exist?(@uploader.thumb.path)).to eq(false)
         FileUtils.rm(@uploader.mini.path)
-        File.exist?(@uploader.mini.path).should == false
+        expect(File.exist?(@uploader.mini.path)).to eq(false)
         FileUtils.rm(@uploader.maxi.path)
-        File.exist?(@uploader.maxi.path).should == false
+        expect(File.exist?(@uploader.maxi.path)).to eq(false)
 
         @uploader.recreate_versions!(:thumb, :maxi)
 
-        File.exist?(@uploader.thumb.path).should == true
-        File.exist?(@uploader.maxi.path).should == true
-        File.exist?(@uploader.mini.path).should == false
+        expect(File.exist?(@uploader.thumb.path)).to eq(true)
+        expect(File.exist?(@uploader.maxi.path)).to eq(true)
+        expect(File.exist?(@uploader.mini.path)).to eq(false)
       end
 
       it "should not create version if proc returns false" do
         @uploader_class.version(:mini, :if => Proc.new { |*args| false } )
         @uploader.store!(@file)
 
-        @uploader.mini.path.should be_nil
+        expect(@uploader.mini.path).to be_nil
 
         @uploader.recreate_versions!(:mini)
 
-        @uploader.mini.path.should be_nil
+        expect(@uploader.mini.path).to be_nil
       end
 
       it "should not change the case of versions" do
         @file = File.open(file_path('Uppercase.jpg'))
         @uploader.store!(@file)
-        @uploader.thumb.path.should == public_path('uploads/thumb_Uppercase.jpg')
+        expect(@uploader.thumb.path).to eq(public_path('uploads/thumb_Uppercase.jpg'))
         @uploader.recreate_versions!
-        @uploader.thumb.path.should == public_path('uploads/thumb_Uppercase.jpg')
+        expect(@uploader.thumb.path).to eq(public_path('uploads/thumb_Uppercase.jpg'))
       end
     end
 
@@ -433,39 +433,39 @@ describe CarrierWave::Uploader do
 
         @file = File.open(file_path('test.jpg'))
 
-        @base_stored_file = mock('a stored file')
-        @thumb_stored_file = mock('a thumb version of a stored file')
+        @base_stored_file = double('a stored file')
+        @thumb_stored_file = double('a thumb version of a stored file')
 
-        @storage = mock('a storage engine')
-        @storage.stub!(:store!).and_return(@base_stored_file)
+        @storage = double('a storage engine')
+        allow(@storage).to receive(:store!).and_return(@base_stored_file)
 
-        @thumb_storage = mock('a storage engine for thumbnails')
-        @thumb_storage.stub!(:store!).and_return(@thumb_stored_file)
+        @thumb_storage = double('a storage engine for thumbnails')
+        allow(@thumb_storage).to receive(:store!).and_return(@thumb_stored_file)
 
-        @uploader_class.storage.stub!(:new).with(@uploader).and_return(@storage)
-        @uploader_class.version(:thumb).storage.stub!(:new).with(@uploader.thumb).and_return(@thumb_storage)
+        allow(@uploader_class.storage).to receive(:new).with(@uploader).and_return(@storage)
+        allow(@uploader_class.version(:thumb).storage).to receive(:new).with(@uploader.thumb).and_return(@thumb_storage)
 
-        @base_stored_file.stub!(:delete)
-        @thumb_stored_file.stub!(:delete)
+        allow(@base_stored_file).to receive(:delete)
+        allow(@thumb_stored_file).to receive(:delete)
 
         @uploader.store!(@file)
       end
 
       it "should reset the current path for the version" do
         @uploader.remove!
-        @uploader.current_path.should be_nil
-        @uploader.thumb.current_path.should be_nil
+        expect(@uploader.current_path).to be_nil
+        expect(@uploader.thumb.current_path).to be_nil
       end
 
       it "should reset the url" do
         @uploader.remove!
-        @uploader.url.should be_nil
-        @uploader.thumb.url.should be_nil
+        expect(@uploader.url).to be_nil
+        expect(@uploader.thumb.url).to be_nil
       end
 
       it "should delete all the files" do
-        @base_stored_file.should_receive(:delete)
-        @thumb_stored_file.should_receive(:delete)
+        expect(@base_stored_file).to receive(:delete)
+        expect(@thumb_stored_file).to receive(:delete)
         @uploader.remove!
       end
 
@@ -478,47 +478,47 @@ describe CarrierWave::Uploader do
 
         @file = File.open(file_path('test.jpg'))
 
-        @base_stored_file = mock('a stored file')
-        @base_stored_file.stub!(:path).and_return('/path/to/somewhere')
-        @base_stored_file.stub!(:url).and_return('http://www.example.com')
+        @base_stored_file = double('a stored file')
+        allow(@base_stored_file).to receive(:path).and_return('/path/to/somewhere')
+        allow(@base_stored_file).to receive(:url).and_return('http://www.example.com')
 
-        @thumb_stored_file = mock('a thumb version of a stored file')
-        @thumb_stored_file.stub!(:path).and_return('/path/to/somewhere/thumb')
-        @thumb_stored_file.stub!(:url).and_return('http://www.example.com/thumb')
+        @thumb_stored_file = double('a thumb version of a stored file')
+        allow(@thumb_stored_file).to receive(:path).and_return('/path/to/somewhere/thumb')
+        allow(@thumb_stored_file).to receive(:url).and_return('http://www.example.com/thumb')
 
-        @storage = mock('a storage engine')
-        @storage.stub!(:retrieve!).and_return(@base_stored_file)
+        @storage = double('a storage engine')
+        allow(@storage).to receive(:retrieve!).and_return(@base_stored_file)
 
-        @thumb_storage = mock('a storage engine for thumbnails')
-        @thumb_storage.stub!(:retrieve!).and_return(@thumb_stored_file)
+        @thumb_storage = double('a storage engine for thumbnails')
+        allow(@thumb_storage).to receive(:retrieve!).and_return(@thumb_stored_file)
 
-        @uploader_class.storage.stub!(:new).with(@uploader).and_return(@storage)
-        @uploader_class.version(:thumb).storage.stub!(:new).with(@uploader.thumb).and_return(@thumb_storage)
+        allow(@uploader_class.storage).to receive(:new).with(@uploader).and_return(@storage)
+        allow(@uploader_class.version(:thumb).storage).to receive(:new).with(@uploader.thumb).and_return(@thumb_storage)
       end
 
       it "should set the current path" do
         @uploader.retrieve_from_store!('monkey.txt')
-        @uploader.current_path.should == '/path/to/somewhere'
-        @uploader.thumb.current_path.should == '/path/to/somewhere/thumb'
+        expect(@uploader.current_path).to eq('/path/to/somewhere')
+        expect(@uploader.thumb.current_path).to eq('/path/to/somewhere/thumb')
       end
 
       it "should set the url" do
         @uploader.retrieve_from_store!('monkey.txt')
-        @uploader.url.should == 'http://www.example.com'
-        @uploader.thumb.url.should == 'http://www.example.com/thumb'
+        expect(@uploader.url).to eq('http://www.example.com')
+        expect(@uploader.thumb.url).to eq('http://www.example.com/thumb')
       end
 
       it "should pass the identifier to the storage engine" do
-        @storage.should_receive(:retrieve!).with('monkey.txt').and_return(@base_stored_file)
-        @thumb_storage.should_receive(:retrieve!).with('monkey.txt').and_return(@thumb_stored_file)
+        expect(@storage).to receive(:retrieve!).with('monkey.txt').and_return(@base_stored_file)
+        expect(@thumb_storage).to receive(:retrieve!).with('monkey.txt').and_return(@thumb_stored_file)
         @uploader.retrieve_from_store!('monkey.txt')
-        @uploader.file.should == @base_stored_file
-        @uploader.thumb.file.should == @thumb_stored_file
+        expect(@uploader.file).to eq(@base_stored_file)
+        expect(@uploader.thumb.file).to eq(@thumb_stored_file)
       end
 
       it "should not set the filename" do
         @uploader.retrieve_from_store!('monkey.txt')
-        @uploader.filename.should be_nil
+        expect(@uploader.filename).to be_nil
       end
     end
   end
@@ -541,14 +541,14 @@ describe CarrierWave::Uploader do
 
     describe '#cache!' do
       before do
-        CarrierWave.stub!(:generate_cache_id).and_return('1369894322-345-2255')
+        allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
       end
 
       it "should cache the files based on the version" do
         @uploader.cache!(File.open(file_path('bork.txt')))
 
-        File.read(public_path(@uploader.to_s)).should_not == File.read(public_path(@uploader.thumb.to_s))
-        File.read(public_path(@uploader.thumb.to_s)).should == File.read(public_path(@uploader.small_thumb.to_s))
+        expect(File.read(public_path(@uploader.to_s))).not_to eq(File.read(public_path(@uploader.thumb.to_s)))
+        expect(File.read(public_path(@uploader.thumb.to_s))).to eq(File.read(public_path(@uploader.small_thumb.to_s)))
       end
     end
   end


### PR DESCRIPTION
This conversion is done by Transpec 1.13.1 with the following command:
    transpec
- 598 conversions
  from: obj.should
    to: expect(obj).to
- 294 conversions
  from: == expected
    to: eq(expected)
- 144 conversions
  from: obj.stub!(:message)
    to: allow(obj).to receive(:message)
- 75 conversions
  from: obj.should_receive(:message)
    to: expect(obj).to receive(:message)
- 50 conversions
  from: obj.should_not
    to: expect(obj).not_to
- 38 conversions
  from: mock('something')
    to: double('something')
- 17 conversions
  from: =~ /pattern/
    to: match(/pattern/)
- 16 conversions
  from: obj.should_not_receive(:message)
    to: expect(obj).not_to receive(:message)
- 14 conversions
  from: obj.stub(:message)
    to: allow(obj).to receive(:message)
- 12 conversions
  from: expect { }.not_to raise_error(SpecificErrorClass)
    to: expect { }.not_to raise_error
- 7 conversions
  from: lambda { }.should
    to: expect { }.to
- 7 conversions
  from: lambda { }.should_not
    to: expect { }.not_to
- 6 conversions
  from: Klass.any_instance.should_receive(:message)
    to: expect_any_instance_of(Klass).to receive(:message)
- 2 conversions
  from: Klass.any_instance.should_not_receive(:message)
    to: expect_any_instance_of(Klass).not_to receive(:message)
- 2 conversions
  from: obj.stub!(:message).and_return { value }
    to: obj.stub!(:message) { value }
- 1 conversion
  from: collection.should have(n).items
    to: expect(collection.size).to eq(n)
- 1 conversion
  from: obj.stub!(:message)
    to: obj.stub(:message)

Up RSpec to 2.14.0
