### PR TITLE
Enable Bundler caching on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 
+cache: bundler
+
 rvm:
  - 2.0
  - 2.1


### PR DESCRIPTION
With Container based CI, public projects can cache the bundle.
This make the build :speedboat:
https://docs.travis-ci.com/user/caching/#Enabling-Bundler-caching