### PR TITLE
Fix mini_magick convert

### DIFF
--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -103,18 +103,9 @@ module CarrierWave
     #
     #     image.convert(:png)
     #
-    def convert(format, page=0)
+    def convert(format, page=nil)
       @format = format
       @page = page
-      manipulate! do |img|
-        img = yield(img) if block_given?
-        img
-      end
-    end
-
-    def convert_all_pages(format)
-      @format = format
-      @page = nil
       manipulate! do |img|
         img = yield(img) if block_given?
         img

--- a/spec/processing/mini_magick_spec.rb
+++ b/spec/processing/mini_magick_spec.rb
@@ -25,8 +25,8 @@ describe CarrierWave::MiniMagick do
       img['format'].should =~ /PNG/
     end
 
-    it "should convert the first page when no page number is specified" do
-      ::MiniMagick::Image.any_instance.should_receive(:format).with('png', 0).once
+    it "should convert all pages when no page number is specified" do
+      ::MiniMagick::Image.any_instance.should_receive(:format).with('png', nil).once
       @instance.convert('png')
     end
 
@@ -53,13 +53,6 @@ describe CarrierWave::MiniMagick do
     it "should scale up the image if it smaller than the given dimensions" do
       @instance.resize_to_fill(1000, 1000)
       @instance.should have_dimensions(1000, 1000)
-    end
-  end
-
-  describe '#convert_all_pages' do
-    it "should convert all pages" do
-      ::MiniMagick::Image.any_instance.should_receive(:format).with('png', nil).once
-      @instance.convert_all_pages('png')
     end
   end
 


### PR DESCRIPTION
MiniMagick.convert by default only converts the first page of tif files to pdf when using below code.

``` ruby
class TestUploader < CarrierWave::Uploader::Base
  include CarrierWave::MiniMagick

  version :pdf do
    process convert: 'pdf'
  end
end
```

After reading throw MiniMagick, I realised that mini_magick makes a poor assumption that by default it will only convert first page. So I had to use below code to convert all pages.

``` ruby
module CarrierWave
  module MiniMagick
    def convert_all_pages_to_pdf
      manipulate! do |img|
        img.format('pdf', nil)
        img = yield(img) if block_given?
        img
      end
    end
  end
end
```

This PR fixes convert to format all pages by default and adds an optional page number parameter to convert specific pages

``` ruby
process convert: 'pdf' #Convert all pages
process convert: ['pdf', 0] #Convert first page
```
