### PR TITLE
[Fix #1594] Reset remove attribute after invoking remove_#{image}

### DIFF
--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -78,9 +78,10 @@ module CarrierWave
         end
 
         def remove_#{column}!
-          super
           self.remove_#{column} = true
           write_#{column}_identifier
+          self.remove_#{column} = false
+          super
         end
 
         # Reset cached mounter on record reload

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -457,17 +457,22 @@ describe CarrierWave::ActiveRecord do
       before do
         @event.image = stub_file('test.jpeg')
         @event.save!
-        @event.remove_image!
       end
 
       it "should clear the serialization column" do
+        @event.remove_image!
+
         expect(@event.attributes['image']).to be_blank
       end
 
-      it "should return to false after being saved" do
-        @event.save!
-        expect(@event.remove_image).to eq(false)
-        expect(@event.remove_image?).to eq(false)
+      it "resets remove_image? to false" do
+        @event.remove_image = true
+
+        expect {
+          @event.remove_image!
+        }.to change {
+          @event.remove_image?
+        }.from(true).to(false)
       end
     end
 


### PR DESCRIPTION
This fixes the behaviour of write_#{column}_identifier in order to
accept re-uploading a file after the previous one was removed from
the same Uploader's instance.