### PR TITLE
Add counter to cache_id

### DIFF
--- a/features/caching.feature
+++ b/features/caching.feature
@@ -23,6 +23,6 @@ Feature: uploader with file storage
   Scenario: retrieving a file from cache
     Given an uploader class that uses the 'file' storage
     And an instance of that class
-    And the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/bork.txt'
-    When I retrieve the cache name '1369894322-345-2255/bork.txt' from the cache
-    Then the uploader should have 'public/uploads/tmp/1369894322-345-2255/bork.txt' as its current path
+    And the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/bork.txt'
+    When I retrieve the cache name '1369894322-345-1234-2255/bork.txt' from the cache
+    Then the uploader should have 'public/uploads/tmp/1369894322-345-1234-2255/bork.txt' as its current path

--- a/features/file_storage.feature
+++ b/features/file_storage.feature
@@ -30,8 +30,8 @@ Feature: uploader with file storage
     And the file at 'public/uploads/bork.txt' should be identical to the file at 'fixtures/bork.txt'
 
   Scenario: retrieving a file from cache then storing
-    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/bork.txt'
-    When I retrieve the cache name '1369894322-345-2255/bork.txt' from the cache
+    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/bork.txt'
+    When I retrieve the cache name '1369894322-345-1234-2255/bork.txt' from the cache
     And I store the file
     Then there should be a file at 'public/uploads/bork.txt'
     And the file at 'public/uploads/bork.txt' should be identical to the file at 'fixtures/bork.txt'

--- a/features/file_storage_overridden_filename.feature
+++ b/features/file_storage_overridden_filename.feature
@@ -31,8 +31,8 @@ Feature: uploader with file storage and overriden filename
     And the file at 'public/uploads/txt.krob' should be identical to the file at 'fixtures/bork.txt'
 
   Scenario: retrieving a file from cache then storing
-    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/bork.txt'
-    When I retrieve the cache name '1369894322-345-2255/bork.txt' from the cache
+    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/bork.txt'
+    When I retrieve the cache name '1369894322-345-1234-2255/bork.txt' from the cache
     And I store the file
     Then there should be a file at 'public/uploads/txt.krob'
     And the file at 'public/uploads/txt.krob' should be identical to the file at 'fixtures/bork.txt'

--- a/features/file_storage_overridden_store_dir.feature
+++ b/features/file_storage_overridden_store_dir.feature
@@ -31,8 +31,8 @@ Feature: uploader with file storage and overridden store dir
     And the file at 'public/monkey/llama/bork.txt' should be identical to the file at 'fixtures/bork.txt'
 
   Scenario: retrieving a file from cache then storing
-    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/bork.txt'
-    When I retrieve the cache name '1369894322-345-2255/bork.txt' from the cache
+    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/bork.txt'
+    When I retrieve the cache name '1369894322-345-1234-2255/bork.txt' from the cache
     And I store the file
     Then there should be a file at 'public/monkey/llama/bork.txt'
     And the file at 'public/monkey/llama/bork.txt' should be identical to the file at 'fixtures/bork.txt'

--- a/features/file_storage_reversing_processor.feature
+++ b/features/file_storage_reversing_processor.feature
@@ -36,8 +36,8 @@ Feature: uploader with file storage and a processor that reverses the file
     And the file at 'public/uploads/bork.txt' should be the reverse of the file at 'fixtures/bork.txt'
 
   Scenario: retrieving a file from cache then storing
-    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/bork.txt'
-    When I retrieve the cache name '1369894322-345-2255/bork.txt' from the cache
+    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/bork.txt'
+    When I retrieve the cache name '1369894322-345-1234-2255/bork.txt' from the cache
     And I store the file
     Then there should be a file at 'public/uploads/bork.txt'
     And the file at 'public/uploads/bork.txt' should be identical to the file at 'fixtures/bork.txt'

--- a/features/versions_basics.feature
+++ b/features/versions_basics.feature
@@ -33,9 +33,9 @@ Feature: uploader with file storage and versions
     And the uploader's version 'thumb' should have the url '/uploads/thumb_bork.txt'
 
   Scenario: retrieving a file from cache then storing
-    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/bork.txt'
-    Given the file 'fixtures/monkey.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/thumb_bork.txt'
-    When I retrieve the cache name '1369894322-345-2255/bork.txt' from the cache
+    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/bork.txt'
+    Given the file 'fixtures/monkey.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/thumb_bork.txt'
+    When I retrieve the cache name '1369894322-345-1234-2255/bork.txt' from the cache
     And I store the file
     Then there should be a file at 'public/uploads/bork.txt'
     Then there should be a file at 'public/uploads/thumb_bork.txt'

--- a/features/versions_nested_versions.feature
+++ b/features/versions_nested_versions.feature
@@ -43,11 +43,11 @@ Feature: uploader with nested versions
     And the uploader's nested version 'micro' nested in 'thumb' should have the url '/uploads/thumb_micro_bork.txt'
 
   Scenario: retrieving a file from cache then storing
