### PR TITLE
Fix wrong method name mount_uploaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Open your model file and mount the uploader:
 
 ```ruby
 class User < ActiveRecord::Base
-  mount_uploaders :avatars, AvatarUploader
+  mount_uploader :avatars, AvatarUploader
 end
 ```
 


### PR DESCRIPTION
Fixes incorrect method name in readme
