### PR TITLE
Make `CarrierWave::MiniMagick#mini_magic_image` private

### DIFF
--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -245,40 +245,25 @@ module CarrierWave
     end
 
     ##
-    # Return the mini magic instance of the image
-    #
-    # === Returns
-    #
-    # #<MiniMagick::Image>
-    #
-    def mini_magic_image
-      if url
-        ::MiniMagick::Image.open(url)
-      else
-        ::MiniMagick::Image.open(current_path)
-      end
-    end
-
-    ##
-    # Gives the width of the image, useful for model validation
+    # Returns the width of the image in pixels.
     #
     # === Returns
     #
     # [Integer] the image's width in pixels
     #
     def width
-      mini_magic_image[:width]
+      mini_magick_image[:width]
     end
 
     ##
-    # Gives the height of the image, useful for model validation
+    # Returns the height of the image in pixels.
     #
     # === Returns
     #
     # [Integer] the image's height in pixels
     #
     def height
-      mini_magic_image[:height]
+      mini_magick_image[:height]
     end
 
     ##
@@ -337,6 +322,16 @@ module CarrierWave
         cmd.send(method, options)
       end
     end
+
+    private
+
+      def mini_magick_image
+        if url
+          ::MiniMagick::Image.open(url)
+        else
+          ::MiniMagick::Image.open(current_path)
+        end
+      end
 
   end # MiniMagick
 end # CarrierWave

--- a/spec/processing/mini_magick_spec.rb
+++ b/spec/processing/mini_magick_spec.rb
@@ -156,6 +156,14 @@ describe CarrierWave::MiniMagick do
     end
   end
 
+  describe "#width and #height" do
+    it "should return the width and height of the image" do
+      @instance.resize_to_fill(200, 300)
+      expect(@instance.width).to eq(200)
+      expect(@instance.height).to eq(300)
+    end
+  end
+
   describe "test errors" do
     context "invalid image file" do
       before do
@@ -185,14 +193,6 @@ describe CarrierWave::MiniMagick do
           end.to raise_exception( CarrierWave::ProcessingError )
         end
       end
-    end
-  end
-
-  describe "return_width_and_height" do
-    it "should return the width and height of the image" do
-      @instance.resize_to_fill(200, 300)
-      expect(@instance.width).to eq(200)
-      expect(@instance.height).to eq(300)
     end
   end
 


### PR DESCRIPTION
I think `CarrierWave::MiniMagick#mini_magic_image` method doesn't need to be part of the public API, at least to keep a symmetry between MiniMagick and RMagick processors (more at #1805). 
This method is used by the new public `#width` and `#height` methods (introduced by #1405).
This commit also fixes a typo in the method name (magick instead of magic).

Any thoughts?