-    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/bork.txt'
-    Given the file 'fixtures/monkey.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/thumb_bork.txt'
-    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/thumb_mini_bork.txt'
-    Given the file 'fixtures/monkey.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/thumb_micro_bork.txt'
-    When I retrieve the cache name '1369894322-345-2255/bork.txt' from the cache
+    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/bork.txt'
+    Given the file 'fixtures/monkey.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/thumb_bork.txt'
+    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/thumb_mini_bork.txt'
+    Given the file 'fixtures/monkey.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/thumb_micro_bork.txt'
+    When I retrieve the cache name '1369894322-345-1234-2255/bork.txt' from the cache
     And I store the file
     Then there should be a file at 'public/uploads/bork.txt'
     Then there should be a file at 'public/uploads/thumb_bork.txt'

--- a/features/versions_overridden_filename.feature
+++ b/features/versions_overridden_filename.feature
@@ -34,9 +34,9 @@ Feature: uploader with file storage and overriden filename
       And the uploader's version 'thumb' should have the url '/uploads/thumb_grark.png'
 
     Scenario: retrieving a file from cache then storing
-      Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/bork.txt'
-      Given the file 'fixtures/monkey.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/thumb_bork.txt'
-      When I retrieve the cache name '1369894322-345-2255/bork.txt' from the cache
+      Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/bork.txt'
+      Given the file 'fixtures/monkey.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/thumb_bork.txt'
+      When I retrieve the cache name '1369894322-345-1234-2255/bork.txt' from the cache
       And I store the file
       Then there should be a file at 'public/uploads/grark.png'
       Then there should be a file at 'public/uploads/thumb_grark.png'

--- a/features/versions_overriden_store_dir.feature
+++ b/features/versions_overriden_store_dir.feature
@@ -31,9 +31,9 @@ Feature: uploader with file storage and versions with overridden store dir
     And the file at 'public/monkey/llama/thumb_bork.txt' should be identical to the file at 'fixtures/bork.txt'
 
   Scenario: retrieving a file from cache then storing
-    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/bork.txt'
-    Given the file 'fixtures/monkey.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/thumb_bork.txt'
-    When I retrieve the cache name '1369894322-345-2255/bork.txt' from the cache
+    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/bork.txt'
+    Given the file 'fixtures/monkey.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/thumb_bork.txt'
+    When I retrieve the cache name '1369894322-345-1234-2255/bork.txt' from the cache
     And I store the file
     Then there should be a file at 'public/uploads/bork.txt'
     Then there should be a file at 'public/monkey/llama/thumb_bork.txt'

--- a/spec/mount_multiple_spec.rb
+++ b/spec/mount_multiple_spec.rb
@@ -249,8 +249,8 @@ describe CarrierWave::Mount do
       it "should be the cache name when a file has been cached" do
         @instance.images = [stub_file('test.jpg'), stub_file('old.jpeg')]
         res = JSON.parse(@instance.images_cache)
-        expect(res[0]).to match(%r(^[\d]+\-[\d]+\-[\d]{4}/test\.jpg$))
-        expect(res[1]).to match(%r(^[\d]+\-[\d]+\-[\d]{4}/old\.jpeg$))
+        expect(res[0]).to match(%r(^[\d]+\-[\d]+\-[\d]{4}\-[\d]{4}/test\.jpg$))
+        expect(res[1]).to match(%r(^[\d]+\-[\d]+\-[\d]{4}\-[\d]{4}/old\.jpeg$))
       end
     end
 
@@ -259,7 +259,7 @@ describe CarrierWave::Mount do
       before do
         allow(@instance).to receive(:write_uploader)
         allow(@instance).to receive(:read_uploader).and_return(nil)
-        CarrierWave::SanitizedFile.new(file_path('test.jpg')).copy_to(public_path('uploads/tmp/1369894322-123-1234/test.jpg'))
+        CarrierWave::SanitizedFile.new(file_path('test.jpg')).copy_to(public_path('uploads/tmp/1369894322-123-0123-1234/test.jpg'))
       end
 
       it "should do nothing when nil is assigned" do
@@ -273,13 +273,13 @@ describe CarrierWave::Mount do
       end
 
       it "retrieve from cache when a cache name is assigned" do
-        @instance.images_cache = ['1369894322-123-1234/test.jpg'].to_json
-        expect(@instance.images[0].current_path).to eq(public_path('uploads/tmp/1369894322-123-1234/test.jpg'))
+        @instance.images_cache = ['1369894322-123-0123-1234/test.jpg'].to_json
+        expect(@instance.images[0].current_path).to eq(public_path('uploads/tmp/1369894322-123-0123-1234/test.jpg'))
       end
 
       it "should not write over a previously assigned file" do
         @instance.images = [stub_file('test.jpg')]
-        @instance.images_cache = ['1369894322-123-1234/monkey.jpg'].to_json
+        @instance.images_cache = ['1369894322-123-0123-1234/monkey.jpg'].to_json
         expect(@instance.images[0].current_path).to match(/test.jpg$/)
       end
     end

--- a/spec/mount_single_spec.rb
+++ b/spec/mount_single_spec.rb
@@ -252,7 +252,7 @@ describe CarrierWave::Mount do
 
       it "should be the cache name when a file has been cached" do
         @instance.image = stub_file('test.jpg')
-        expect(@instance.image_cache).to match(%r(^[\d]+\-[\d]+\-[\d]{4}/test\.jpg$))
+        expect(@instance.image_cache).to match(%r(^[\d]+\-[\d]+\-[\d]{4}\-[\d]{4}/test\.jpg$))
       end
 
     end
