### PR TITLE
add a process command: resize_to_extend

### DIFF
--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -85,6 +85,10 @@ module CarrierWave
       def resize_and_pad(width, height, background=:transparent, gravity='Center')
         process :resize_and_pad => [width, height, background, gravity]
       end
+
+      def resize_to_extend(width,height, gravity = 'Center')
+        process :resize_to_extend =>[width,height, gravity]
+      end
     end
 
     ##
@@ -243,6 +247,31 @@ module CarrierWave
         img
       end
     end
+    
+    ##
+    # Resize the image to given size and chop the image in the given dimension.
+    # 
+    # === Parameters
+    #
+    # [width (Integer)] the width to scale the image to
+    # [height (Integer)] the height to scale the image to
+    # [gravity (String)] the current gravity suggestion 
+    # (default: 'Center'; options: 'NorthWest', 'North', 'NorthEast', 'West', 'Center', 'East', 'SouthWest', 'South', 'SouthEast')
+    #
+    # === Yields
+    #
+    # [MiniMagick::Image] additional manipulations to perform
+    #
+    def resize_to_extend(width, height, gravity = 'Center')
+      manipulate! do |img|
+        img.gravity gravity
+        img.resize "#{width}^x#{height}^"
+        img.extent "#{width}x#{height}" 
+        img = yield(img) if block_given?
+        img
+      end
+    end
+
 
     ##
     # Return the mini magic instance of the image

--- a/spec/processing/mini_magick_spec.rb
+++ b/spec/processing/mini_magick_spec.rb
@@ -156,6 +156,23 @@ describe CarrierWave::MiniMagick do
     end
   end
 
+  describe '#resize_to_extend' do
+    it 'should resize the image to fit within the given dimensions, maintain file type' do
+      expect(::MiniMagick::Tool::Identify.new.verbose(@instance.current_path).call).to_not include('Quality: 70')
+      @instance.resize_to_extend(200, 200)
+      expect(@instance).to have_dimensions(200, 200)
+      expect(::MiniMagick::Image.open(@instance.current_path)['format']).to match(/JPEG/)
+    end
+
+    it "should resize the image to fit within the given dimensions and maintain updated file type" do
+      @instance.convert('png')
+      @instance.resize_to_extend(200, 200)
+      expect(@instance).to have_dimensions(200, 200)
+      expect(::MiniMagick::Image.open(@instance.current_path)['format']).to match(/PNG/)
+      expect(@instance.file.extension).to eq('png')
+    end
+  end
+
   describe "test errors" do
     context "invalid image file" do
       before do


### PR DESCRIPTION
I add a process command: resize_to_extend for mini magick processings. It resize the image to fill target dimension and chop the extend part(s).  This process works well in my project.