### PR TITLE
Change Google's url to the public_url

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -353,7 +353,8 @@ module CarrierWave
                 end
               end
             when 'Google'
-              "https://commondatastorage.googleapis.com/#{@uploader.fog_directory}/#{encoded_path}"
+              file = directory.files.get(encoded_path)
+              file.nil?? "" : file.public_url
             else
               # avoid a get by just using local reference
               directory.files.new(:key => path).public_url


### PR DESCRIPTION
`commondatastorage` is a deprecated endpoint, the current [Request URIs](https://cloud.google.com/storage/docs/reference-uris) should be used instead, and `fog-google` is already up to date.

I guess this could be extended to the other providers too.