### PR TITLE
Don't error when size is called on a deleted file

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -288,7 +288,7 @@ module CarrierWave
         # [Integer] size of file body
         #
         def size
-          file.content_length
+          file.nil? ? 0 : file.content_length
         end
 
         ##

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -183,6 +183,17 @@ end
           @fog_file.delete
           @directory.files.head(store_path).should == nil
         end
+        context "when the file has been deleted" do
+          before do
+            @fog_file.delete
+          end
+
+          it "should not error getting the file size" do
+            expect {
+              @fog_file.size
+            }.not_to raise_error
+          end
+        end
       end
 
       describe '#retrieve!' do


### PR DESCRIPTION
When using Fog and AWS and a new file is uploaded and the old file is missing  `content_length` is called on nil, resulting in the inability to upload a new file.

This change updates the `CarrierWave::Storage::Fog` class such that it will not error if this situation occurs and instead return a 0 file size.

It seems that this change could also be made in https://github.com/carrierwaveuploader/carrierwave/blob/master/lib/carrierwave/sanitized_file.rb#L136 by reversing the conditional `(self.size.zero? && ! self.exists?)`, however the change in this PR seemed less invasive.

The error caused by this issue:
````
NoMethodError: undefined method `content_length' for nil:NilClass
	from /srv/app/releases/20150213002036/vendor/bundle/ruby/2.1.0/bundler/gems/carrierwave-0033279be9b6/lib/carrierwave/storage/fog.rb:291:in `size'
	from /srv/app/releases/20150213002036/vendor/bundle/ruby/2.1.0/bundler/gems/carrierwave-0033279be9b6/lib/carrierwave/uploader/proxy.rb:57:in `size'
	from /srv/app/releases/20150213002036/vendor/bundle/ruby/2.1.0/bundler/gems/carrierwave-0033279be9b6/lib/carrierwave/sanitized_file.rb:96:in `size'
	from /srv/app/releases/20150213002036/vendor/bundle/ruby/2.1.0/bundler/gems/carrierwave-0033279be9b6/lib/carrierwave/sanitized_file.rb:136:in `empty?'
	from /srv/app/releases/20150213002036/vendor/bundle/ruby/2.1.0/bundler/gems/carrierwave-0033279be9b6/lib/carrierwave/uploader/cache.rb:111:in `cache!'
	from /srv/app/releases/20150213002036/vendor/bundle/ruby/2.1.0/bundler/gems/carrierwave-0033279be9b6/lib/carrierwave/mounter.rb:43:in `block in cache'
	from /srv/app/releases/20150213002036/vendor/bundle/ruby/2.1.0/bundler/gems/carrierwave-0033279be9b6/lib/carrierwave/mounter.rb:41:in `map'
	from /srv/app/releases/20150213002036/vendor/bundle/ruby/2.1.0/bundler/gems/carrierwave-0033279be9b6/lib/carrierwave/mounter.rb:41:in `cache'
	from /srv/app/releases/20150213002036/vendor/bundle/ruby/2.1.0/bundler/gems/carrierwave-0033279be9b6/lib/carrierwave/mount.rb:148:in `avatar='
````