@@ -262,7 +262,7 @@ describe CarrierWave::Mount do
       before do
         allow(@instance).to receive(:write_uploader)
         allow(@instance).to receive(:read_uploader).and_return(nil)
-        CarrierWave::SanitizedFile.new(file_path('test.jpg')).copy_to(public_path('uploads/tmp/1369894322-123-1234/test.jpg'))
+        CarrierWave::SanitizedFile.new(file_path('test.jpg')).copy_to(public_path('uploads/tmp/1369894322-123-0123-1234/test.jpg'))
       end
 
       it "should do nothing when nil is assigned" do
@@ -276,13 +276,13 @@ describe CarrierWave::Mount do
       end
 
       it "retrieve from cache when a cache name is assigned" do
-        @instance.image_cache = '1369894322-123-1234/test.jpg'
-        expect(@instance.image.current_path).to eq(public_path('uploads/tmp/1369894322-123-1234/test.jpg'))
+        @instance.image_cache = '1369894322-123-0123-1234/test.jpg'
+        expect(@instance.image.current_path).to eq(public_path('uploads/tmp/1369894322-123-0123-1234/test.jpg'))
       end
 
       it "should not write over a previously assigned file" do
         @instance.image = stub_file('test.jpg')
-        @instance.image_cache = '1369894322-123-1234/monkey.jpg'
+        @instance.image_cache = '1369894322-123-0123-1234/monkey.jpg'
         expect(@instance.image.current_path).to match(/test.jpg$/)
       end
     end

--- a/spec/uploader/cache_spec.rb
+++ b/spec/uploader/cache_spec.rb
@@ -38,7 +38,7 @@ describe CarrierWave::Uploader do
   describe '#cache!' do
 
     before do
-      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-1234-2255')
     end
 
     it "should cache a file" do
@@ -53,7 +53,7 @@ describe CarrierWave::Uploader do
 
     it "should store the cache name" do
       @uploader.cache!(File.open(file_path('test.jpg')))
-      expect(@uploader.cache_name).to eq('1369894322-345-2255/test.jpg')
+      expect(@uploader.cache_name).to eq('1369894322-345-1234-2255/test.jpg')
     end
 
     it "should set the filename to the file's sanitized filename" do
@@ -63,13 +63,13 @@ describe CarrierWave::Uploader do
 
     it "should move it to the tmp dir" do
       @uploader.cache!(File.open(file_path('test.jpg')))
-      expect(@uploader.file.path).to eq(public_path('uploads/tmp/1369894322-345-2255/test.jpg'))
+      expect(@uploader.file.path).to eq(public_path('uploads/tmp/1369894322-345-1234-2255/test.jpg'))
       expect(@uploader.file.exists?).to be_truthy
     end
 
     it "should set the url" do
       @uploader.cache!(File.open(file_path('test.jpg')))
-      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-2255/test.jpg')
+      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-1234-2255/test.jpg')
     end
 
     it "should raise an error when trying to cache a string" do
@@ -135,10 +135,10 @@ describe CarrierWave::Uploader do
         @tmpfile = File.open(tmpfile)
 
         ## stub
-        allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
+        allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-1234-2255')
 
-        @cached_path = public_path('uploads/tmp/1369894322-345-2255/test_move.jpeg')
-        @workfile_path = tmp_path('1369894322-345-2255/test_move.jpeg')
+        @cached_path = public_path('uploads/tmp/1369894322-345-1234-2255/test_move.jpeg')
+        @workfile_path = tmp_path('1369894322-345-1234-2255/test_move.jpeg')
         @uploader_class.permissions = 0777
         @uploader_class.directory_permissions = 0777
       end
@@ -211,39 +211,39 @@ describe CarrierWave::Uploader do
 
   describe '#retrieve_from_cache!' do
     it "should cache a file" do
-      @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpeg')
+      @uploader.retrieve_from_cache!('1369894322-345-1234-2255/test.jpeg')
       expect(@uploader.file).to be_an_instance_of(CarrierWave::SanitizedFile)
     end
 
     it "should be cached" do
-      @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpeg')
+      @uploader.retrieve_from_cache!('1369894322-345-1234-2255/test.jpeg')
       expect(@uploader).to be_cached
     end
 
     it "should set the path to the tmp dir" do
-      @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpeg')
-      expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/test.jpeg'))
+      @uploader.retrieve_from_cache!('1369894322-345-1234-2255/test.jpeg')
+      expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-1234-2255/test.jpeg'))
     end
 
     it "should overwrite a file that has already been cached" do
-      @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpeg')
-      @uploader.retrieve_from_cache!('1369894322-345-2255/bork.txt')
-      expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/bork.txt'))
+      @uploader.retrieve_from_cache!('1369894322-345-1234-2255/test.jpeg')
+      @uploader.retrieve_from_cache!('1369894322-345-1234-2255/bork.txt')
+      expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-1234-2255/bork.txt'))
     end
 
     it "should store the cache_name" do
-      @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpeg')
-      expect(@uploader.cache_name).to eq('1369894322-345-2255/test.jpeg')
+      @uploader.retrieve_from_cache!('1369894322-345-1234-2255/test.jpeg')
+      expect(@uploader.cache_name).to eq('1369894322-345-1234-2255/test.jpeg')
     end
 
     it "should store the filename" do
