### PR TITLE
Model.attached was nil, using model_attached fixes it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ end
 u.save!
 u.avatar.url # => '/url/to/file.png'
 u.avatar.current_path # => 'path/to/file.png'
-u.avatar.identifier # => 'file.png'
+u.avatar_identifier # => 'file.png'
 ```
 
 ### DataMapper, Mongoid, Sequel


### PR DESCRIPTION
As seen on issue #1386. The documentation was indicating a broken way to do so.