### PR TITLE
Get rid of rmagick deprecation warning

### DIFF
--- a/lib/carrierwave/processing/rmagick.rb
+++ b/lib/carrierwave/processing/rmagick.rb
@@ -62,10 +62,14 @@ module CarrierWave
 
     included do
       begin
-        require "RMagick" unless defined?(::Magick)
+        require "rmagick" unless defined?(::Magick)
       rescue LoadError => e
-        e.message << " (You may need to install the rmagick gem)"
-        raise e
+        begin
+          require "RMagick"
+        rescue LoadError => e
+          e.message << " (You may need to install the rmagick gem)"
+          raise e
+        end
       end
     end
 


### PR DESCRIPTION
Rmagick introduced a  deprecation warning in 2.14.0 for loading it with `require "RMagick"` (https://github.com/gemhome/rmagick/blob/master/ChangeLog#L7)