### PR TITLE
Improve Fog Loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ You can also pass in additional options, as documented fully in lib/carrierwave/
 
 ```ruby
 CarrierWave.configure do |config|
-  config.fog_provider = 'fog-aws'
+  config.fog_provider = 'fog-aws'                        # required
   config.fog_credentials = {
     provider:              'AWS',                        # required
     aws_access_key_id:     'xxx',                        # required
@@ -647,11 +647,12 @@ Using a US-based account:
 
 ```ruby
 CarrierWave.configure do |config|
+  config.fog_provider = "fog/rackspace/storage"   # optional, defaults to "fog"
   config.fog_credentials = {
     provider:           'Rackspace',
     rackspace_username: 'xxxxxx',
     rackspace_api_key:  'yyyyyy',
-    rackspace_region:   :ord                # optional, defaults to :dfw
+    rackspace_region:   :ord                      # optional, defaults to :dfw
   }
   config.fog_directory = 'name_of_directory'
 end
@@ -661,6 +662,7 @@ Using a UK-based account:
 
 ```ruby
 CarrierWave.configure do |config|
+  config.fog_provider = "fog/rackspace/storage"   # optional, defaults to "fog"
   config.fog_credentials = {
     provider:           'Rackspace',
     rackspace_username: 'xxxxxx',
@@ -708,7 +710,7 @@ under the section “Interoperable Access”.
 
 ```ruby
 CarrierWave.configure do |config|
-  config.fog_provider = 'fog-google'
+  config.fog_provider = 'fog-google'                        # required
   config.fog_credentials = {
     provider:                         'Google',
     google_storage_access_key_id:     'xxxxxx',

--- a/README.md
+++ b/README.md
@@ -607,6 +607,7 @@ You can also pass in additional options, as documented fully in lib/carrierwave/
 
 ```ruby
 CarrierWave.configure do |config|
+  config.fog_provider = 'fog-aws'
   config.fog_credentials = {
     provider:              'AWS',                        # required
     aws_access_key_id:     'xxx',                        # required
@@ -692,10 +693,10 @@ the url to the file on Rackspace Cloud Files.
 
 ## Using Google Storage for Developers
 
-[Fog](http://github.com/fog/fog) is used to support Google Storage for Developers. Ensure you have it in your Gemfile:
+[Fog](http://github.com/fog/fog-google) is used to support Google Storage for Developers. Ensure you have it in your Gemfile:
 
 ```ruby
-gem "fog"
+gem "fog-google"
 ```
 
 You'll need to configure a directory (also known as a bucket), access key id and secret access key in the initializer.
@@ -707,6 +708,7 @@ under the section “Interoperable Access”.
 
 ```ruby
 CarrierWave.configure do |config|
+  config.fog_provider = 'fog-google'
   config.fog_credentials = {
     provider:                         'Google',
     google_storage_access_key_id:     'xxxxxx',
@@ -729,10 +731,10 @@ the url to the file on Google.
 
 ## Optimized Loading of Fog
 
-Since Carrierwave doesn't know which parts of Fog you intend to use, it will just load the entire library (unless you use e.g. fog-aws instead of fog proper). If you prefer to load fewer classes into your application, you need to load those parts of Fog yourself *before* loading CarrierWave in your Gemfile.  Ex:
+Since Carrierwave doesn't know which parts of Fog you intend to use, it will just load the entire library (unless you use e.g. [`fog-aws`, `fog-google`] instead of fog proper). If you prefer to load fewer classes into your application, you need to load those parts of Fog yourself *before* loading CarrierWave in your Gemfile.  Ex:
 
 ```ruby
-gem "fog", "~> 1.27", require: "fog/google/storage"
+gem "fog", "~> 1.27", require: "fog/rackspace/storage"
 gem "carrierwave"
 ```
 
@@ -740,12 +742,15 @@ A couple of notes about versions:
 * This functionality was introduced in Fog v1.20.
 * This functionality is slated for CarrierWave v1.0.0.
 
-If you're not relying on Gemfile entries alone and are requiring "carrierwave" anywhere, ensure you require "fog/google/storage" before it.  Ex:
+If you're not relying on Gemfile entries alone and are requiring "carrierwave" anywhere, ensure you require "fog/rackspace/storage" before it.  Ex:
 
 ```ruby
-require "fog/google/storage"
+require "fog/rackspace/storage"
 require "carrierwave"
 ```
+
+Beware that this specific require is only needed when working with a fog provider that was not extracted to its own gem yet.
+A list of the extracted providers can be found in the page of the `fog` organizations [here](https://github.com/fog).
 
 When in doubt, inspect `Fog.constants` to see what has been loaded.
 

--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -37,7 +37,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "cucumber", "~> 1.3.2"
   s.add_development_dependency "rspec", "~> 2.14.1"
   s.add_development_dependency "sham_rack"
-  s.add_development_dependency "fog-aws", ">= 0.1.0"
   s.add_development_dependency "fog", ">= 1.28.0"
   s.add_development_dependency "mini_magick", ">= 3.6.0"
   if RUBY_ENGINE != 'jruby'

--- a/lib/carrierwave/storage.rb
+++ b/lib/carrierwave/storage.rb
@@ -1,13 +1,2 @@
 require "carrierwave/storage/abstract"
 require "carrierwave/storage/file"
-
-begin
-  require "fog/core"
-rescue LoadError
-  begin
-    require "fog" unless defined?(::Fog)
-  rescue LoadError
-  end
-end
-
-require "carrierwave/storage/fog" if defined?(Fog)

--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -1,11 +1,5 @@
 # encoding: utf-8
 
-begin
-  require "fog/core"
-rescue LoadError
-  require "fog" unless defined?(::Fog)
-end
-
 module CarrierWave
   module Storage
 

--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -23,6 +23,7 @@ module CarrierWave
         add_config :remove_previously_stored_files_after_update
 
         # fog
+        add_config :fog_provider
         add_config :fog_attributes
         add_config :fog_credentials
         add_config :fog_directory
@@ -108,6 +109,8 @@ module CarrierWave
           class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def self.eager_load_fog(fog_credentials)
               # see #1198. This will hopefully no longer be necessary after fog 2.0
+              require self.fog_provider || 'fog'
+              require 'carrierwave/storage/fog'
               Fog::Storage.new(fog_credentials) if fog_credentials.present?
             end
 
@@ -135,7 +138,7 @@ module CarrierWave
               value = self.class.#{name} unless instance_variable_defined?(:@#{name})
               if value.instance_of?(Proc)
                 value.arity >= 1 ? value.call(self) : value.call
-              else 
+              else
                 value
               end
             end


### PR DESCRIPTION
This PR is an attempt to create an easy support for both providers within `fog` and the ones that were already extracted.
Instead of rely on constant definition to load `fog` support, now it depends on a configuration.
If `fog_provider` is not defined `carrierwave` will try to load `fog` completely. If the user has only `fog-aws` on its Gemfile it will fail.
The use won't need to require any `fog` specifics before `carrierwave` anymore because `carrierwave` will do that now.
The optimized loading of fog is not necessary if the user is using an extracted provider and `google` was extracted so i did some changes on `README` reflecting this.

Let me know if i need to change something else or something is wrong.