### PR TITLE
Suppress RMagick warning

### DIFF
--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "fog", ">= 1.28.0"
   s.add_development_dependency "mini_magick", ">= 3.6.0"
   if RUBY_ENGINE != 'jruby'
-    s.add_development_dependency "rmagick"
+    s.add_development_dependency "rmagick", ">= 2.14.0"
     s.add_development_dependency "ruby-filemagic", ">= 0.6.3"
   end
   s.add_development_dependency "nokogiri", "~> 1.6.3"

--- a/lib/carrierwave/processing/rmagick.rb
+++ b/lib/carrierwave/processing/rmagick.rb
@@ -62,7 +62,7 @@ module CarrierWave
 
     included do
       begin
-        require "RMagick" unless defined?(::Magick)
+        require "rmagick" unless defined?(::Magick)
       rescue LoadError => e
         e.message << " (You may need to install the rmagick gem)"
         raise e


### PR DESCRIPTION
Requiring `RMagick` is deprecated on RMagick 2.14.0, so use `rmagick` instead.