### PR TITLE
Reflect the documented minimum versions requirements in the .gemspec file

### DIFF
--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -24,8 +24,10 @@ Gem::Specification.new do |s|
   s.specification_version = 3
   s.licenses = ["MIT"]
 
-  s.add_dependency "activesupport", ">= 3.2.0"
-  s.add_dependency "activemodel", ">= 3.2.0"
+  s.required_ruby_version = ">= 2.0.0"
+
+  s.add_dependency "activesupport", ">= 4.0.0"
+  s.add_dependency "activemodel", ">= 4.0.0"
   s.add_dependency "json", ">= 1.7"
   s.add_dependency "mime-types", ">= 1.16"
   if RUBY_ENGINE == 'jruby'
@@ -33,7 +35,7 @@ Gem::Specification.new do |s|
   else
     s.add_development_dependency "pg"
   end
-  s.add_development_dependency "rails", ">= 3.2.0"
+  s.add_development_dependency "rails", ">= 4.0.0"
   s.add_development_dependency "cucumber", "~> 2.0.0"
   s.add_development_dependency "rspec", "~> 3.2.0"
   s.add_development_dependency "sham_rack"


### PR DESCRIPTION
This change reflects what is documented on minimal versions requirements (and what is tested in CI) for the 1.0.0 release.
Those requirements has been introduced at 2517d66809472fca9b1d5638eeeb515b351a8602.