### PR TITLE
Fix cache workfile collision between versions

### DIFF
--- a/lib/carrierwave/uploader/cache.rb
+++ b/lib/carrierwave/uploader/cache.rb
@@ -172,7 +172,7 @@ module CarrierWave
     private
 
       def workfile_path(for_file=original_filename)
-        File.join(CarrierWave.tmp_path, @cache_id, for_file)
+        File.join(CarrierWave.tmp_path, @cache_id, version_name.to_s, for_file)
       end
 
       attr_reader :cache_id, :original_filename

--- a/spec/uploader/cache_spec.rb
+++ b/spec/uploader/cache_spec.rb
@@ -185,6 +185,13 @@ describe CarrierWave::Uploader do
       end
 
     end
+
+    it "should use different workfiles for different versions" do
+      @uploader_class.version :small
+      @uploader_class.version :large
+      @uploader.cache!(File.open(file_path('test.jpg')))
+      expect(@uploader.small.send(:workfile_path)).not_to eq @uploader.large.send(:workfile_path)
+    end
   end
 
   describe '#retrieve_from_cache!' do


### PR DESCRIPTION
After struggling with this for quite a few hours, it turns out that the changes to the cache from #1312 are not versions aware: during caching, different versions share the same workfile which gets deleted in between. Effectively, this breaks cache use for uploaders with two versions or more.

This patch ensures each version creates its own workfile. There are probably still problems if `move_to_cache` is defined as true, and perhaps this issue can also be solved by _somehow_ sharing workfiles without deleting until all are done with it... The problem also does not seem to occur if the `file` storage mechanism is used, which makes it hard to add a failing test (I presume because of the state tracked by the `SanitizedFile` class, which is reused.) There's a lot of moving parts involved here...
