### PR TITLE
Fix file delete being called twice on remove

### DIFF
--- a/lib/carrierwave/mount.rb
+++ b/lib/carrierwave/mount.rb
@@ -240,7 +240,7 @@ module CarrierWave
         end
 
         def remove_previously_stored_#{column}
-          if @previous_model_for_#{column} && @previous_model_for_#{column}.#{column}.path != #{column}.path
+          if @previous_model_for_#{column} && @previous_model_for_#{column}.#{column}.path != #{column}.path && !#{column}.path.nil?
             @previous_model_for_#{column}.#{column}.remove!
             @previous_model_for_#{column} = nil
           end

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -658,6 +658,12 @@ describe CarrierWave::ActiveRecord do
         expect(@event.save).to be_false
         expect(File.exist?(public_path('uploads/old.jpeg'))).to be_true
       end
+
+      it "should only delete the file once when the file is removed" do
+        @event.remove_image = true
+        expect_any_instance_of(CarrierWave::SanitizedFile).to receive(:delete).exactly(1).times
+        expect(@event.save).to be_true
+      end
     end
 
     describe 'with an overriden filename' do


### PR DESCRIPTION
When a file is removed with something like `.remove_image = true` it's seen as you replacing the file with a new file and still tries to delete the "old file" even though the old file was just deleted. This is mitigated in `CarrierWave::SanitizedFile#delete` by an `if exists?` condition. But it's unnecessary and especially annoying when trying to use a file storage API.
