### PR TITLE
Change image extension when converting formats.

### DIFF
--- a/lib/carrierwave/processing/mime_types.rb
+++ b/lib/carrierwave/processing/mime_types.rb
@@ -59,7 +59,7 @@ module CarrierWave
     #
     def set_content_type(override=false)
       if override || file.content_type.blank? || generic_content_type?
-        new_content_type = ::MIME::Types.type_for(file.original_filename).first.to_s
+        new_content_type = ::MIME::Types.type_for(current_path).first.to_s
         if file.respond_to?(:content_type=)
           file.content_type = new_content_type
         else

--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -300,6 +300,12 @@ module CarrierWave
         image.format(@format.to_s.downcase) if @format
         image = yield(image)
         image.write(current_path)
+
+        if @format
+          move_to = current_path.chomp(File.extname(current_path)) + ".#{@format}"
+          file.move_to(move_to, permissions, directory_permissions)
+        end
+
         image.run_command("identify", current_path)
       ensure
         image.destroy!

--- a/lib/carrierwave/processing/rmagick.rb
+++ b/lib/carrierwave/processing/rmagick.rb
@@ -322,11 +322,15 @@ module CarrierWave
       frames.append(true) if block_given?
 
       write_block = create_info_block(options[:write])
+
       if options[:format] || @format
         frames.write("#{options[:format] || @format}:#{current_path}", &write_block)
+        move_to = current_path.chomp(File.extname(current_path)) + ".#{options[:format] || @format}"
+        file.move_to(move_to, permissions, directory_permissions)
       else
         frames.write(current_path, &write_block)
       end
+
       destroy_image(frames)
     rescue ::Magick::ImageMagickError => e
       raise CarrierWave::ProcessingError, I18n.translate(:"errors.messages.rmagick_processing_error", :e => e, :default => I18n.translate(:"errors.messages.rmagick_processing_error", :e => e, :locale => :en))

--- a/spec/processing/mime_types_spec.rb
+++ b/spec/processing/mime_types_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe CarrierWave::MimeTypes do
 
   before do
-    @klass = Class.new do
+    @klass = Class.new(CarrierWave::Uploader::Base) do
       attr_accessor :content_type
       include CarrierWave::MimeTypes
     end

--- a/spec/processing/mini_magick_spec.rb
+++ b/spec/processing/mini_magick_spec.rb
@@ -5,18 +5,19 @@ require 'spec_helper'
 describe CarrierWave::MiniMagick do
 
   before do
-    @klass = Class.new do
+    @klass = Class.new(CarrierWave::Uploader::Base) do
       include CarrierWave::MiniMagick
     end
     @instance = @klass.new
     FileUtils.cp(file_path('landscape.jpg'), file_path('landscape_copy.jpg'))
-    @instance.stub(:current_path).and_return(file_path('landscape_copy.jpg'))
     @instance.stub(:cached?).and_return true
     @instance.stub(:url).and_return nil
+    @instance.stub(:file).and_return(CarrierWave::SanitizedFile.new(file_path('landscape_copy.jpg')))
   end
 
   after do
-    FileUtils.rm(file_path('landscape_copy.jpg'))
+    FileUtils.rm(file_path('landscape_copy.jpg')) if File.exist?(file_path('landscape_copy.jpg'))
+    FileUtils.rm(file_path('landscape_copy.png')) if File.exist?(file_path('landscape_copy.png'))
   end
 
   describe "#convert" do
@@ -24,6 +25,7 @@ describe CarrierWave::MiniMagick do
       @instance.convert('png')
       img = ::MiniMagick::Image.open(@instance.current_path)
       img['format'].should =~ /PNG/
+      @instance.file.extension.should == 'png'
     end
   end
 
@@ -39,8 +41,9 @@ describe CarrierWave::MiniMagick do
       @instance.resize_to_fill(200, 200)
       @instance.should have_dimensions(200, 200)
       ::MiniMagick::Image.open(@instance.current_path)['format'].should =~ /PNG/
+      @instance.file.extension.should == 'png'
     end
-    
+
     it "should scale up the image if it smaller than the given dimensions" do
       @instance.resize_to_fill(1000, 1000)
       @instance.should have_dimensions(1000, 1000)
@@ -102,6 +105,7 @@ describe CarrierWave::MiniMagick do
       @instance.resize_to_fit(200, 200)
       @instance.should have_dimensions(200, 150)
       ::MiniMagick::Image.open(@instance.current_path)['format'].should =~ /PNG/
+      @instance.file.extension.should == 'png'
     end
 
     it "should scale up the image if it smaller than the given dimensions" do
@@ -122,6 +126,7 @@ describe CarrierWave::MiniMagick do
       @instance.resize_to_limit(200, 200)
       @instance.should have_dimensions(200, 150)
       ::MiniMagick::Image.open(@instance.current_path)['format'].should =~ /PNG/
+      @instance.file.extension.should == 'png'
     end
 
     it "should not scale up the image if it smaller than the given dimensions" do


### PR DESCRIPTION
It's a new version of https://github.com/carrierwaveuploader/carrierwave/pull/404 but I think it should be default behaviour and we don't need that rename option. @bensie what do you think?
