### PR TITLE
Custom version filename and callbacks

### DIFF
--- a/lib/carrierwave/mount.rb
+++ b/lib/carrierwave/mount.rb
@@ -241,6 +241,11 @@ module CarrierWave
 
         def remove_previously_stored_#{column}
           if @previous_model_for_#{column} && @previous_model_for_#{column}.#{column}.path != #{column}.path
+            #{column}.versions.each do |name, v|
+              if @previous_model_for_#{column}.#{column}.versions[name].path == v.path
+                @previous_model_for_#{column}.#{column}.versions[name].file.keep_file!
+              end
+            end
             @previous_model_for_#{column}.#{column}.remove!
             @previous_model_for_#{column} = nil
           end

--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -16,7 +16,7 @@ module CarrierWave
   #
   class SanitizedFile
 
-    attr_accessor :file
+    attr_accessor :file, :keep_file
 
     class << self
       attr_writer :sanitize_regexp
@@ -27,7 +27,12 @@ module CarrierWave
     end
 
     def initialize(file)
-      self.file = file
+      self.file      = file
+      self.keep_file = false
+    end
+
+    def keep_file!
+      self.keep_file = true
     end
 
     ##

--- a/lib/carrierwave/uploader/remove.rb
+++ b/lib/carrierwave/uploader/remove.rb
@@ -12,7 +12,7 @@ module CarrierWave
       #
       def remove!
         with_callbacks(:remove) do
-          @file.delete if @file
+          @file.delete if @file && !@file.keep_file
           @file = nil
           @cache_id = nil
         end

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -619,6 +619,11 @@ describe CarrierWave::ActiveRecord do
       @class = Class.new(Event)
       @class.table_name = "events"
       @uploader = Class.new(CarrierWave::Uploader::Base)
+      @uploader.version :thumb do
+        def full_filename(for_file = model.avatar.file)
+          "thumb.jpeg"
+        end
+      end
       @class.mount_uploader(:image, @uploader)
       @event = @class.new
       @event.image = stub_file('old.jpeg')
@@ -631,6 +636,12 @@ describe CarrierWave::ActiveRecord do
     end
 
     describe 'normally' do
+      it "should not remove version with fixed path" do
+        @event.image = stub_file('new.jpeg')
+        expect(@event.save).to be_true
+        expect(File.exist?(public_path('uploads/thumb.jpeg'))).to be_true
+      end
+
       it "should remove old file if old file had a different path" do
         @event.image = stub_file('new.jpeg')
         expect(@event.save).to be_true


### PR DESCRIPTION
Hi,

I'm have an `AvatarUploader` and I want to add and static version to keep the same url when the user change his avatar.

I found the following issue, when I change the avatar:

``` ruby
u.update_attributes avatar: File.open("/Users/jrdi/Downloads/avatar-1.jpg")
```

It doesn't generates the static version. I make some experiments and I found that if I skip the remove callback:

``` ruby
skip_callback :save, :after, :remove_previously_stored_avatar
```

Everything works fine (but it doesn't remove previous avatar of course), so I suspect that something is wrong with this callback.

Here you can found AvatarUploader.

``` ruby
class AvatarUploader < CarrierWave::Uploader::Base
  include CarrierWave::MiniMagick

  storage :file

  def store_dir
    "system/uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
  end

  process :resize_to_fill => [150, 150]

  def extension_white_list
    %w(jpg jpeg png)
  end

  version :big do
    process :resize_to_fill => [84, 84]
  end

  version :medium do
    process :resize_to_fill => [56, 56]
  end

  version :small do
    process :resize_to_fill => [42, 42]
  end

  version :static do
    def full_filename(for_file = model.avatar.file)
      "static.jpg"
    end
  end
end
```

Any idea about what is going wrong? Thanks!
