### PR TITLE
Add `#width` and `#height` methods to the RMagick processor

### DIFF
--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -318,8 +318,6 @@ module CarrierWave
         end
       end
 
-    private
-
       def mini_magick_image
         if url
           ::MiniMagick::Image.open(url)

--- a/lib/carrierwave/processing/rmagick.rb
+++ b/lib/carrierwave/processing/rmagick.rb
@@ -252,6 +252,28 @@ module CarrierWave
     end
 
     ##
+    # Returns the width of the image.
+    #
+    # === Returns
+    #
+    # [Integer] the image's width in pixels
+    #
+    def width
+      rmagick_image.columns
+    end
+
+    ##
+    # Returns the height of the image.
+    #
+    # === Returns
+    #
+    # [Integer] the image's height in pixels
+    #
+    def height
+      rmagick_image.rows
+    end
+
+    ##
     # Manipulate the image with RMagick. This method will load up an image
     # and then pass each of its frames to the supplied block. It will then
     # save the image to disk.
@@ -349,6 +371,10 @@ module CarrierWave
 
     def destroy_image(image)
       image.destroy! if image.respond_to?(:destroy!)
+    end
+
+    def rmagick_image
+      ::Magick::Image.read(current_path).first
     end
 
   end # RMagick

--- a/spec/processing/rmagick_spec.rb
+++ b/spec/processing/rmagick_spec.rb
@@ -196,6 +196,14 @@ describe CarrierWave::RMagick, :rmagick => true do
     end
   end
 
+  describe "#width and #height" do
+    it "should return the width and height of the image" do
+      @instance.resize_to_fill(200, 300)
+      expect(@instance.width).to eq(200)
+      expect(@instance.height).to eq(300)
+    end
+  end
+
   describe "test errors" do
     context "invalid image file" do
       before do


### PR DESCRIPTION
This keeps the symmetry with MiniMagick processor where `#width` and
`#height` methods has been introduced by #1405.