### PR TITLE
Make `CarrierWave::MiniMagick#append_combine_options` private

### DIFF
--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -325,18 +325,13 @@ module CarrierWave
       raise CarrierWave::ProcessingError, message
     end
 
-    ##
-    # Takes a hash of options for a combine_options cmd and appends to command on each option
-    #
-    # === Parameters
-    #
-    # [cmd (MiniMagick::Tool)] command tool
-    # [combine_options (Hash)] a hash of command options and values
-    def append_combine_options(cmd, combine_options)
-      combine_options.each do |method, options|
-        cmd.send(method, options)
+    private
+
+      def append_combine_options(cmd, combine_options)
+        combine_options.each do |method, options|
+          cmd.send(method, options)
+        end
       end
-    end
 
   end # MiniMagick
 end # CarrierWave


### PR DESCRIPTION
This method isn't intended to be part of the public API.
It's used internally by the processor to accept `combine_options`
introduced at #1754.