### PR TITLE
Don't read file twice in sanitized_file

### DIFF
--- a/lib/carrierwave/uploader/cache.rb
+++ b/lib/carrierwave/uploader/cache.rb
@@ -71,10 +71,8 @@ module CarrierWave
         _content = file.read
         if _content.is_a?(File) # could be if storage is Fog
           sanitized = CarrierWave::Storage::Fog.new(self).retrieve!(File.basename(_content.path))
-          sanitized.read if sanitized.exists?
-
         else
-          sanitized = SanitizedFile.new :tempfile => StringIO.new(file.read),
+          sanitized = SanitizedFile.new :tempfile => StringIO.new(_content),
             :filename => File.basename(path), :content_type => file.content_type
         end
         sanitized

--- a/spec/uploader/cache_spec.rb
+++ b/spec/uploader/cache_spec.rb
@@ -20,6 +20,21 @@ describe CarrierWave::Uploader do
     end
   end
 
+  describe '#sanitized_file' do
+    before do
+      @uploader.store! CarrierWave::SanitizedFile.new(File.open(file_path('test.jpg')))
+    end
+
+    it "should return a sanitized file" do
+      @uploader.sanitized_file.should be_an_instance_of(CarrierWave::SanitizedFile)
+    end
+
+    it "should only read file once" do
+      @uploader.file.should_receive(:read).once.and_return('this is stuff')
+      @uploader.sanitized_file
+    end
+  end
+
   describe '#cache!' do
 
     before do


### PR DESCRIPTION
This can cause excess extra traffic and memory usage when using cache! or directly calling sanitized_file, especially with fog. Also removed what seems to be a useless read in the if block.

I added some specs for the normal case, but the case where file.read returns a File is not tested, because I have no idea how to reproduce that situation. It seems to be related to an old issue #814.
