### PR TITLE
Streaming of SanitizedFile.

### DIFF
--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -16,6 +16,8 @@ module CarrierWave
   #
   class SanitizedFile
 
+    DEFAULT_STREAM_SIZE = 2000000
+
     attr_accessor :file
 
     class << self
@@ -166,6 +168,7 @@ module CarrierWave
       end
     end
 
+
     ##
     # Moves the file to the given path
     #
@@ -183,7 +186,7 @@ module CarrierWave
       if exists?
         FileUtils.mv(path, new_path) unless new_path == path
       else
-        File.open(new_path, "wb") { |f| f.write(read) }
+        move_stream(new_path)
       end
       chmod!(new_path, permissions)
       if keep_filename
@@ -215,7 +218,7 @@ module CarrierWave
       if exists?
         FileUtils.cp(path, new_path) unless new_path == path
       else
-        File.open(new_path, "wb") { |f| f.write(read) }
+        move_stream(new_path)
       end
       chmod!(new_path, permissions)
       self.class.new({:tempfile => new_path, :content_type => content_type})
@@ -328,5 +331,31 @@ module CarrierWave
       return filename, "" # In case we weren't able to split the extension
     end
 
+    protected
+    def move_stream(new_path)
+      File.open(new_path, "wb") do |f| 
+        with_reader do |data|
+          f.write(data)
+        end
+      end
+    end
+
+    def with_reader
+      if @content
+        yield @content
+      elsif is_path?
+        File.open(@file, "rb") do |file|
+          while current_data = file.read(DEFAULT_STREAM_SIZE)
+            yield current_data
+          end
+        end
+      else
+        @file.rewind if @file.respond_to?(:rewind)
+        while current_data = @file.read(DEFAULT_STREAM_SIZE)
+          yield current_data
+        end
+        @file.close if @file.respond_to?(:close) && @file.respond_to?(:closed?) && !@file.closed?
+      end
+    end
   end # SanitizedFile
 end # CarrierWave

--- a/lib/carrierwave/uploader/download.rb
+++ b/lib/carrierwave/uploader/download.rb
@@ -53,6 +53,10 @@ module CarrierWave
           end
         end
 
+        def read(*args, &block)
+          file.read(*args, &block)
+        end
+
         def method_missing(*args, &block)
           file.send(*args, &block)
         end


### PR DESCRIPTION
Added streaming, where available, for moving/copying of SantizedFile.

This doesn't completely fix the issue with streaming, as that will require a re-work of the existing API to support chunked reads.  However, it does keep large files out of memory where possible (e.g. Streaming a large POST body as binary) - at least in the behaviour of sanitized file.

I'm aware there is a fairly bad hack to support the legacy api - but I can't see a way around it without major incompatibilities.