### PR TITLE
Update Ruby version in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ You should now be able to run the remote tests:
 
     REMOTE=true bundle exec rake
 
-Please test with the latest Ruby 1.8.x and 1.9.x versions using RVM if possible.
+Please test with the latest Ruby 2.2.x version using RVM if possible.
 
 ## Running active record tests
 


### PR DESCRIPTION
I tried to run tests using Ruby 1.8. and failed on `bundle install`: seems that `ruby-filemagic` requires at least 1.9.3 version.

```
Gem::InstallError: ruby-filemagic requires Ruby version >= 1.9.3.
Installing timecop 0.7.1
Installing fission 0.5.0
An error occurred while installing i18n (0.7.0), and Bundler cannot continue.
Make sure that `gem install i18n -v '0.7.0'` succeeds before bundling.
boris@boris-Inspiron-N5040:~/dev/toptal/carrierwave$ gem install i18n -v '0.7.0'
ERROR:  Error installing i18n:
	i18n requires Ruby version >= 1.9.3.
boris@boris-laptop:~/dev/toptal/carrierwave$ 
```