### PR TITLE
Fix broken filename when AWS Signature contains /

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -394,8 +394,8 @@ module CarrierWave
         # [NilClass] no file name available
         #
         def filename(options = {})
-          if file_url = url(options)
-            URI.decode(file_url.split('?').first).gsub(/.*\/(.*?$)/, '\1')
+          if file_url = URI.parse(url(options)) rescue nil
+            File.basename(file_url.path)
           end
         end
 


### PR DESCRIPTION
Needs a small change to ensure the File class is unambiguous (Carrierwave vs. IO)