-      @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpeg')
+      @uploader.retrieve_from_cache!('1369894322-345-1234-2255/test.jpeg')
       expect(@uploader.filename).to eq('test.jpeg')
     end
 
     it "should set the url" do
-      @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpeg')
-      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-2255/test.jpeg')
+      @uploader.retrieve_from_cache!('1369894322-345-1234-2255/test.jpeg')
+      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-1234-2255/test.jpeg')
     end
 
     it "should raise an error when the cache_id has an invalid format" do
@@ -258,15 +258,20 @@ describe CarrierWave::Uploader do
 
     it "should raise an error when the original_filename contains invalid characters" do
       expect(running {
-        @uploader.retrieve_from_cache!('1369894322-345-2255/te/st.jpeg')
+        @uploader.retrieve_from_cache!('1369894322-345-1234-2255/te/st.jpeg')
       }).to raise_error(CarrierWave::InvalidParameter)
       expect(running {
-        @uploader.retrieve_from_cache!('1369894322-345-2255/te??%st.jpeg')
+        @uploader.retrieve_from_cache!('1369894322-345-1234-2255/te??%st.jpeg')
       }).to raise_error(CarrierWave::InvalidParameter)
 
       expect(@uploader.file).to be_nil
       expect(@uploader.filename).to be_nil
       expect(@uploader.cache_name).to be_nil
+    end
+    
+    it "should support old format of cache_id (without counter) for backwards compartibility" do
+      @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpeg')
+      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-2255/test.jpeg')
     end
   end
 
@@ -282,7 +287,7 @@ describe CarrierWave::Uploader do
     describe '#cache!' do
 
       before do
-        allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
+        allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-1234-2255')
       end
 
       it "should set the filename to the file's reversed filename" do
@@ -292,28 +297,40 @@ describe CarrierWave::Uploader do
 
       it "should move it to the tmp dir with the filename unreversed" do
         @uploader.cache!(File.open(file_path('test.jpg')))
-        expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/test.jpg'))
+        expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-1234-2255/test.jpg'))
         expect(@uploader.file.exists?).to be_truthy
       end
     end
 
     describe '#retrieve_from_cache!' do
       it "should set the path to the tmp dir" do
-        @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpg')
-        expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/test.jpg'))
+        @uploader.retrieve_from_cache!('1369894322-345-1234-2255/test.jpg')
+        expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-1234-2255/test.jpg'))
       end
 
       it "should set the filename to the reversed name of the file" do
-        @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpg')
+        @uploader.retrieve_from_cache!('1369894322-345-1234-2255/test.jpg')
         expect(@uploader.filename).to eq("gpj.tset")
       end
     end
   end
+  
   describe '.generate_cache_id' do
-    it 'should generate dir name bsed on UTC time' do
-      Timecop.travel(Time.at(1369896000)) do
-        expect(CarrierWave.generate_cache_id).to match(/\A1369896000-\d+-\d+\Z/)
+    it 'should generate dir name based on UTC time' do
+      Timecop.freeze(Time.at(1369896000)) do
+        expect(CarrierWave.generate_cache_id).to match(/\A1369896000-\d+-\d+-\d+\Z/)
       end
+    end
+    
+    it 'should generate dir name with a counter substring' do
+      @counter = CarrierWave.generate_cache_id.split('-')[2].to_i
+      expect(CarrierWave.generate_cache_id.split('-')[2].to_i).to eq(@counter + 1)
+    end
+    
+    it 'should generate dir name with constant length even when counter has big value' do
+      @length = CarrierWave.generate_cache_id.length
+      allow(CarrierWave::CacheCounter).to receive(:increment).and_return(1234567890)
+      expect(CarrierWave.generate_cache_id.length).to eq(@length)
     end
   end
 end

--- a/spec/uploader/default_url_spec.rb
+++ b/spec/uploader/default_url_spec.rb
@@ -49,7 +49,7 @@ describe CarrierWave::Uploader do
     describe '#cache!' do
 
       before do
-        allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
+        allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-1234-2255')
       end
 
       it "should cache a file" do
@@ -69,13 +69,13 @@ describe CarrierWave::Uploader do
 
       it "should set the current_path" do
         @uploader.cache!(File.open(file_path('test.jpg')))
-        expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/test.jpg'))
+        expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-1234-2255/test.jpg'))
       end
 
       it "should set the url" do
         @uploader.cache!(File.open(file_path('test.jpg')))
         expect(@uploader.url).not_to eq('http://someurl.example.com')
-        expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-2255/test.jpg')
+        expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-1234-2255/test.jpg')
       end
 
     end

--- a/spec/uploader/download_spec.rb
+++ b/spec/uploader/download_spec.rb
@@ -16,7 +16,7 @@ describe CarrierWave::Uploader::Download do
   describe '#download!' do
 
     before do
-      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-1234-2255')
 
       sham_rack_app = ShamRack.at('www.example.com').stub
       sham_rack_app.register_resource('/test.jpg', File.read(file_path('test.jpg')), 'image/jpg')
