### PR TITLE
Use `try` instead of `obj.foo if obj.respond_to?(:foo)`

### DIFF
--- a/lib/carrierwave.rb
+++ b/lib/carrierwave.rb
@@ -2,6 +2,7 @@
 
 require 'fileutils'
 require 'active_support/core_ext/object/blank'
+require 'active_support/core_ext/object/try'
 require 'active_support/core_ext/class/attribute'
 require 'active_support/concern'
 

--- a/lib/carrierwave/mounter.rb
+++ b/lib/carrierwave/mounter.rb
@@ -133,7 +133,7 @@ module CarrierWave
           value
         end
       end
-      after_paths = Array(after).reject(&:blank?).map { |value| value.respond_to?(:path) ? value.path : value }
+      after_paths = Array(after).reject(&:blank?).map { |value| value.try(:path) || value }
       before.each do |uploader|
         if uploader.remove_previously_stored_files_after_update and not after_paths.include?(uploader.path)
           uploader.remove!

--- a/lib/carrierwave/processing/rmagick.rb
+++ b/lib/carrierwave/processing/rmagick.rb
@@ -370,7 +370,7 @@ module CarrierWave
     end
 
     def destroy_image(image)
-      image.destroy! if image.respond_to?(:destroy!)
+      image.try(:destroy!)
     end
 
     def rmagick_image

--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -164,9 +164,9 @@ module CarrierWave
       elsif is_path?
         File.open(@file, "rb") {|file| file.read}
       else
-        @file.rewind if @file.respond_to?(:rewind)
+        @file.try(:rewind)
         @content = @file.read
-        @file.close if @file.respond_to?(:close) && @file.respond_to?(:closed?) && !@file.closed?
+        @file.try(:close) unless @file.try(:closed?)
         @content
       end
     end

--- a/lib/carrierwave/uploader/proxy.rb
+++ b/lib/carrierwave/uploader/proxy.rb
@@ -19,7 +19,7 @@ module CarrierWave
       # [String] the path where the file is currently located.
       #
       def current_path
-        file.path if file.respond_to?(:path)
+        file.try(:path)
       end
 
       alias_method :path, :current_path
@@ -32,7 +32,7 @@ module CarrierWave
       # [String] uniquely identifies a file
       #
       def identifier
-        storage.identifier if storage.respond_to?(:identifier)
+        storage.try(:identifier)
       end
 
       ##
@@ -43,7 +43,7 @@ module CarrierWave
       # [String] contents of the file
       #
       def read
-        file.read if file.respond_to?(:read)
+        file.try(:read)
       end
 
       ##
@@ -54,7 +54,7 @@ module CarrierWave
       # [Integer] size of the file
       #
       def size
-        file.respond_to?(:size) ? file.size : 0
+        file.try(:size) || 0
       end
 
       ##
@@ -80,7 +80,7 @@ module CarrierWave
       # [String] content type of the file
       #
       def content_type
-        file.respond_to?(:content_type) ? file.content_type : nil
+        file.try(:content_type)
       end
 
     end # Proxy


### PR DESCRIPTION
As CarrierWave already depends on ActiveSupport that brings `try`,
this change helps to improve the code readability avoiding conditionals.