### PR TITLE
Avoid duplication between RSpec and Cucumber AR support config

### DIFF
--- a/features/support/activerecord.rb
+++ b/features/support/activerecord.rb
@@ -16,9 +16,5 @@ class TestMigration < ActiveRecord::Migration
 end
 
 Before do
-  if [ActiveRecord::VERSION::MAJOR, ActiveRecord::VERSION::MINOR] == [4, 2]
-    ActiveRecord::Base.raise_in_transactional_callbacks = true
-  end
-
   TestMigration.up
 end

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -26,12 +26,6 @@ describe CarrierWave::ActiveRecord do
   before(:all) { TestMigration.up }
   after(:all) { TestMigration.down }
 
-  if [ActiveRecord::VERSION::MAJOR, ActiveRecord::VERSION::MINOR] == [4, 2]
-    before :all do
-      ActiveRecord::Base.raise_in_transactional_callbacks = true
-    end
-  end
-
   before do
     sham_rack_app = ShamRack.at('www.example.com').stub
     sham_rack_app.register_resource('/test.jpg', File.read(file_path('test.jpg')), 'images/jpg')

--- a/spec/support/activerecord.rb
+++ b/spec/support/activerecord.rb
@@ -25,3 +25,7 @@ end
 ActiveRecord::Base.establish_connection(dbconfig.merge(:database => database))
 
 ActiveRecord::Migration.verbose = false
+
+if ActiveRecord::VERSION::STRING >= '4.2'
+  ActiveRecord::Base.raise_in_transactional_callbacks = true
+end


### PR DESCRIPTION
Since `spec/support/activerecord.rb` is required in `features/support/activerecord.rb`, duplicated AR config could be avoided (only migrations differs).
`raise_in_transactional_callbacks` should/would be set to `true` not only for Rails 4.2 but >= 4.2.
Related to #1815.