### PR TITLE
Update Multiple File Uploads section of READEME.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ u.avatars[0].current_path # => 'path/to/file.png'
 u.avatars[0].identifier # => 'file.png'
 ```
 
+### Sample Project
+[Sample project](https://github.com/bobintornado/sample-gallery-app-with-carrierwave) with corresponding [blog post](http://bobintornado.github.io/rails/2015/12/29/Multiple-Images-Uploading-With-CarrierWave-and-PostgreSQL-Array.html).
+
 ## Changing the storage directory
 
 In order to change where uploaded files are put, just override the `store_dir`


### PR DESCRIPTION
This PR adds in some documentation for the Multiple file uploads feature provided by CarrierWave with 

1. A sample project
2. A blog post as temporary documentation addon

The sample project supports following features
* Create a new gallery by uploading multiple images
* Upload more images into existing gallery
* Delete specific image from existing gallery (one at a time)