### PR TITLE
Remove UTF-8 magic comments from all the Ruby files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 require 'rubygems'
 begin
   require 'bundler/setup'

--- a/features/step_definitions/activerecord_steps.rb
+++ b/features/step_definitions/activerecord_steps.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 Given /^an activerecord class that uses the '([^\']*)' table$/ do |name|
   @mountee_klass = Class.new(ActiveRecord::Base)
   @mountee_klass.table_name = name

--- a/features/step_definitions/caching_steps.rb
+++ b/features/step_definitions/caching_steps.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 Given /^the file '(.*?)' is cached file at '(.*?)'$/ do |file, cached|
   FileUtils.mkdir_p(File.dirname(file_path(cached)))
   FileUtils.cp(file_path(file), file_path(cached))

--- a/features/step_definitions/datamapper_steps.rb
+++ b/features/step_definitions/datamapper_steps.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 Given /^a datamapper class that has a '([^\']*)' column$/ do |column|
   @mountee_klass = Class.new do
     include DataMapper::Resource

--- a/features/step_definitions/file_steps.rb
+++ b/features/step_definitions/file_steps.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 ###
 # EXISTENCE
 

--- a/features/step_definitions/general_steps.rb
+++ b/features/step_definitions/general_steps.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 Given /^an uploader class that uses the '(.*?)' storage$/ do |kind|
   @klass = Class.new(CarrierWave::Uploader::Base)
   @klass.storage = kind.to_sym

--- a/features/step_definitions/mount_steps.rb
+++ b/features/step_definitions/mount_steps.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 When /^I assign the file '([^\']*)' to the '([^\']*)' column$/ do |path, column|
   @instance.send("#{column}=", File.open(file_path(path)))
 end

--- a/features/step_definitions/store_steps.rb
+++ b/features/step_definitions/store_steps.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 Given /^the file '(.*?)' is stored at '(.*?)'$/ do |file, stored|
   FileUtils.mkdir_p(File.dirname(file_path(stored)))
   FileUtils.cp(file_path(file), file_path(stored))

--- a/features/support/activerecord.rb
+++ b/features/support/activerecord.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'carrierwave/mount'
 require File.join(File.dirname(__FILE__), '..', '..', 'spec', 'support', 'activerecord')
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 $:.unshift File.expand_path(File.join('..', '..', 'lib'), File.dirname(__FILE__))
 
 require File.join(File.dirname(__FILE__), 'activerecord')

--- a/lib/carrierwave.rb
+++ b/lib/carrierwave.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'fileutils'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/object/try'

--- a/lib/carrierwave/compatibility/paperclip.rb
+++ b/lib/carrierwave/compatibility/paperclip.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module CarrierWave
   module Compatibility
 

--- a/lib/carrierwave/mount.rb
+++ b/lib/carrierwave/mount.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module CarrierWave
 
   ##
