### PR TITLE
Decrease Memory footprint

### DIFF
--- a/lib/carrierwave/processing/mime_types.rb
+++ b/lib/carrierwave/processing/mime_types.rb
@@ -29,6 +29,9 @@ module CarrierWave
     included do
       CarrierWave::Utilities::Deprecation.new "0.11.0", "CarrierWave::MimeTypes is deprecated and will be removed in the future, get the content_type from the SanitizedFile object directly."
       begin
+        # Use mime/types/columnar if available, for reduced memory usage
+        require 'mime/types/columnar'
+      rescue LoadError
         require "mime/types"
       rescue LoadError => e
         e.message << " (You may need to install the mime-types gem)"

--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -2,7 +2,13 @@
 
 require 'pathname'
 require 'active_support/core_ext/string/multibyte'
-require 'mime/types'
+
+begin
+  # Use mime/types/columnar if available, for reduced memory usage
+  require 'mime/types/columnar'
+rescue LoadError
+  require 'mime/types'
+end
 
 module CarrierWave
 

--- a/spec/sanitized_file_spec.rb
+++ b/spec/sanitized_file_spec.rb
@@ -1,7 +1,13 @@
 # encoding: utf-8
 
 require 'spec_helper'
-require 'mime/types'
+
+begin
+  # Use mime/types/columnar if available, for reduced memory usage
+  require 'mime/types/columnar'
+rescue LoadError
+  require 'mime/types'
+end
 
 describe CarrierWave::SanitizedFile do
 


### PR DESCRIPTION
Mime-types  2.6.1+ has a columnar store that only loads the data that is needed for a drastically reduced memory footprint. cc/ @jeremyevans @halostatue