### PR TITLE
doc correction for remove_previously_stored_avatar

### DIFF
--- a/README.md
+++ b/README.md
@@ -904,7 +904,7 @@ avatar, even after uploading a new one), you can use ActiveRecord’s
 ```ruby
 class User
   mount_uploader :avatar, AvatarUploader
-  skip_callback :commit, :after, :remove_previously_stored_avatar
+  skip_callback :save, :after, :remove_previously_stored_avatar
 end
 ```
 


### PR DESCRIPTION
I noticed that `skip_callback :commit, :after, :remove_previously_stored_avatar` does __not__ prevent previous files from being destroyed on update. 

Using `skip_callback :save, :after, :remove_previously_stored_avatar` instead, does keep previous versions.

See this example app i created to demonstration: https://github.com/somlor/carrierwave_avatar