### PR TITLE
Retrieve old file using identifier string not changes array itself

### DIFF
--- a/lib/carrierwave/mounter.rb
+++ b/lib/carrierwave/mounter.rb
@@ -127,7 +127,7 @@ module CarrierWave
       before = before.reject(&:blank?).map do |value|
         if value.is_a?(String)
           uploader = blank_uploader
-          uploader.retrieve_from_store!(before)
+          uploader.retrieve_from_store!(value)
           uploader
         else
           value


### PR DESCRIPTION
Hi all,

I use carrierwave with [Cloudinary uploader](https://github.com/cloudinary/cloudinary_gem) and I'm randomly seeing this error.

    undefined method `match' for ["image/upload/v111111/aaaaaaaaaa.png"]:Array
    vendor/bundle/ruby/2.2.0/gems/cloudinary-1.1.0/lib/cloudinary/carrier_wave.rb:150 in initialize
    vendor/bundle/ruby/2.2.0/gems/cloudinary-1.1.0/lib/cloudinary/carrier_wave.rb:29 in new
    vendor/bundle/ruby/2.2.0/gems/cloudinary-1.1.0/lib/cloudinary/carrier_wave.rb:29 in retrieve_from_store!
    vendor/bundle/ruby/2.2.0/bundler/gems/carrierwave-49fdad1ec6ca/lib/carrierwave/mounter.rb:130 in block in remove_previous
    vendor/bundle/ruby/2.2.0/bundler/gems/carrierwave-49fdad1ec6ca/lib/carrierwave/mounter.rb:127 in map
    vendor/bundle/ruby/2.2.0/bundler/gems/carrierwave-49fdad1ec6ca/lib/carrierwave/mounter.rb:127 in remove_previous
    vendor/bundle/ruby/2.2.0/bundler/gems/carrierwave-49fdad1ec6ca/lib/carrierwave/mount.rb:192 in remove_previously_stored_photo
    vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:430 in block in make_lambda
    vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:251 in call
    vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/callbacks.rb:251 in block in conditional
    ...

I think CarrierWave is passing an array to retrieve_from_store! method on uploader when it should pass a plain string.

    before = before.reject(&:blank?).map do |value|
        if value.is_a?(String)
          uploader = blank_uploader
          uploader.retrieve_from_store!(before)
          uploader
        else
          value
        end
      end

Tests are green, probably because ["file"]:Array and "file":String are equivalent in many cases but Clodinary uploader expect a String to call match method.

I really don't know why my app is not failing consistently, but this fix doesn't break tests and code make me think there is a typo. Also the parameter for retrieve_from_store is always a String so clodinary error should disappear now.

Sorry for my english.