### PR TITLE
Fix broken filename when AWS Signature contains /

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -394,8 +394,8 @@ module CarrierWave
         # [NilClass] no file name available
         #
         def filename(options = {})
-          if file_url = url(options)
-            URI.decode(file_url.split('?').first).gsub(/.*\/(.*?$)/, '\1')
+          if file_url = URI.parse(url(options)) rescue nil
+            File.basename(file_url.path)
           end
         end
 


### PR DESCRIPTION
I'm using fog storage with AWS S3.

Sometimes [CarrierWave::Storage::Fog::File#url](http://www.rdoc.info/github/jnicklas/carrierwave/CarrierWave/Storage/Fog/File:url) returns url with Signature parameter that contains '/', something like:

`https://foobar.s3-ap-northeast-1.amazonaws.com/uploads/foobar/foobar/1/foobar.csv?AWSAccessKeyId=BLAHBLAHBLAH&Signature=EyLYyChcqFXEaCBg2p4M6/4LrWs=&Expires=1407927326`

the [CarrierWave::Storage::Fog::File#filename](http://www.rdoc.info/github/jnicklas/carrierwave/CarrierWave/Storage/Fog/File:filename) method returns `"4LrWs=&Expires=1407927326"` for this url :dizzy_face:

i fixed that.
