### PR TITLE
mount_uploaders: Assigning column to [] fails to remove files

### DIFF
--- a/spec/mount_multiple_spec.rb
+++ b/spec/mount_multiple_spec.rb
@@ -557,6 +557,16 @@ describe CarrierWave::Mount do
         expect(@instance).to receive(:write_uploader).with(:images, nil)
         @instance.write_images_identifier
       end
+
+      it "should remove from the column when files are empty" do
+        expect(@instance).to receive(:write_uploader).with(:images, ["test.jpg"])
+        @instance.images = [stub_file('test.jpg')]
+        @instance.write_images_identifier
+
+        expect(@instance).to receive(:write_uploader).with(:images, [])
+        @instance.images = []
+        @instance.write_images_identifier
+      end
     end
 
     describe '#images_identifiers' do


### PR DESCRIPTION
Here's a failing test case.
When assigning `@instance.images = []`, the files are not removed for some reason.

I tried to fix it by removing the condition at https://github.com/carrierwaveuploader/carrierwave/blob/master/lib/carrierwave/mount.rb#L327 -- but some other tests start to fail.

Thanks,
Nico :)