### PR TITLE
rails-master-gemfile: Include rack from master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ gemfile:
   - gemfiles/rails-4-0-stable.gemfile
   - gemfiles/rails-4-1-stable.gemfile
   - gemfiles/rails-4-2-stable.gemfile
-  - gemfiles/rails-master.gemfile
 
 sudo: false
 


### PR DESCRIPTION
This is a dependency of the rails/rails@master which is used in this
Gemfile.

Since rails/rails@master is a moving target, it may be removed from the
gemfiles till it reaches v5.0