### PR TITLE
Fixed typos in the CarrierWave::MiniMagick documentation

### DIFF
--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -39,6 +39,7 @@ module CarrierWave
   #           img
   #         end
   #       end
+  #     end
   #
   # === Note
   #
@@ -49,7 +50,7 @@ module CarrierWave
   #
   # http://mini_magick.rubyforge.org/
   # and
-  # https://github.com/minimagic/minimagick/
+  # https://github.com/minimagick/minimagick/
   #
   #
   module MiniMagick


### PR DESCRIPTION
In mini_magick.rb:
- Added missing `end` statement to the example helper method.
- Made correction to the github repo url for minimagick.
