### PR TITLE
Inheritance problem: failing spec (why?)

### DIFF
--- a/spec/uploader/versions_spec.rb
+++ b/spec/uploader/versions_spec.rb
@@ -164,6 +164,31 @@ describe CarrierWave::Uploader do
       end
     end
 
+    it "shouldn't raise an error in this test" do
+      @child_uploader_class = Class.new(@uploader_class)
+      @child_uploader = @child_uploader_class.new
+
+      @uploader_class.version :thumb do
+      end
+      # should next code affect original uploader?!
+      @child_uploader_class.version :thumb do
+        process :foo
+      end
+
+      @class = Class.new
+      @class.send(:extend, CarrierWave::Mount)
+      @class.mount_uploader(:image, @uploader_class)
+      @instance = @class.new
+
+      # this line is failing.
+      # it tries to call `foo` method, but why?
+      # `@instance.image` is a @uploader_class but not @child_uploader_class.
+      # should `process :foo` affect *parent class*?!
+      @instance.image = stub_file('test.jpg')
+
+      @instance.image.should be_a(@uploader_class)
+    end
+
   end
 
   describe 'with a version' do


### PR DESCRIPTION
```
CarrierWave::Uploader.version shouldn't raise an error in this test
Failure/Error: @instance.image = stub_file('test.jpg')
NoMethodError: undefined method `foo' for #<#<Class:0x00000005a86da8>:0x00000005b4f190>
# ./lib/carrierwave/uploader/processing.rb:84:in `block in process!'
# ./lib/carrierwave/uploader/processing.rb:76:in `each'
# ./lib/carrierwave/uploader/processing.rb:76:in `process!'
# ./lib/carrierwave/uploader/callbacks.rb:16:in `block in with_callbacks'
# ./lib/carrierwave/uploader/callbacks.rb:16:in `each'
# ./lib/carrierwave/uploader/callbacks.rb:16:in `with_callbacks'
# ./lib/carrierwave/uploader/cache.rb:129:in `cache!'
# ./lib/carrierwave/uploader/versions.rb:263:in `block in cache_versions!'
# ./lib/carrierwave/uploader/versions.rb:261:in `each'
# ./lib/carrierwave/uploader/versions.rb:261:in `cache_versions!'
# ./lib/carrierwave/uploader/callbacks.rb:18:in `block in with_callbacks'
# ./lib/carrierwave/uploader/callbacks.rb:18:in `each'
# ./lib/carrierwave/uploader/callbacks.rb:18:in `with_callbacks'
# ./lib/carrierwave/uploader/cache.rb:129:in `cache!'
# ./lib/carrierwave/mount.rb:329:in `cache'
# ./lib/carrierwave/mount.rb:163:in `image='
# ./lib/carrierwave/mount.rb:148:in `image='
# ./spec/uploader/versions_spec.rb:183:in `block (3 levels) in <top (required)>'
```
