### PR TITLE
fix cache! and store! for single version

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -312,7 +312,7 @@ module CarrierWave
             fog_file = new_file.to_file
             @content_type ||= new_file.content_type
             @file = directory.files.create({
-              :body         => (fog_file ? fog_file : new_file).read,
+              :body         => fog_file ? fog_file : new_file,
               :content_type => @content_type,
               :key          => path,
               :public       => @uploader.fog_public

--- a/lib/carrierwave/uploader/cache.rb
+++ b/lib/carrierwave/uploader/cache.rb
@@ -110,11 +110,18 @@ module CarrierWave
         return if new_file.empty?
 
         raise CarrierWave::FormNotMultipart if new_file.is_path? && ensure_multipart_form
+        
+        if !version_name.nil? && model.send(mounted_as).file.present?
+          # try to guess the original_filename
+          self.original_filename = model.send(mounted_as).file.filename
+        else
+          self.original_filename = new_file.filename
+        end
 
         self.cache_id = CarrierWave.generate_cache_id unless cache_id
 
         @filename = new_file.filename
-        self.original_filename = new_file.filename
+        
 
         begin
           # first, create a workfile on which we perform processings
@@ -122,8 +129,10 @@ module CarrierWave
             @file = new_file.move_to(File.expand_path(workfile_path, root), permissions, directory_permissions)
           else
             @file = new_file.copy_to(File.expand_path(workfile_path, root), permissions, directory_permissions)
-          end
 
+          end
+          
+          # e.g. before :cache, :process!
           with_callbacks(:cache, @file) do
             @file = cache_storage.cache!(@file)
           end

--- a/lib/carrierwave/uploader/store.rb
+++ b/lib/carrierwave/uploader/store.rb
@@ -39,7 +39,7 @@ module CarrierWave
       #
       # [String] the store path
       #
-      def store_path(for_file=filename)
+      def store_path(for_file=original_filename)
         File.join([store_dir, full_filename(for_file)].compact)
       end
 

--- a/lib/carrierwave/uploader/versions.rb
+++ b/lib/carrierwave/uploader/versions.rb
@@ -273,10 +273,9 @@ module CarrierWave
 
       def store_versions!(new_file, versions=nil)
         if versions
-          active = Hash[active_versions]
-          versions.each { |v| active[v].try(:store!, new_file) } unless active.empty?
+          dependent_versions.each { |name, v| next unless versions.any?{|version| version.to_sym == name.to_sym}; v.try(:store!, new_file) }
         else
-          active_versions.each { |name, v| v.store!(new_file) }
+          dependent_versions.each { |name, v| v.store!(new_file) }
         end
       end
 


### PR DESCRIPTION
version :large
version :medium, from_version=>:large
version :small, from_version=>:large
uploader.large.cache!
uploader.large.store!
uploader.large.store_versions!(nil,[:small])

With S3, for example, it doesn't have to download the original if one wants to recreate the versions small and medium. 
I found it useful to work with versions in the same was, as with the "original" version. So `store_versions! ` works the same way, as `cache_versions!` (using `dependent_versions` )

I didn't found a smarter solution to find the original filename than `model.send(mounted_as).file.filename` 
Any ideas?