### PR TITLE
Replace gem 'fog-aws' with 'fog' require 'fog/aws'

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ Processing can be enabled for a single version by setting the processing flag on
 [Fog AWS](http://github.com/fog/fog-aws) is used to support Amazon S3. Ensure you have it in your Gemfile:
 
 ```ruby
-gem "fog-aws"
+gem 'fog', require: 'fog/aws'
 ```
 
 You'll need to provide your fog_credentials and a fog_directory (also known as a bucket) in an initializer.


### PR DESCRIPTION
Using `gem 'fog-aws'` results the error `NameError: uninitialized constant CarrierWave::Storage::Fog`. This change was introduced in #1570.

Switching to `gem 'fog', require: 'fog/aws'` fixed the issue.

Versions:
- carrierwave (0.10.0)
- fog (1.28.0)
- rails (4.1.8)

```
NameError: uninitialized constant CarrierWave::Storage::Fog
	from ~/.rvm/gems/ruby-2.1.2/gems/carrierwave-0.10.0/lib/carrierwave/uploader/configuration.rb:73:in `eval'
	from ~/.rvm/gems/ruby-2.1.2/gems/carrierwave-0.10.0/lib/carrierwave/uploader/configuration.rb:73:in `eval'
	from ~/.rvm/gems/ruby-2.1.2/gems/carrierwave-0.10.0/lib/carrierwave/uploader/configuration.rb:73:in `storage'
	from ~/Code/livegenic/app/uploaders/remote_uploader.rb:9:in `<class:RemoteUploader>'
	from ~/Code/livegenic/app/uploaders/remote_uploader.rb:1:in `<top (required)>'
	from ~/Code/livegenic/app/models/file_instance.rb:3:in `<class:FileInstance>'
	from ~/Code/livegenic/app/models/file_instance.rb:1:in `<top (required)>'
	from (irb):1
	from ~/.rvm/gems/ruby-2.1.2/gems/railties-4.1.8/lib/rails/commands/console.rb:90:in `start'
	from ~/.rvm/gems/ruby-2.1.2/gems/railties-4.1.8/lib/rails/commands/console.rb:9:in `start'
	from ~/.rvm/gems/ruby-2.1.2/gems/railties-4.1.8/lib/rails/commands/commands_tasks.rb:69:in `console'
	from ~/.rvm/gems/ruby-2.1.2/gems/railties-4.1.8/lib/rails/commands/commands_tasks.rb:40:in `run_command!'
	from ~/.rvm/gems/ruby-2.1.2/gems/railties-4.1.8/lib/rails/commands.rb:17:in `<top (required)>'
	from ~/Code/livegenic/bin/rails:8:in `<top (required)>'
	from ~/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from ~/.rvm/rubies/ruby-2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
```