### PR TITLE
Fix bug with remove_previously_stored_#{column} callback, when updating in a transaction, and that process is rollback

### DIFF
--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -30,7 +30,7 @@ module CarrierWave
       after_commit :"remove_#{column}!", :on => :destroy
       after_commit :"mark_remove_#{column}_false", :on => :update
       before_update :"store_previous_model_for_#{column}"
-      after_save :"remove_previously_stored_#{column}"
+      after_commit :"remove_previously_stored_#{column}", :on => :update
 
       class_eval <<-RUBY, __FILE__, __LINE__+1
         def #{column}=(new_file)

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -637,6 +637,17 @@ describe CarrierWave::ActiveRecord do
         expect(File.exist?(public_path('uploads/new.jpeg'))).to be_true
         expect(File.exist?(public_path('uploads/old.jpeg'))).to be_false
       end
+      
+      it 'should not remove old file if transaction is rollback' do
+        Event.transaction do
+          @event.image = stub_file('new.jpeg')
+          @event.save
+          expect(File.exist?(public_path('uploads/new.jpeg'))).to be_true
+          expect(File.exist?(public_path('uploads/old.jpeg'))).to be_true
+          raise ActiveRecord::Rollback
+        end
+        expect(File.exist?(public_path('uploads/old.jpeg'))).to be_true
+      end
 
       it "should not remove old file if old file had a different path but config is false" do
         @uploader.stub(:remove_previously_stored_files_after_update).and_return(false)


### PR DESCRIPTION
Fix bug with remove_previously_stored_#{column} callback, when updating in a transaction, and that process is rollback

The old file will be delete, but the new file name can not store success into database.
## For example:

``` ruby
User.transaction do
  @user.avatar = new_file
  @user.save
  # new file stored
  # old file deleted with callback: remove_previously_stored_avatar
  # ... do bla bla
  raise ActiveRecord::Rollback
  # new file name can not update to datebase
end
```
