### PR TITLE
Flush mounters on dup of active record model

### DIFF
--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -85,6 +85,12 @@ module CarrierWave
           @_mounters = nil
           super
         end
+
+        # Reset cached mounter on record dup
+        def initialize_dup(other)
+          @_mounters = nil
+          super
+        end
       RUBY
     end
 

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -1485,4 +1485,12 @@ describe CarrierWave::ActiveRecord do
       expect(File.exist?(public_path('uploads/old.jpeg'))).to be_true
     end
   end
+
+  describe "#dup" do
+    it "appropriately removes the model reference from the new models uploader" do
+      @event.save
+      new_event = @event.dup
+      expect(new_event.image.model).not_to eq @event
+    end
+  end
 end


### PR DESCRIPTION
When an ActiveRecord model is "#dup"ed the mounted carrierwave uploaders retain their reference to the old model.

Gist showing the bug: https://gist.github.com/danielevans/2316c9b07afa7efca92a