### PR TITLE
fix use rmagick 2.14

### DIFF
--- a/lib/carrierwave/processing/rmagick.rb
+++ b/lib/carrierwave/processing/rmagick.rb
@@ -61,11 +61,16 @@ module CarrierWave
     extend ActiveSupport::Concern
 
     included do
+      next if defined?(::Magick)
       begin
-        require "RMagick" unless defined?(::Magick)
-      rescue LoadError => e
-        e.message << " (You may need to install the rmagick gem)"
-        raise e
+        require "rmagick"
+      rescue
+        begin
+          require "RMagick"
+        rescue LoadError => e
+          e.message << " (You may need to install the rmagick gem)"
+          raise e
+        end
       end
     end
 


### PR DESCRIPTION
https://github.com/gemhome/rmagick/commit/77827346b046c6e42ce27909970036d7cc1f16de

> [DEPRECATION] requiring "RMagick" is deprecated. Use "rmagick" instead

