### PR TITLE
Allow failures in CI builds against Rails master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
+    - gemfile: gemfiles/rails-master.gemfile
 
 notifications:
   email: false


### PR DESCRIPTION
CI builds against Rails master are currently failing as Rails 5 depends on an unpublished version of Rack.