### PR TITLE
Add be_format test matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,10 @@ describe MyUploader do
   it "should make the image readable only to the owner and not executable" do
     @uploader.should have_permissions(0600)
   end
+
+  it "should be the correct format" do
+    @uploader.should be_format('png')
+  end
 end
 ```
 

--- a/lib/carrierwave/test/matchers.rb
+++ b/lib/carrierwave/test/matchers.rb
@@ -301,6 +301,39 @@ module CarrierWave
         BeNoTallerThan.new(height)
       end
 
+      class BeFormat # :nodoc:
+        def initialize(expected)
+          @expected = expected
+        end
+
+        def matches?(actual)
+          @actual = actual
+          # Satisfy expectation here. Return false or raise an error if it's not met.
+          image = ImageLoader.load_image(@actual.current_path)
+          @actual_expected = image.format
+          !@expected.nil? && @actual_expected.casecmp(@expected).zero?
+        end
+
+        def failure_message
+          "expected #{@actual.current_path.inspect} to have #{@expected} format, but it was #{@actual_expected}."
+        end
+
+        def failure_message_when_negated
+          "expected #{@actual.current_path.inspect} not to have #{@expected} format, but it did."
+        end
+
+        def description
+          "have #{@expected} format"
+        end
+
+        # RSpec 2 compatibility:
+        alias_method :negative_failure_message, :failure_message_when_negated
+      end
+
+      def be_format(expected)
+        BeFormat.new(expected)
+      end
+
       class ImageLoader # :nodoc:
         def self.load_image(filename)
           if defined? ::MiniMagick
@@ -330,6 +363,10 @@ module CarrierWave
           image.rows
         end
 
+        def format
+          image.format
+        end
+
         def initialize(filename)
           @image = ::Magick::Image.read(filename).first
         end
@@ -343,6 +380,10 @@ module CarrierWave
 
         def height
           image[:height]
+        end
+
+        def format
+          image[:format]
         end
 
         def initialize(filename)

--- a/spec/processing/mini_magick_spec.rb
+++ b/spec/processing/mini_magick_spec.rb
@@ -23,9 +23,8 @@ describe CarrierWave::MiniMagick do
   describe "#convert" do
     it "should convert from one format to another" do
       @instance.convert('png')
-      img = ::MiniMagick::Image.open(@instance.current_path)
-      expect(img['format']).to match(/PNG/)
       expect(@instance.file.extension).to eq('png')
+      expect(@instance).to be_format('png')
     end
 
     it "should convert all pages when no page number is specified" do

--- a/spec/processing/rmagick_spec.rb
+++ b/spec/processing/rmagick_spec.rb
@@ -22,8 +22,8 @@ describe CarrierWave::RMagick, :rmagick => true do
   describe '#convert' do
     it "should convert the image to the given format" do
       @instance.convert(:png)
-      expect(::Magick::Image.read(@instance.current_path).first.format).to eq('PNG')
       expect(@instance.file.extension).to eq('png')
+      expect(@instance).to be_format('png')
     end
   end
 


### PR DESCRIPTION
Add a test matcher for the `format`.
Could be useful to test that a conversion has happened.

Usage:
```
context 'the thumb format' do
  it 'should be JPEG' do
    @uploader.thumb.should be_format('JPEG')
   end
end
```