### PR TITLE
Fix ArgumentError when ActiveRecord::Locking::Pessimistic#with_lock call...

### DIFF
--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -81,7 +81,7 @@ module CarrierWave
         end
 
         # Reset cached mounter on record reload
-        def reload
+        def reload(*)
           @_mounters = nil
           super
         end

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -1490,5 +1490,9 @@ describe CarrierWave::ActiveRecord do
       expect(@event.save).to be_true
       expect(File.exist?(public_path('uploads/old.jpeg'))).to be_true
     end
+
+    it "should not raise ArgumentError when with_lock method is called" do
+      expect { @event.with_lock {} }.to_not raise_error
+    end
   end
 end


### PR DESCRIPTION
...ed

This method pass one argument to reload, so reload with no args
definition raise ArgumentError.