### PR TITLE
[Fix #1571] - Do not write to ActiveModel::Dirty changes when assigning ...

### DIFF
--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -65,7 +65,10 @@ module CarrierWave
       class_eval <<-RUBY, __FILE__, __LINE__+1
         def #{column}=(new_file)
           column = _mounter(:#{column}).serialization_column
-          send(:"\#{column}_will_change!")
+          if !(new_file.blank? && send(:#{column}).blank?)
+            send(:"\#{column}_will_change!")
+          end
+
           super
         end
 

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -200,15 +200,45 @@ describe CarrierWave::ActiveRecord do
         expect(@event.image.current_path).to match(%r(^#{public_path('uploads/tmp')}))
       end
 
-      it "should do nothing when nil is assigned" do
-        @event.image = nil
-        expect(@event.image).to be_blank
+      context "when empty string is assigned" do
+        it "does nothing when" do
+          @event.image = ''
+          expect(@event.image).to be_blank
+        end
+
+        context "and the previous value was an empty string" do
+          before do
+            @event.image = ""
+            @event.save
+          end
+
+          it "does not write to dirty changes" do
+            @event.image = ''
+            expect(@event.changes.keys).not_to include("image")
+          end
+        end
+
       end
 
-      it "should do nothing when an empty string is assigned" do
-        @event.image = ''
-        expect(@event.image).to be_blank
+      context "when nil is assigned" do
+        it "does nothing" do
+          @event.image = nil
+          expect(@event.image).to be_blank
+        end
+
+        context "and the previous value was nil" do
+          before do
+            @event.image = nil
+            @event.save
+          end
+
+          it "does not write to dirty changes" do
+            @event.image = nil
+            expect(@event.changes.keys).not_to include("image")
+          end
+        end
       end
+
 
       context 'when validating white list integrity' do
         before do


### PR DESCRIPTION
...something blank to a mounter that was originally blank

This is a WIP. I'm not sure it doesn't break anything yet and want to experiment with it before merging.

Feedback is more than welcome