@@ -49,7 +49,7 @@ describe CarrierWave::Uploader::Download do
 
     it "should store the cache name" do
       @uploader.download!('http://www.example.com/test.jpg')
-      expect(@uploader.cache_name).to eq('1369894322-345-2255/test.jpg')
+      expect(@uploader.cache_name).to eq('1369894322-345-1234-2255/test.jpg')
     end
 
     it "should set the filename to the file's sanitized filename" do
@@ -59,13 +59,13 @@ describe CarrierWave::Uploader::Download do
 
     it "should move it to the tmp dir" do
       @uploader.download!('http://www.example.com/test.jpg')
-      expect(@uploader.file.path).to eq(public_path('uploads/tmp/1369894322-345-2255/test.jpg'))
+      expect(@uploader.file.path).to eq(public_path('uploads/tmp/1369894322-345-1234-2255/test.jpg'))
       expect(@uploader.file.exists?).to be_truthy
     end
 
     it "should set the url" do
       @uploader.download!('http://www.example.com/test.jpg')
-      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-2255/test.jpg')
+      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-1234-2255/test.jpg')
     end
 
     it "should set permissions if options are given" do
@@ -96,22 +96,22 @@ describe CarrierWave::Uploader::Download do
 
     it "should accept spaces in the url" do
       @uploader.download!('http://www.example.com/test with spaces/test.jpg')
-      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-2255/test.jpg')
+      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-1234-2255/test.jpg')
     end
 
     it "should follow redirects" do
       @uploader.download!('http://www.redirect.com/')
-      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-2255/test.jpg')
+      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-1234-2255/test.jpg')
     end
 
     it "should read content-disposition headers" do
       @uploader.download!('http://www.example.com/content-disposition')
-      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-2255/another_test.jpg')
+      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-1234-2255/another_test.jpg')
     end
 
     it 'should set file extension based on content-type if missing' do
       @uploader.download!('http://www.example.com/test-with-no-extension/test')
-      expect(@uploader.url).to match %r{/uploads/tmp/1369894322-345-2255/test\.jp(e|e?g)$}
+      expect(@uploader.url).to match %r{/uploads/tmp/1369894322-345-1234-2255/test\.jp(e|e?g)$}
     end
 
     it 'should not obscure original exception message' do

--- a/spec/uploader/extension_blacklist_spec.rb
+++ b/spec/uploader/extension_blacklist_spec.rb
@@ -15,7 +15,7 @@ describe CarrierWave::Uploader do
   describe '#cache!' do
 
     before do
-      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-1234-2255')
     end
 
     it "should not raise an integrity error if there is no black list" do

--- a/spec/uploader/extension_whitelist_spec.rb
+++ b/spec/uploader/extension_whitelist_spec.rb
@@ -16,7 +16,7 @@ describe CarrierWave::Uploader do
   describe '#cache!' do
 
     before do
-      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-1234-2255')
     end
 
     it "should not raise an integrity error if there is no white list" do

--- a/spec/uploader/file_size_spec.rb
+++ b/spec/uploader/file_size_spec.rb
@@ -15,7 +15,7 @@ describe CarrierWave::Uploader do
   describe '#cache!' do
 
     before do
-      allow(CarrierWave).to receive(:generate_cache_id).and_return('20071201-1234-2255')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('20071201-1234-1234-2255')
     end
 
     it "should not raise an integrity error if there is no range specified" do

--- a/spec/uploader/magic_mime_blacklist_spec.rb
+++ b/spec/uploader/magic_mime_blacklist_spec.rb
@@ -24,7 +24,7 @@ describe CarrierWave::Uploader, filemagic: true do
   describe '#cache!' do
 
     before do
-      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-1234-2255')
     end
 
     context "when the is no blacklist pattern" do

--- a/spec/uploader/magic_mime_whitelist_spec.rb
+++ b/spec/uploader/magic_mime_whitelist_spec.rb
@@ -24,7 +24,7 @@ describe CarrierWave::Uploader, filemagic: true do
   describe '#cache!' do
 
     before do
-      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-1234-2255')
     end
 
     context "when the is no whitelist pattern" do

--- a/spec/uploader/processing_spec.rb
+++ b/spec/uploader/processing_spec.rb
@@ -138,7 +138,7 @@ describe CarrierWave::Uploader do
 
   describe '#cache!' do
     before do
-      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-1234-2255')
     end
 
     it "should trigger a process!" do
@@ -149,7 +149,7 @@ describe CarrierWave::Uploader do
 
   describe '#recreate_versions!' do
     before do
-      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-1234-2255')
     end
 
     it "should trigger a process!" do

--- a/spec/uploader/proxy_spec.rb
+++ b/spec/uploader/proxy_spec.rb
@@ -19,7 +19,7 @@ describe CarrierWave::Uploader do
     end
 
     it "should not be true when the file is empty" do
-      @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpeg')
+      @uploader.retrieve_from_cache!('1369894322-345-1234-2255/test.jpeg')
       expect(@uploader).to be_blank
     end
 
@@ -62,7 +62,7 @@ describe CarrierWave::Uploader do
     end
 
     it "should get the content type when the file is empty" do
-      @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpeg')
+      @uploader.retrieve_from_cache!('1369894322-345-1234-2255/test.jpeg')
       expect(@uploader.content_type).to eq('image/jpeg')
     end
   end

