### PR TITLE
Fixed filename which was returning random strings

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -395,7 +395,8 @@ module CarrierWave
         #
         def filename(options = {})
           if file_url = url(options)
-            URI.decode(file_url.split('?').first).gsub(/.*\/(.*?$)/, '\1')
+            uri = URI.parse(file_url)
+            Pathname(uri.path).basename.to_s
           end
         end
 

--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -396,7 +396,8 @@ module CarrierWave
         def filename(options = {})
           if file_url = url(options)
             uri = URI.parse(file_url)
-            Pathname(uri.path).basename.to_s
+            path = URI.decode uri.path
+            Pathname(path).basename.to_s
           end
         end
 


### PR DESCRIPTION
cf.

```ruby
[103] pry(main)> URI.decode('https://wulst.s3-eu-west-1.amazonaws.com/uploads/attachment/file/140/guy.rb?AWSAccessKeyId=24g24t82g4248g&Signature=Efq9pbU/sOtpm6SdDquaVzuY9/Q%3D&Expires=1418659279').gsub(/.*\/(.*?$)/, '\1').split('?').first
=> "Q=&Expires=1418659279"
```

The regex fails if the signature contains slashes. I might add a test. Just noting that not to forget about it.

This happens when using S3 as the fog storage.