### PR TITLE
Extract UNSAFE regex in utilities uri to reduce memory usage

### DIFF
--- a/lib/carrierwave/utilities/uri.rb
+++ b/lib/carrierwave/utilities/uri.rb
@@ -3,14 +3,13 @@
 module CarrierWave
   module Utilities
     module Uri
+    # based on Ruby < 2.0's URI.encode
+    SAFE_STRING = URI::REGEXP::PATTERN::UNRESERVED + '\/'
+    UNSAFE = Regexp.new("[^#{SAFE_STRING}]", false)
 
     private
       def encode_path(path)
-        # based on Ruby < 2.0's URI.encode
-        safe_string = URI::REGEXP::PATTERN::UNRESERVED + '\/'
-        unsafe = Regexp.new("[^#{safe_string}]", false)
-
-        path.to_s.gsub(unsafe) do
+        path.to_s.gsub(UNSAFE) do
           us = $&
           tmp = ''
           us.each_byte do |uc|


### PR DESCRIPTION
While benchmarking my app (using `derailed`), I noticed a an unusual memory usage in the `Carrierwave::Utilities::Uri` module. The action benchmarked is serializing 60 records each containing a field with an uploader that has 3 versions. The memory usage is not critical and this is not a huge gain in performance so merge it if you think the code respect the guideline of the repository :smile: 

Here is my benchmarks results:

allocated memory by gem
-----------------------------------
**Before**

2399180  `carrierwave/lib`
1470695  `activesupport-4.2.0`
1444700  `activerecord-4.2.0`

**After**

1708780  `carrierwave/lib`
1470695  `activesupport-4.2.0`
1444700  `activerecord-4.2.0`


allocated memory by file
-----------------------------------
**Before**

989475  `/Users/simonprev/.rbenv/versions/2.2.2/.../active_support/json/encoding.rb`
817070  `/Users/simonprev/Code/carrierwave/lib/carrierwave/utilities/uri.rb` _<-- This is unusual_
509070  `/Users/simonprev/Code/carrierwave/lib/carrierwave/uploader/url.rb`
507460  `/Users/simonprev/.rbenv/versions/2.2.2/.../json/common.rb`

**After**
989475  `/Users/simonprev/.rbenv/versions/2.2.2/.../active_support/json/encoding.rb`
509070  `/Users/simonprev/Code/carrierwave/lib/carrierwave/uploader/url.rb`
507460  `/Users/simonprev/.rbenv/versions/2.2.2/.../json/common.rb`
...
126670  `/Users/simonprev/Code/carrierwave/lib/carrierwave/utilities/uri.rb` <-- Ahh