--- a/spec/uploader/remove_spec.rb
+++ b/spec/uploader/remove_spec.rb
@@ -17,7 +17,7 @@ describe CarrierWave::Uploader do
     before do
       @file = File.open(file_path('test.jpg'))
 
-      allow(CarrierWave).to receive(:generate_cache_id).and_return('1390890634-26112-2122')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1390890634-26112-1234-2122')
 
       @cached_file = double('a cached file')
       allow(@cached_file).to receive(:delete)

--- a/spec/uploader/store_spec.rb
+++ b/spec/uploader/store_spec.rb
@@ -29,7 +29,7 @@ describe CarrierWave::Uploader do
     before do
       @file = File.open(file_path('test.jpg'))
 
-      allow(CarrierWave).to receive(:generate_cache_id).and_return('1390890634-26112-2122')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1390890634-26112-1234-2122')
 
       @cached_file = double('a cached file')
       allow(@cached_file).to receive(:delete)
@@ -215,7 +215,7 @@ describe CarrierWave::Uploader do
     end
 
     it "should overwrite a file that has already been cached" do
-      @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpeg')
+      @uploader.retrieve_from_cache!('1369894322-345-1234-2255/test.jpeg')
       @uploader.retrieve_from_store!('bork.txt')
       expect(@uploader.file).to eq(@stored_file)
     end
@@ -271,7 +271,7 @@ describe CarrierWave::Uploader do
       before do
         @file = File.open(file_path('test.jpg'))
 
-        allow(CarrierWave).to receive(:generate_cache_id).and_return('1390890634-26112-2122')
+        allow(CarrierWave).to receive(:generate_cache_id).and_return('1390890634-26112-1234-2122')
 
         @cached_file = double('a cached file')
         allow(@cached_file).to receive(:delete)
@@ -347,7 +347,7 @@ describe CarrierWave::Uploader do
       @file = File.open(file_path('test.jpg'))
       @uploader_class.permissions = 0777
       @uploader_class.directory_permissions = 0777
-      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-1234-2255')
     end
 
     context "set to true" do
@@ -361,7 +361,7 @@ describe CarrierWave::Uploader do
         @cached_path = @uploader.file.path
         @stored_path = ::File.expand_path(@uploader.store_path, @uploader.root)
 
-        expect(@cached_path).to eq(public_path('uploads/tmp/1369894322-345-2255/test.jpg'))
+        expect(@cached_path).to eq(public_path('uploads/tmp/1369894322-345-1234-2255/test.jpg'))
         expect(File.exist?(@cached_path)).to be_truthy
         expect(File.exist?(@stored_path)).to be_falsey
 

--- a/spec/uploader/url_spec.rb
+++ b/spec/uploader/url_spec.rb
@@ -17,7 +17,7 @@ describe CarrierWave::Uploader do
 
   describe '#url' do
     before do
-      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-1234-2255')
     end
 
     it "should default to nil" do
@@ -45,13 +45,13 @@ describe CarrierWave::Uploader do
 
     it "should get the directory relative to public, prepending a slash" do
       @uploader.cache!(File.open(file_path('test.jpg')))
-      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-2255/test.jpg')
+      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-1234-2255/test.jpg')
     end
 
     it "should get the directory relative to public for a specific version" do
       MyCoolUploader.version(:thumb)
       @uploader.cache!(File.open(file_path('test.jpg')))
-      expect(@uploader.url(:thumb)).to eq('/uploads/tmp/1369894322-345-2255/thumb_test.jpg')
+      expect(@uploader.url(:thumb)).to eq('/uploads/tmp/1369894322-345-1234-2255/thumb_test.jpg')
     end
 
     it "should get the directory relative to public for a nested version" do
@@ -59,7 +59,7 @@ describe CarrierWave::Uploader do
         version(:mini)
       end
       @uploader.cache!(File.open(file_path('test.jpg')))
-      expect(@uploader.url(:thumb, :mini)).to eq('/uploads/tmp/1369894322-345-2255/thumb_mini_test.jpg')
+      expect(@uploader.url(:thumb, :mini)).to eq('/uploads/tmp/1369894322-345-1234-2255/thumb_mini_test.jpg')
     end
 
     it "should prepend the config option 'asset_host', if set and a string" do
@@ -68,7 +68,7 @@ describe CarrierWave::Uploader do
         config.asset_host = "http://foo.bar"
       end
       @uploader.cache!(File.open(file_path('test.jpg')))
-      expect(@uploader.url(:thumb)).to eq('http://foo.bar/uploads/tmp/1369894322-345-2255/thumb_test.jpg')
+      expect(@uploader.url(:thumb)).to eq('http://foo.bar/uploads/tmp/1369894322-345-1234-2255/thumb_test.jpg')
     end
 
     it "should prepend the result of the config option 'asset_host', if set and a proc" do
@@ -77,7 +77,7 @@ describe CarrierWave::Uploader do
         config.asset_host = proc { "http://foo.bar" }
       end
       @uploader.cache!(File.open(file_path('test.jpg')))
-      expect(@uploader.url(:thumb)).to eq('http://foo.bar/uploads/tmp/1369894322-345-2255/thumb_test.jpg')
+      expect(@uploader.url(:thumb)).to eq('http://foo.bar/uploads/tmp/1369894322-345-1234-2255/thumb_test.jpg')
     end
 
     it "should prepend the config option 'base_path', if set and 'asset_host' is not set" do
