### PR TITLE
Fix Travis JRuby modes for JRuby 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ rvm:
  - jruby
  - jruby-head
 
+env:
+  - JRUBY_OPTS="--2.0"
+
 gemfile:
   - Gemfile
   - gemfiles/rails-4-0-stable.gemfile


### PR DESCRIPTION
Since #1754 merge, JRuby builds fails due to the new hash syntax.
See https://travis-ci.org/carrierwaveuploader/carrierwave/jobs/93603851

This is due to JRuby mode. 
`jruby` resolves to 1.7.10 in 1.9 mode and `jruby-head` resolves to the JRuby master branch in 2.1 mode.
As Travis doesn't support d20 and d21 for JRuby (see https://github.com/travis-ci/travis-ci/issues/2432#issuecomment-46647960), using `JRUBY_OPTS` sets the mode to run for JRuby 1.7.
Note that `JRUBY_OPTS` is ignored by `jruby-head`, which uses Ruby 2.2.3 mode (https://travis-ci.org/carrierwaveuploader/carrierwave/jobs/99350211#L212)

I preferred this instead of changing the hash syntax as it matches MRI Ruby minimal requirements for CarrierWave 1.0.0 (Rails 4 and Ruby 2).
I think though we should only support and test against a recent JRuby version like `jruby-9.0.1.0` for CW 1.0.0 release. I'll make another PR to reflect this if it sounds good to you.

CI is :green_heart: again :tada: 