### PR TITLE
Add test: .version with nested versions should set the version name for the #versions

### DIFF
--- a/spec/uploader/versions_spec.rb
+++ b/spec/uploader/versions_spec.rb
@@ -137,6 +137,13 @@ describe CarrierWave::Uploader do
         expect(@uploader.thumb.micro.version_name).to eq(:thumb_micro)
       end
 
+      it "should set the version name for the #versions" do
+        expect(@uploader.version_name).to be_nil
+        expect(@uploader.versions[:thumb].version_name).to eq(:thumb)
+        expect(@uploader.versions[:thumb].versions[:mini].version_name).to eq(:thumb_mini)
+        expect(@uploader.versions[:thumb].versions[:micro].version_name).to eq(:thumb_micro)
+      end
+
       it "should process nested versions" do
         @uploader_class.class_eval {
           include CarrierWave::MiniMagick


### PR DESCRIPTION
There is this test in features, but there isn't it in unit tests.

By the way, it failed when I was manipulating with #1672, but unit tests were green.