@@ -87,7 +87,7 @@ describe CarrierWave::Uploader do
         config.asset_host = nil
       end
       @uploader.cache!(File.open(file_path('test.jpg')))
-      expect(@uploader.url(:thumb)).to eq('/base_path/uploads/tmp/1369894322-345-2255/thumb_test.jpg')
+      expect(@uploader.url(:thumb)).to eq('/base_path/uploads/tmp/1369894322-345-1234-2255/thumb_test.jpg')
     end
 
     it "should return file#url if available" do
@@ -99,12 +99,12 @@ describe CarrierWave::Uploader do
     it "should get the directory relative to public, if file#url is blank" do
       @uploader.cache!(File.open(file_path('test.jpg')))
       allow(@uploader.file).to receive(:url).and_return('')
-      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-2255/test.jpg')
+      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-1234-2255/test.jpg')
     end
 
     it "should uri encode the path of a file without an asset host" do
       @uploader.cache!(File.open(file_path('test+.jpg')))
-      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-2255/test%2B.jpg')
+      expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-1234-2255/test%2B.jpg')
     end
 
     it "should uri encode the path of a file with a string asset host" do
@@ -113,7 +113,7 @@ describe CarrierWave::Uploader do
         config.asset_host = "http://foo.bar"
       end
       @uploader.cache!(File.open(file_path('test+.jpg')))
-      expect(@uploader.url(:thumb)).to eq('http://foo.bar/uploads/tmp/1369894322-345-2255/thumb_test%2B.jpg')
+      expect(@uploader.url(:thumb)).to eq('http://foo.bar/uploads/tmp/1369894322-345-1234-2255/thumb_test%2B.jpg')
     end
 
     it "should uri encode the path of a file with a proc asset host" do
@@ -122,7 +122,7 @@ describe CarrierWave::Uploader do
         config.asset_host = proc { "http://foo.bar" }
       end
       @uploader.cache!(File.open(file_path('test+.jpg')))
-      expect(@uploader.url(:thumb)).to eq('http://foo.bar/uploads/tmp/1369894322-345-2255/thumb_test%2B.jpg')
+      expect(@uploader.url(:thumb)).to eq('http://foo.bar/uploads/tmp/1369894322-345-1234-2255/thumb_test%2B.jpg')
     end
 
     it "shouldn't double-encode the path of an available file#url" do
@@ -135,7 +135,7 @@ describe CarrierWave::Uploader do
 
   describe '#to_json' do
     before do
-      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-1234-2255')
     end
 
     it "should return a hash with a nil URL" do
@@ -150,7 +150,7 @@ describe CarrierWave::Uploader do
 
     it "should return a hash including a cached URL" do
       @uploader.cache!(File.open(file_path("test.jpg")))
-      expect(JSON.parse(@uploader.to_json)).to eq({"url" => "/uploads/tmp/1369894322-345-2255/test.jpg"})
+      expect(JSON.parse(@uploader.to_json)).to eq({"url" => "/uploads/tmp/1369894322-345-1234-2255/test.jpg"})
     end
 
     it "should return a hash including a cached URL of a version" do
@@ -158,7 +158,7 @@ describe CarrierWave::Uploader do
       @uploader.cache!(File.open(file_path("test.jpg")))
       hash = JSON.parse(@uploader.to_json)
       expect(hash.keys).to include "thumb"
-      expect(hash["thumb"]).to eq({"url" => "/uploads/tmp/1369894322-345-2255/thumb_test.jpg"})
+      expect(hash["thumb"]).to eq({"url" => "/uploads/tmp/1369894322-345-1234-2255/thumb_test.jpg"})
     end
 
     it "should allow an options parameter to be passed in" do
@@ -168,7 +168,7 @@ describe CarrierWave::Uploader do
 
   describe '#to_xml' do
     before do
-      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-1234-2255')
     end
 
     it "should return a hash with a blank URL" do
@@ -177,25 +177,25 @@ describe CarrierWave::Uploader do
 
     it "should return a hash including a cached URL" do
       @uploader.cache!(File.open(file_path("test.jpg")))
-      expect(Hash.from_xml(@uploader.to_xml)).to eq({"uploader" => {"url" => "/uploads/tmp/1369894322-345-2255/test.jpg"}})
+      expect(Hash.from_xml(@uploader.to_xml)).to eq({"uploader" => {"url" => "/uploads/tmp/1369894322-345-1234-2255/test.jpg"}})
     end
 
     it "should return a hash including a cached URL of a version" do
       MyCoolUploader.version(:thumb)
       @uploader.cache!(File.open(file_path("test.jpg")))
-      expect(Hash.from_xml(@uploader.to_xml)["uploader"]["thumb"]).to eq({"url" => "/uploads/tmp/1369894322-345-2255/thumb_test.jpg"})
+      expect(Hash.from_xml(@uploader.to_xml)["uploader"]["thumb"]).to eq({"url" => "/uploads/tmp/1369894322-345-1234-2255/thumb_test.jpg"})
     end
 
     it "should return a hash including an array with a cached URL" do
       @uploader.cache!(File.open(file_path("test.jpg")))
       hash = Hash.from_xml([@uploader].to_xml)
