### PR TITLE
Passing options to Rackspace authenticated_url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ spec/test.log
 spec/tmp
 *.swp
 .rvmrc
+.idea
 .bundle
 Gemfile.lock
 gemfiles/*.lock

--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -189,12 +189,16 @@ module CarrierWave
             # avoid a get by using local references
             local_directory = connection.directories.new(:key => @uploader.fog_directory)
             local_file = local_directory.files.new(:key => path)
-            if @uploader.fog_credentials[:provider] == "AWS"
-              local_file.url(::Fog::Time.now + @uploader.fog_authenticated_url_expiration, options)
-            elsif ['Rackspace', 'OpenStack'].include?(@uploader.fog_credentials[:provider])
-              connection.get_object_https_url(@uploader.fog_directory, path, ::Fog::Time.now + @uploader.fog_authenticated_url_expiration)
-            else
-              local_file.url(::Fog::Time.now + @uploader.fog_authenticated_url_expiration)
+            expire_at = ::Fog::Time.now + @uploader.fog_authenticated_url_expiration
+            case @uploader.fog_credentials[:provider]
+              when 'AWS'
+                local_file.url(expire_at, options)
+              when 'Rackspace'
+                connection.get_object_https_url(@uploader.fog_directory, path, expire_at, options)
+              when 'OpenStack'
+                connection.get_object_https_url(@uploader.fog_directory, path, expire_at)
+              else
+                local_file.url(expire_at)
             end
           end
         end


### PR DESCRIPTION
Hi!

This update allows to pass additional options to Rackspaces `authenticated_url `.
Options are described [here](http://docs.rackspace.com/files/api/v1/cf-devguide/content/TempURL_File_Name_Overrides-d1e213.html).

Corresponding `fog` PR is fog/fog#3665