### PR TITLE
Fix typo in callbacks instruction to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -990,8 +990,8 @@ Will add these callbacks:
 after_save :store_avatar!
 before_save :write_avatar_identifier
 after_commit :remove_avatar!, on: :destroy
-after_commit :"mark_remove_avatar_false", on: :update
-after_save :"store_previous_changes_for_avatar"
+after_commit :mark_remove_avatar_false, on: :update
+after_save :store_previous_changes_for_avatar
 after_commit :remove_previously_stored_avatar, on: :update
 ```
 


### PR DESCRIPTION
I've found a small typo in README.md. Please review.