### PR TITLE
Add the cache_only configuration option

### DIFF
--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -38,6 +38,7 @@ module CarrierWave
         add_config :validate_processing
         add_config :validate_download
         add_config :mount_on
+        add_config :cache_only
 
         # set default values
         reset_config

--- a/lib/carrierwave/uploader/store.rb
+++ b/lib/carrierwave/uploader/store.rb
@@ -54,7 +54,7 @@ module CarrierWave
       #
       def store!(new_file=nil)
         cache!(new_file) if new_file && ((@cache_id != parent_cache_id) || @cache_id.nil?)
-        if @file and @cache_id
+        if !cache_only and @file and @cache_id
           with_callbacks(:store, new_file) do
             new_file = storage.store!(@file)
             if delete_tmp_file_after_storage

--- a/spec/uploader/store_spec.rb
+++ b/spec/uploader/store_spec.rb
@@ -102,6 +102,35 @@ describe CarrierWave::Uploader do
       @uploader.store!
     end
 
+    context "with the cache_only option set to true" do
+      before do
+        @uploader_class.cache_only = true
+      end
+
+      it "should not instruct the storage engine to store the file" do
+        @uploader.cache!(@file)
+        @storage.should_not_receive(:store!)
+        @uploader.store!
+      end
+
+      it "should still be cached" do
+        @uploader.store!(@file)
+        @uploader.should be_cached
+      end
+
+      it "should not reset the cache_name" do
+        @uploader.cache!(@file)
+        @uploader.store!
+        @uploader.cache_name.should_not be_nil
+      end
+
+      it "should not delete the old file" do
+        @uploader.cache!(@file)
+        @uploader.file.should_not_receive(:delete)
+        @uploader.store!
+      end
+    end
+
     context "with the delete_tmp_file_after_storage option set to false" do
       before do
         @uploader_class.delete_tmp_file_after_storage = false


### PR DESCRIPTION
Hey everyone,

I’ve been trying to get test fixtures working on CarrierWave, and came up with [a solution that works by monkey-patching `CarrierWave::Mount::Mounter#store!`](http://jeffkreeftmeijer.com/2014/using-test-fixtures-with-carrierwave/). That way, you prevent CarrierWave from moving the files from the cache directory to the `store_dir`.

It’d be great to be able to set a configuration option in your tests instead of breaking a method in the mounter, so I added a configuration option called “cache_only”, which does the same thing. What do you think?
