### PR TITLE
.all.each is highly inefficient with many rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ instance.recreate_versions!(:thumb, :large)
 Or on a mounted uploader:
 
 ```ruby
-User.all.each do |user|
+User.find_each do |user|
   user.avatar.recreate_versions!
 end
 ```
@@ -439,7 +439,7 @@ end
 Note: `recreate_versions!` will throw an exception on records without an image. To avoid this, scope the records to those with images or check if an image exists within the block. If you're using ActiveRecord, recreating versions for a user avatar might look like this:
 
 ```ruby
-User.all.each do |user|
+User.find_each do |user|
   user.avatar.recreate_versions! if user.avatar?
 end
 ```


### PR DESCRIPTION
According to http://guides.rubyonrails.org/active_record_querying.html, chapter 1.3, you should never use .all.each when iterating over the whole table.
