### PR TITLE
Remove duplicate 'uploader' when generate.

### DIFF
--- a/lib/generators/templates/uploader.rb
+++ b/lib/generators/templates/uploader.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-class <%= class_name %>Uploader < CarrierWave::Uploader::Base
+class <%= uploader_class_name %>Uploader < CarrierWave::Uploader::Base
 
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick

--- a/lib/generators/uploader_generator.rb
+++ b/lib/generators/uploader_generator.rb
@@ -2,6 +2,14 @@ class UploaderGenerator < Rails::Generators::NamedBase
   source_root File.expand_path("../templates", __FILE__)
 
   def create_uploader_file
-    template "uploader.rb", File.join('app/uploaders', class_path, "#{file_name}_uploader.rb")
+    template "uploader.rb", File.join('app/uploaders', class_path, "#{uploader_file_name}_uploader.rb")
+  end
+
+  def uploader_file_name
+    file_name.gsub("_uploader", "")
+  end
+
+  def uploader_class_name
+    class_name.gsub("Uploader", "")
   end
 end

--- a/spec/generators/uploader_generator_spec.rb
+++ b/spec/generators/uploader_generator_spec.rb
@@ -18,4 +18,10 @@ describe UploaderGenerator, :type => :generator do
     run_generator %w(MyModule::Avatar)
     assert_file 'app/uploaders/my_module/avatar_uploader.rb', /class MyModule::AvatarUploader < CarrierWave::Uploader::Base/
   end
+
+  it "should not append '_uploader' if user specifies it" do
+    run_generator %w(attachment_uploader)
+    assert_file 'app/uploaders/attachment_uploader.rb', /class AttachmentUploader < CarrierWave::Uploader::Base/
+  end
+
 end


### PR DESCRIPTION
Sometimes when generating, it is really annoying.

Before this commit, when user generate uploader with
<kbd>rails generate uploader image_uploader</kbd>

User get `app/uploaders/image_uploader_uploader.rb`

After this commit,

User get `app/uploaders/image_uploader.rb`

Class name is fixed the same way.

This commit fix the duplicate 'uploader' problem.
