### PR TITLE
Remove rails-master gemfile from travis checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ gemfile:
   - gemfiles/rails-4-0-stable.gemfile
   - gemfiles/rails-4-1-stable.gemfile
   - gemfiles/rails-4-2-stable.gemfile
+  - gemfiles/rails-master.gemfile
 
 sudo: false
 
@@ -30,6 +31,7 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
+    - gemfile: gemfiles/rails-master.gemfile
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ gemfile:
   - gemfiles/rails-4-0-stable.gemfile
   - gemfiles/rails-4-1-stable.gemfile
   - gemfiles/rails-4-2-stable.gemfile
-  - gemfiles/rails-master.gemfile
 
 sudo: false
 


### PR DESCRIPTION
rails/rails@master is currently being developed for the Rails 5 version.
At the moment, the actionpack-5.0.0.alpha depends on rack-2.0.0.alpha
which is not published in rubygems.org on in any of rack's branches,
thus leading to failures in our build.