### PR TITLE
Fog storage handles missing files on delete

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -237,6 +237,7 @@ module CarrierWave
         def delete
           # avoid a get by just using local reference
           directory.files.new(:key => path).destroy
+        rescue ::Fog::Service::NotFound
         end
 
         ##


### PR DESCRIPTION
... to mirror the file storage behaviour on delete.