### PR TITLE
Backport: Require rmagick first instead of deprecated RMagick

### DIFF
--- a/lib/carrierwave/processing/rmagick.rb
+++ b/lib/carrierwave/processing/rmagick.rb
@@ -62,6 +62,8 @@ module CarrierWave
 
     included do
       begin
+        require "rmagick"
+      rescue LoadError
         require "RMagick"
       rescue LoadError => e
         e.message << " (You may need to install the rmagick gem)"


### PR DESCRIPTION
Backport of #1681.

> Requiring `RMagick` is deprecated on RMagick 2.14.0, so use `rmagick` instead.