### PR TITLE
Fix bug with remove_previously_stored_#{column} callback, when updating in a transaction, and that process is rollback. Again~

### DIFF
--- a/lib/carrierwave/mount.rb
+++ b/lib/carrierwave/mount.rb
@@ -182,9 +182,13 @@ module CarrierWave
         def #{column}_identifier
           _mounter(:#{column}).read_identifiers[0]
         end
+        
+        def store_previous_changes_for_#{column}
+          @_previous_changes_for_#{column} = changes[_mounter(:#{column}).serialization_column]
+        end
 
         def remove_previously_stored_#{column}
-          before, after = changes[_mounter(:#{column}).serialization_column]
+          before, after = @_previous_changes_for_#{column}
           _mounter(:#{column}).remove_previous([before], [after])
         end
       RUBY
@@ -328,9 +332,13 @@ module CarrierWave
         def #{column}_identifiers
           _mounter(:#{column}).read_identifiers
         end
+        
+        def store_previous_changes_for_#{column}
+          @_previous_changes_for_#{column} = changes[_mounter(:#{column}).serialization_column]
+        end
 
         def remove_previously_stored_#{column}
-          _mounter(:#{column}).remove_previous(*changes[_mounter(:#{column}).serialization_column])
+          _mounter(:#{column}).remove_previous(*@_previous_changes_for_#{column})
         end
       RUBY
     end

--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -59,7 +59,8 @@ module CarrierWave
       after_commit :"remove_#{column}!", :on => :destroy
       after_commit :"mark_remove_#{column}_false", :on => :update
 
-      after_save :"remove_previously_stored_#{column}"
+      after_save :"store_previous_changes_for_#{column}"
+      after_commit :"remove_previously_stored_#{column}", :on => :update
 
       class_eval <<-RUBY, __FILE__, __LINE__+1
         def #{column}=(new_file)

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -710,6 +710,17 @@ describe CarrierWave::ActiveRecord do
       expect(File.exist?(public_path('uploads/old.jpeg'))).to be_true
       expect(File.exist?(public_path('uploads/thumb_old.jpeg'))).to be_true
     end
+    
+    it 'should not remove old file if transaction is rollback' do
+      Event.transaction do
+        @event.image = stub_file('new.jpeg')
+        @event.save
+        expect(File.exist?(public_path('uploads/new.jpeg'))).to be_true
+        expect(File.exist?(public_path('uploads/old.jpeg'))).to be_true
+        raise ActiveRecord::Rollback
+      end
+      expect(File.exist?(public_path('uploads/old.jpeg'))).to be_true
+    end
   end
 
   describe '#mount_uploader removing old files with multiple uploaders' do


### PR DESCRIPTION
like #1447 @bensie 
