### PR TITLE
Cause Fog::File.read to return its contents after upload

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -314,7 +314,7 @@ module CarrierWave
             fog_file = new_file.to_file
             @content_type ||= new_file.content_type
             @file = directory.files.create({
-              :body         => fog_file ? fog_file : new_file.read,
+              :body         => (fog_file ? fog_file : new_file).read,
               :content_type => @content_type,
               :key          => path,
               :public       => @uploader.fog_public

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -53,6 +53,9 @@ end
         end
 
         it "should upload the file" do
+          # reading the file after upload should return the body, not a closed tempfile
+          @fog_file.read.should == 'this is stuff'
+          # make sure it actually uploaded to the service, too
           @directory.files.get(store_path).body.should == 'this is stuff'
         end
 


### PR DESCRIPTION
This solves the case where uploading a file to Fog and then reading its body
immediately afterward results in a deleted, closed tempfile rather
than the actual contents of the upload. #1338 
