### PR TITLE
Fixed StringIO support

### DIFF
--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -161,7 +161,7 @@ module CarrierWave
       else
         @file.rewind if @file.respond_to?(:rewind)
         @content = @file.read
-        @file.close if @file.respond_to?(:close) && @file.respond_to?(:closed?) && !@file.closed?
+        @file.close if @file.respond_to?(:close) && @file.respond_to?(:closed?) && !@file.closed? && !@file.is_a?(StringIO)
         @content
       end
     end

--- a/lib/carrierwave/uploader/cache.rb
+++ b/lib/carrierwave/uploader/cache.rb
@@ -128,7 +128,6 @@ module CarrierWave
           with_callbacks(:cache, new_file) do
             self.cache_id = CarrierWave.generate_cache_id unless cache_id
 
-            @filename = new_file.filename
             self.original_filename = new_file.filename
 
             if move_to_cache
@@ -136,6 +135,8 @@ module CarrierWave
             else
               @file = new_file.copy_to(cache_path, permissions, directory_permissions)
             end
+
+            @filename = @file.filename
           end
         end
       end

--- a/lib/carrierwave/uploader/cache.rb
+++ b/lib/carrierwave/uploader/cache.rb
@@ -94,7 +94,13 @@ module CarrierWave
       # [String] a cache name, in the format YYYYMMDD-HHMM-PID-RND/filename.txt
       #
       def cache_name
-        File.join(cache_id, full_original_filename) if cache_id and original_filename
+        if cache_id
+          if full_original_filename.present?
+            File.join(cache_id, full_original_filename)
+          else
+            File.join(cache_id, cache_id)
+          end
+        end
       end
 
       ##


### PR DESCRIPTION
Fixed two bugs in this method:

1. Previous implementation was checking ```original_filename``` was non-nil but then using ```full_original_filename``` - these may not be the same.

2. ```full_original_filename``` will return an empty string ("") if the Uploader is uploading a file that is *not* a version and the "file" being uploaded doesn't have a path (i.e. is a StringIO). This means you end up writing to a *file* path like:

```
tmp/cache_id
```

This is fine if your Uploader has no versions attached to it. However, if your Uploader also has versions attached to it they end up trying to copy_to:

    tmp/cache_id/version_cache_name

This fails because ```tmp/cache_id``` is a file, not a directory.

Consequently, this pull request will ensure the main (non-version) upload is written to:

    tmp/cache_id/cache_id

when ```full_original_filename``` is ```blank?```. This avoids the issue whereby we're trying to treat a file like a directory.