@@ -182,7 +180,7 @@ module CarrierWave
         def #{column}_identifier
           _mounter(:#{column}).read_identifiers[0]
         end
-        
+
         def store_previous_changes_for_#{column}
           @_previous_changes_for_#{column} = changes[_mounter(:#{column}).serialization_column]
         end
@@ -332,7 +330,7 @@ module CarrierWave
         def #{column}_identifiers
           _mounter(:#{column}).read_identifiers
         end
-        
+
         def store_previous_changes_for_#{column}
           @_previous_changes_for_#{column} = changes[_mounter(:#{column}).serialization_column]
         end

--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'active_record'
 require 'carrierwave/validations/active_model'
 

--- a/lib/carrierwave/processing/magic_mime_types.rb
+++ b/lib/carrierwave/processing/magic_mime_types.rb
@@ -1,9 +1,7 @@
-# encoding: utf-8
-
 module CarrierWave
   ##
   # This module simplifies the use of ruby-filemagic gem to intelligently
-  # and correctly guess and set the content-type of a file. If you want 
+  # and correctly guess and set the content-type of a file. If you want
   # to use this, you'll need to require this file:
   #
   #    require 'carrierwave/processing/magic_mime_types'

--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module CarrierWave
 
   ##

--- a/lib/carrierwave/processing/rmagick.rb
+++ b/lib/carrierwave/processing/rmagick.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module CarrierWave
 
   ##

--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'pathname'
 require 'active_support/core_ext/string/multibyte'
 

--- a/lib/carrierwave/storage/abstract.rb
+++ b/lib/carrierwave/storage/abstract.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module CarrierWave
   module Storage
 

--- a/lib/carrierwave/storage/file.rb
+++ b/lib/carrierwave/storage/file.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module CarrierWave
   module Storage
 

--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module CarrierWave
   module Storage
 

--- a/lib/carrierwave/test/matchers.rb
+++ b/lib/carrierwave/test/matchers.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module CarrierWave
   module Test
 
@@ -394,4 +392,3 @@ module CarrierWave
     end # Matchers
   end # Test
 end # CarrierWave
-

--- a/lib/carrierwave/uploader.rb
+++ b/lib/carrierwave/uploader.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "carrierwave/uploader/configuration"
 require "carrierwave/uploader/callbacks"
 require "carrierwave/uploader/proxy"

--- a/lib/carrierwave/uploader/cache.rb
+++ b/lib/carrierwave/uploader/cache.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module CarrierWave
 
   class FormNotMultipart < UploadError
@@ -7,13 +5,13 @@ module CarrierWave
       "You tried to assign a String or a Pathname to an uploader, for security reasons, this is not allowed.\n\n If this is a file upload, please check that your upload form is multipart encoded."
     end
   end
-  
+
   class CacheCounter
     @@counter = 0
 
     def self.increment
       @@counter += 1
-    end  
+    end
   end
 
   ##
@@ -25,8 +23,8 @@ module CarrierWave
   #
   def self.generate_cache_id
     [Time.now.utc.to_i,
-      Process.pid, 
-      '%04d' % (CarrierWave::CacheCounter.increment % 1000), 
+      Process.pid,
+      '%04d' % (CarrierWave::CacheCounter.increment % 1000),
       '%04d' % rand(9999)
     ].map(&:to_s).join('-')
   end

--- a/lib/carrierwave/uploader/callbacks.rb
+++ b/lib/carrierwave/uploader/callbacks.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module CarrierWave
   module Uploader
     module Callbacks

--- a/lib/carrierwave/uploader/default_url.rb
+++ b/lib/carrierwave/uploader/default_url.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module CarrierWave
   module Uploader
     module DefaultUrl

--- a/lib/carrierwave/uploader/download.rb
+++ b/lib/carrierwave/uploader/download.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'open-uri'
 
 module CarrierWave

--- a/lib/carrierwave/uploader/extension_whitelist.rb
+++ b/lib/carrierwave/uploader/extension_whitelist.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module CarrierWave
   module Uploader
     module ExtensionWhitelist

--- a/lib/carrierwave/uploader/file_size.rb
+++ b/lib/carrierwave/uploader/file_size.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module CarrierWave
   module Uploader
     module FileSize

--- a/lib/carrierwave/uploader/magic_mime_blacklist.rb
+++ b/lib/carrierwave/uploader/magic_mime_blacklist.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module CarrierWave
   module Uploader
 

--- a/lib/carrierwave/uploader/magic_mime_whitelist.rb
+++ b/lib/carrierwave/uploader/magic_mime_whitelist.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module CarrierWave
   module Uploader
 

--- a/lib/carrierwave/uploader/mountable.rb
+++ b/lib/carrierwave/uploader/mountable.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module CarrierWave
   module Uploader
     module Mountable

--- a/lib/carrierwave/uploader/processing.rb
+++ b/lib/carrierwave/uploader/processing.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module CarrierWave
   module Uploader
     module Processing

--- a/lib/carrierwave/uploader/proxy.rb
+++ b/lib/carrierwave/uploader/proxy.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module CarrierWave
   module Uploader
     module Proxy

--- a/lib/carrierwave/uploader/remove.rb
+++ b/lib/carrierwave/uploader/remove.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module CarrierWave
   module Uploader
     module Remove

--- a/lib/carrierwave/uploader/serialization.rb
+++ b/lib/carrierwave/uploader/serialization.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require "json"
 require "active_support/core_ext/hash"
 

--- a/lib/carrierwave/uploader/store.rb
+++ b/lib/carrierwave/uploader/store.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module CarrierWave
   module Uploader
     module Store

--- a/lib/carrierwave/uploader/url.rb
+++ b/lib/carrierwave/uploader/url.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module CarrierWave
   module Uploader
     module Url

--- a/lib/carrierwave/uploader/versions.rb
+++ b/lib/carrierwave/uploader/versions.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module CarrierWave
   module Uploader
     module Versions

--- a/lib/carrierwave/utilities.rb
+++ b/lib/carrierwave/utilities.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'carrierwave/utilities/uri'
 
 module CarrierWave

--- a/lib/carrierwave/utilities/uri.rb
+++ b/lib/carrierwave/utilities/uri.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module CarrierWave
   module Utilities
     module Uri

--- a/lib/carrierwave/validations/active_model.rb
+++ b/lib/carrierwave/validations/active_model.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'active_model/validator'
 require 'active_support/concern'
 

--- a/lib/generators/templates/uploader.rb
+++ b/lib/generators/templates/uploader.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class <%= class_name %>Uploader < CarrierWave::Uploader::Base
 
   # Include RMagick or MiniMagick support:

--- a/spec/compatibility/paperclip_spec.rb
+++ b/spec/compatibility/paperclip_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 require 'carrierwave/orm/activerecord'

--- a/spec/mount_multiple_spec.rb
+++ b/spec/mount_multiple_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe CarrierWave::Mount do

--- a/spec/mount_single_spec.rb
+++ b/spec/mount_single_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe CarrierWave::Mount do

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 require 'support/activerecord'
 

--- a/spec/processing/magic_mime_types_spec.rb
+++ b/spec/processing/magic_mime_types_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe CarrierWave::MagicMimeTypes, :filemagic => true do

--- a/spec/processing/mini_magick_spec.rb
+++ b/spec/processing/mini_magick_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe CarrierWave::MiniMagick do

--- a/spec/processing/rmagick_spec.rb
+++ b/spec/processing/rmagick_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe CarrierWave::RMagick, :rmagick => true do

--- a/spec/sanitized_file_spec.rb
+++ b/spec/sanitized_file_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 begin

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'rubygems'
 require 'bundler/setup'
 

--- a/spec/storage/file_spec.rb
+++ b/spec/storage/file_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 require 'support/file_utils_helper'
 require 'tempfile'

--- a/spec/storage/fog_spec.rb
+++ b/spec/storage/fog_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 require 'fog'
 require 'carrierwave/storage/fog'

--- a/spec/uploader/cache_spec.rb
+++ b/spec/uploader/cache_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe CarrierWave::Uploader do
@@ -268,7 +266,7 @@ describe CarrierWave::Uploader do
       expect(@uploader.filename).to be_nil
       expect(@uploader.cache_name).to be_nil
     end
-    
+
     it "should support old format of cache_id (without counter) for backwards compartibility" do
       @uploader.retrieve_from_cache!('1369894322-345-2255/test.jpeg')
       expect(@uploader.url).to eq('/uploads/tmp/1369894322-345-2255/test.jpeg')
@@ -314,19 +312,19 @@ describe CarrierWave::Uploader do
       end
     end
   end
-  
+
   describe '.generate_cache_id' do
     it 'should generate dir name based on UTC time' do
       Timecop.freeze(Time.at(1369896000)) do
         expect(CarrierWave.generate_cache_id).to match(/\A1369896000-\d+-\d+-\d+\Z/)
       end
     end
-    
+
     it 'should generate dir name with a counter substring' do
       @counter = CarrierWave.generate_cache_id.split('-')[2].to_i
       expect(CarrierWave.generate_cache_id.split('-')[2].to_i).to eq(@counter + 1)
     end
-    
+
     it 'should generate dir name with constant length even when counter has big value' do
       @length = CarrierWave.generate_cache_id.length
       allow(CarrierWave::CacheCounter).to receive(:increment).and_return(1234567890)

--- a/spec/uploader/callback_spec.rb
+++ b/spec/uploader/callback_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe CarrierWave::Uploader do

--- a/spec/uploader/configuration_spec.rb
+++ b/spec/uploader/configuration_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 

--- a/spec/uploader/default_url_spec.rb
+++ b/spec/uploader/default_url_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe CarrierWave::Uploader do

--- a/spec/uploader/download_spec.rb
+++ b/spec/uploader/download_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe CarrierWave::Uploader::Download do

--- a/spec/uploader/extension_blacklist_spec.rb
+++ b/spec/uploader/extension_blacklist_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe CarrierWave::Uploader do

--- a/spec/uploader/extension_whitelist_spec.rb
+++ b/spec/uploader/extension_whitelist_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe CarrierWave::Uploader do

--- a/spec/uploader/file_size_spec.rb
+++ b/spec/uploader/file_size_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe CarrierWave::Uploader do

--- a/spec/uploader/magic_mime_blacklist_spec.rb
+++ b/spec/uploader/magic_mime_blacklist_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe CarrierWave::Uploader, filemagic: true do

--- a/spec/uploader/magic_mime_whitelist_spec.rb
+++ b/spec/uploader/magic_mime_whitelist_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe CarrierWave::Uploader, filemagic: true do

--- a/spec/uploader/mountable_spec.rb
+++ b/spec/uploader/mountable_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe CarrierWave::Uploader do

--- a/spec/uploader/overrides_spec.rb
+++ b/spec/uploader/overrides_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe CarrierWave::Uploader do

--- a/spec/uploader/paths_spec.rb
+++ b/spec/uploader/paths_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe CarrierWave::Uploader do

--- a/spec/uploader/processing_spec.rb
+++ b/spec/uploader/processing_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe CarrierWave::Uploader do

--- a/spec/uploader/proxy_spec.rb
+++ b/spec/uploader/proxy_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe CarrierWave::Uploader do

--- a/spec/uploader/remove_spec.rb
+++ b/spec/uploader/remove_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe CarrierWave::Uploader do

--- a/spec/uploader/store_spec.rb
+++ b/spec/uploader/store_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe CarrierWave::Uploader do

--- a/spec/uploader/url_spec.rb
+++ b/spec/uploader/url_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 require 'active_support/json'
 

--- a/spec/uploader/versions_spec.rb
+++ b/spec/uploader/versions_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'spec_helper'
 
 describe CarrierWave::Uploader do


### PR DESCRIPTION
Ruby 2 made UTF-8 the default encoding, which make magic comments omissible.
I can remove from the diff the whitespaces and EOF lintings if you prefer