-      expect(hash).to have_value([{"url"=>"/uploads/tmp/1369894322-345-2255/test.jpg"}])
+      expect(hash).to have_value([{"url"=>"/uploads/tmp/1369894322-345-1234-2255/test.jpg"}])
     end
   end
 
   describe '#to_s' do
     before do
-      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
+      allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-1234-2255')
     end
 
     it "should default to empty space" do
@@ -204,7 +204,7 @@ describe CarrierWave::Uploader do
 
     it "should get the directory relative to public, prepending a slash" do
       @uploader.cache!(File.open(file_path('test.jpg')))
-      expect(@uploader.to_s).to eq('/uploads/tmp/1369894322-345-2255/test.jpg')
+      expect(@uploader.to_s).to eq('/uploads/tmp/1369894322-345-1234-2255/test.jpg')
     end
 
     it "should return file#url if available" do

--- a/spec/uploader/versions_spec.rb
+++ b/spec/uploader/versions_spec.rb
@@ -229,7 +229,7 @@ describe CarrierWave::Uploader do
     describe '#cache!' do
 
       before do
-        allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
+        allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-1234-2255')
       end
 
       it "should set store_path with versions" do
@@ -243,8 +243,8 @@ describe CarrierWave::Uploader do
       it "should move it to the tmp dir with the filename prefixed" do
         expect(CarrierWave).to receive(:generate_cache_id).once
         @uploader.cache!(File.open(file_path('test.jpg')))
-        expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/test.jpg'))
-        expect(@uploader.thumb.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/thumb_test.jpg'))
+        expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-1234-2255/test.jpg'))
+        expect(@uploader.thumb.current_path).to eq(public_path('uploads/tmp/1369894322-345-1234-2255/thumb_test.jpg'))
         expect(@uploader.file.exists?).to be_truthy
         expect(@uploader.thumb.file.exists?).to be_truthy
       end
@@ -260,7 +260,7 @@ describe CarrierWave::Uploader do
     describe "version with move_to_cache set" do
       before do
         FileUtils.cp(file_path('test.jpg'), file_path('test_copy.jpg'))
-        allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
+        allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-1234-2255')
         @uploader_class.send(:define_method, :move_to_cache) do
           true
         end
@@ -273,8 +273,8 @@ describe CarrierWave::Uploader do
       it "should copy the parent file when creating the version" do
         @uploader_class.version(:thumb)
         @uploader.cache!(File.open(file_path('test.jpg')))
-        expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/test.jpg'))
-        expect(@uploader.thumb.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/thumb_test.jpg'))
+        expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-1234-2255/test.jpg'))
+        expect(@uploader.thumb.current_path).to eq(public_path('uploads/tmp/1369894322-345-1234-2255/thumb_test.jpg'))
         expect(@uploader.file.exists?).to be_truthy
         expect(@uploader.thumb.file.exists?).to be_truthy
       end
@@ -286,8 +286,8 @@ describe CarrierWave::Uploader do
           end
         end
         @uploader.cache!(File.open(file_path('test.jpg')))
-        expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/test.jpg'))
-        expect(@uploader.thumb.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/thumb_test.jpg'))
+        expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-1234-2255/test.jpg'))
+        expect(@uploader.thumb.current_path).to eq(public_path('uploads/tmp/1369894322-345-1234-2255/thumb_test.jpg'))
         expect(@uploader.file.exists?).to be_falsey
         expect(@uploader.thumb.file.exists?).to be_truthy
       end
@@ -295,13 +295,13 @@ describe CarrierWave::Uploader do
 
     describe '#retrieve_from_cache!' do
       it "should set the path to the tmp dir" do
-        @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpg')
-        expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/test.jpg'))
-        expect(@uploader.thumb.current_path).to eq(public_path('uploads/tmp/1369894322-345-2255/thumb_test.jpg'))
+        @uploader.retrieve_from_cache!('1369894322-345-1234-2255/test.jpg')
+        expect(@uploader.current_path).to eq(public_path('uploads/tmp/1369894322-345-1234-2255/test.jpg'))
+        expect(@uploader.thumb.current_path).to eq(public_path('uploads/tmp/1369894322-345-1234-2255/thumb_test.jpg'))
       end
 
       it "should set store_path with versions" do
-        @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpg')
+        @uploader.retrieve_from_cache!('1369894322-345-1234-2255/test.jpg')
         expect(@uploader.store_path).to eq('uploads/test.jpg')
         expect(@uploader.thumb.store_path).to eq('uploads/thumb_test.jpg')
         expect(@uploader.thumb.store_path('kebab.png')).to eq('uploads/thumb_kebab.png')
@@ -621,7 +621,7 @@ describe CarrierWave::Uploader do
 
     describe '#cache!' do
       before do
-        allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-2255')
+        allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-1234-2255')
       end
 
       it "should cache the files based on the version" do


### PR DESCRIPTION
Current (in master) version of generate_cache_id is collision-prone: for complex factories with multiple
uploaders we have quite a few flaky specs because of that. Having a counter, this and similar situations, like mentioned [here](https://github.com/carrierwaveuploader/carrierwave/issues/1232), should be resolved completely.