### PR TITLE
to be future changes-proof don't rely on mime gem file extensions order

### DIFF
--- a/spec/uploader/download_spec.rb
+++ b/spec/uploader/download_spec.rb
@@ -111,7 +111,7 @@ describe CarrierWave::Uploader::Download do
 
     it 'should set file extension based on content-type if missing' do
       @uploader.download!('http://www.example.com/test-with-no-extension/test')
-      @uploader.url.should == '/uploads/tmp/1369894322-345-2255/test.jpeg'
+      @uploader.url.should match %r{/uploads/tmp/1369894322-345-2255/test\.jp(e|e?g)$}
     end
 
     it 'should not obscure original exception message' do


### PR DESCRIPTION
We taking first extension matching mime type while remote downloading. 
mime-types (2.3) gem has this json definition:

``` json
{"content-type":"image/jpeg","encoding":"base64","extensions":["jpe","jpeg","jpg"], ....
```

So, this spec fails: 
https://github.com/carrierwaveuploader/carrierwave/blob/be840d15eaf8900f48241ab6d802fd62b5e3b584/spec/uploader/download_spec.rb#L112-L115
