### PR TITLE
Provide whitelisted/blacklisted types for better error messages in MagicMime

### DIFF
--- a/lib/carrierwave/uploader/magic_mime_blacklist.rb
+++ b/lib/carrierwave/uploader/magic_mime_blacklist.rb
@@ -51,19 +51,31 @@ module CarrierWave
       #
       def blacklist_mime_type_pattern; end
 
+      # === Returns
+      #
+      # [Array] a black list array of extensions to match blacklist regexp, 
+      #         is passed as a local to error message  
+      #
+      # === Examples
+      #
+      #     def blacklist_mime_type_extensions
+      #       %w(json)
+      #     end
+      #
+      def blacklist_mime_type_extensions; end
+
     private
 
       def check_blacklist_pattern!(new_file)
-        prohibited_types = blacklist_mime_type_pattern
-        return if prohibited_types.nil?
+        return if blacklist_mime_type_pattern.nil?
 
         content_type = extract_content_type(new_file)
 
-        if content_type.match(prohibited_types)
+        if content_type.match(blacklist_mime_type_pattern)
           raise CarrierWave::IntegrityError,
             I18n.translate(:"errors.messages.mime_type_pattern_black_list_error",
                            content_type: content_type,
-                           prohibited_types: prohibited_types)
+                           prohibited_types: blacklist_mime_type_extensions)
         end
       end
 

--- a/lib/carrierwave/uploader/magic_mime_blacklist.rb
+++ b/lib/carrierwave/uploader/magic_mime_blacklist.rb
@@ -54,14 +54,16 @@ module CarrierWave
     private
 
       def check_blacklist_pattern!(new_file)
-        return if blacklist_mime_type_pattern.nil?
+        prohibited_types = blacklist_mime_type_pattern
+        return if prohibited_types.nil?
 
         content_type = extract_content_type(new_file)
 
-        if content_type.match(blacklist_mime_type_pattern)
+        if content_type.match(prohibited_types)
           raise CarrierWave::IntegrityError,
             I18n.translate(:"errors.messages.mime_type_pattern_black_list_error",
-                           :content_type => content_type)
+                           content_type: content_type,
+                           prohibited_types: prohibited_types)
         end
       end
 

--- a/lib/carrierwave/uploader/magic_mime_blacklist.rb
+++ b/lib/carrierwave/uploader/magic_mime_blacklist.rb
@@ -62,7 +62,7 @@ module CarrierWave
       #       %w(json)
       #     end
       #
-      def blacklist_mime_type_extensions; end
+      def blacklist_mime_type_extensions; [] end
 
     private
 
@@ -75,7 +75,7 @@ module CarrierWave
           raise CarrierWave::IntegrityError,
             I18n.translate(:"errors.messages.mime_type_pattern_black_list_error",
                            content_type: content_type,
-                           prohibited_types: blacklist_mime_type_extensions)
+                           prohibited_types: blacklist_mime_type_extensions.join(', '))
         end
       end
 

--- a/lib/carrierwave/uploader/magic_mime_whitelist.rb
+++ b/lib/carrierwave/uploader/magic_mime_whitelist.rb
@@ -54,14 +54,16 @@ module CarrierWave
     private
 
       def check_whitelist_pattern!(new_file)
-        return if whitelist_mime_type_pattern.nil?
+        allowed_types = whitelist_mime_type_pattern
+        return if allowed_types.nil?
 
         content_type = extract_content_type(new_file)
 
-        if !content_type.match(whitelist_mime_type_pattern)
+        if !content_type.match(allowed_types)
           raise CarrierWave::IntegrityError,
             I18n.translate(:"errors.messages.mime_type_pattern_white_list_error",
-                           :content_type => content_type)
+                           content_type: content_type,
+                           allowed_types: allowed_types)
         end
       end
 

--- a/lib/carrierwave/uploader/magic_mime_whitelist.rb
+++ b/lib/carrierwave/uploader/magic_mime_whitelist.rb
@@ -75,7 +75,7 @@ module CarrierWave
           raise CarrierWave::IntegrityError,
             I18n.translate(:"errors.messages.mime_type_pattern_white_list_error",
                            content_type: content_type,
-                           allowed_types: whitelist_mime_type_extension)
+                           allowed_types: whitelist_mime_type_extensions)
         end
       end
 

--- a/lib/carrierwave/uploader/magic_mime_whitelist.rb
+++ b/lib/carrierwave/uploader/magic_mime_whitelist.rb
@@ -62,7 +62,7 @@ module CarrierWave
       #       %w(json)
       #     end
       #
-      def whitelist_mime_type_extensions; end
+      def whitelist_mime_type_extensions; [] end
 
     private
 
@@ -75,7 +75,7 @@ module CarrierWave
           raise CarrierWave::IntegrityError,
             I18n.translate(:"errors.messages.mime_type_pattern_white_list_error",
                            content_type: content_type,
-                           allowed_types: whitelist_mime_type_extensions)
+                           allowed_types: whitelist_mime_type_extensions.join(', '))
         end
       end
 

--- a/lib/carrierwave/uploader/magic_mime_whitelist.rb
+++ b/lib/carrierwave/uploader/magic_mime_whitelist.rb
@@ -51,19 +51,31 @@ module CarrierWave
       #
       def whitelist_mime_type_pattern; end
 
+      # === Returns
+      #
+      # [Array] a white list array of extensions to match whitelist regexp, 
+      #         is passed as a local to error message  
+      #
+      # === Examples
+      #
+      #     def whitelist_mime_type_extensions
+      #       %w(json)
+      #     end
+      #
+      def whitelist_mime_type_extensions; end
+
     private
 
       def check_whitelist_pattern!(new_file)
-        allowed_types = whitelist_mime_type_pattern
-        return if allowed_types.nil?
+        return if whitelist_mime_type_pattern.nil?
 
         content_type = extract_content_type(new_file)
 
-        if !content_type.match(allowed_types)
+        if !content_type.match(whitelist_mime_type_pattern)
           raise CarrierWave::IntegrityError,
             I18n.translate(:"errors.messages.mime_type_pattern_white_list_error",
                            content_type: content_type,
-                           allowed_types: allowed_types)
+                           allowed_types: whitelist_mime_type_extension)
         end
       end
 


### PR DESCRIPTION
Similar to the original `extension_whitelist` and `extension_blacklist` CarrierWave functions, I wanted to provide the whitelisted & blacklisted types to error messages for MagicMime.

The provided whitelist & blacklist functions for MagicMime return a regexp not string extensions so passing it to the error message did not look great. I decided to create two new functions `whitelist_mime_type_extension` and `blacklist_mime_type_extension`. They both return an array of strings that represent the filetypes you are whitelisting or blacklisting in the pattern functions. These are then passed as locals to the corresponding errors.

Then in my `config/locale/en.yml` I could use it like so
```
en:
  errors: 
    messages:
      mime_type_pattern_white_list_error: "cannot be filetype %{content_type}, allowed filetypes: %{allowed_types}"
```