### PR TITLE
update README.md wrt Cache-Control max-age

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,9 +557,9 @@ CarrierWave.configure do |config|
     :host                   => 's3.example.com',             # optional, defaults to nil
     :endpoint               => 'https://s3.example.com:8080' # optional, defaults to nil
   }
-  config.fog_directory  = 'name_of_directory'                     # required
-  config.fog_public     = false                                   # optional, defaults to true
-  config.fog_attributes = {'Cache-Control'=>'max-age=315576000'}  # optional, defaults to {}
+  config.fog_directory  = 'name_of_directory'                          # required
+  config.fog_public     = false                                        # optional, defaults to true
+  config.fog_attributes = {'Cache-Control'=>"max-age=#{365.day.to_i}"} # optional, defaults to {}
 end
 ```
 


### PR DESCRIPTION
Change max-age from `10` years (`315576000` seconds) to `1` year (`31557600`) (the actual maximum) -- as per issue #1466 -- though just as I was making this edit I realized that it is even more convenient to say `365.day` (as opposed to `1.year`), as it enables people to easily change the number to `1.day` or `7.day` or `14.day` or `30.day`, etc., in accordance with what makes sense for their application.
