### PR TITLE
Refactor AR specs

### DIFF
--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -25,8 +25,6 @@ describe CarrierWave::ActiveRecord do
   after(:all) { TestMigration.down }
 
   before do
-    # Rails 4 defaults to no root in JSON, join the party
-    ActiveRecord::Base.include_root_in_json = false
     # My god, what a horrible, horrible solution, but AR validations don't work
     # unless the class has a name. This is the best I could come up with :S
     $arclass += 1

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -17,27 +17,19 @@ class TestMigration < ActiveRecord::Migration
   end
 end
 
-class Event < ActiveRecord::Base; end # setup a basic AR class for testing
-$arclass = 0
+def reset_class(class_name)
+  Object.send(:remove_const, class_name) rescue nil
+  Object.const_set(class_name, Class.new(ActiveRecord::Base))
+end
 
 describe CarrierWave::ActiveRecord do
   before(:all) { TestMigration.up }
   after(:all) { TestMigration.down }
 
   before do
-    # My god, what a horrible, horrible solution, but AR validations don't work
-    # unless the class has a name. This is the best I could come up with :S
-    $arclass += 1
-
-    @class = Class.new(Event)
-    # AR validations don't work unless the class has a name, and
-    # anonymous classes can be named by assigning them to a constant
-    Object.const_set("Event#{$arclass}", @class)
-    @class.table_name = "events"
     @uploader = Class.new(CarrierWave::Uploader::Base)
-    @class.mount_uploader(:image, @uploader)
-    @class.mount_uploaders(:images, @uploader)
-    @event = @class.new
+    reset_class("Event")
+    @event = Event.new
   end
 
   after do
@@ -45,6 +37,10 @@ describe CarrierWave::ActiveRecord do
   end
 
   describe '#mount_uploader' do
+    before do
+      Event.mount_uploader(:image, @uploader)
+    end
+
     describe '#image' do
 
       it "should return blank uploader when nothing has been assigned" do
@@ -97,8 +93,9 @@ describe CarrierWave::ActiveRecord do
       end
 
       it "should return valid XML when to_xml is called when image is nil" do
+        hash = Hash.from_xml(@event.to_xml)["event"]
+
         expect(@event[:image]).to be_nil
-        hash = Hash.from_xml(@event.to_xml)["event#{$arclass}"]
         expect(hash.keys).to include("image")
         expect(hash["image"].keys).to include("url")
         expect(hash["image"]["url"]).to be_nil
@@ -109,7 +106,7 @@ describe CarrierWave::ActiveRecord do
         @event.save!
         @event.reload
 
-        expect(Hash.from_xml(@event.to_xml)["event#{$arclass}"]["image"]).to eq({"url" => "/uploads/test.jpeg"})
+        expect(Hash.from_xml(@event.to_xml)["event"]["image"]).to eq({"url" => "/uploads/test.jpeg"})
       end
 
       it "should respect options[:only] when passed to as_json for the serializable hash" do
@@ -140,7 +137,7 @@ describe CarrierWave::ActiveRecord do
         @event.save!
         @event.reload
 
-        expect(Hash.from_xml(@event.to_xml(:only => [:foo]))["event#{$arclass}"]["image"]).to be_nil
+        expect(Hash.from_xml(@event.to_xml(only: [:foo]))["event"]["image"]).to be_nil
       end
 
       it "should respect options[:except] when passed to to_xml for the serializable hash" do
@@ -148,7 +145,7 @@ describe CarrierWave::ActiveRecord do
         @event.save!
         @event.reload
 
-        expect(Hash.from_xml(@event.to_xml(:except => [:image]))["event#{$arclass}"]["image"]).to be_nil
+        expect(Hash.from_xml(@event.to_xml(except: [:image]))["event"]["image"]).to be_nil
       end
 
       it "should respect both options[:only] and options[:except] when passed to to_xml for the serializable hash" do
@@ -156,7 +153,7 @@ describe CarrierWave::ActiveRecord do
         @event.save!
         @event.reload
 
-        expect(Hash.from_xml(@event.to_xml(:only => [:foo], :except => [:id]))["event#{$arclass}"]["image"]).to be_nil
+        expect(Hash.from_xml(@event.to_xml(only: [:foo], except: [:id]))["event"]["image"]).to be_nil
       end
 
       it "resets cached value on record reload" do
@@ -164,7 +161,8 @@ describe CarrierWave::ActiveRecord do
         @event.save!
 
         expect(@event.reload.image).to be_present
-        @class.find(@event.id).update_column(:image, nil)
+
+        Event.find(@event.id).update_column(:image, nil)
 
         expect(@event.reload.image).to be_blank
       end
@@ -357,8 +355,9 @@ describe CarrierWave::ActiveRecord do
       end
 
       it "should do nothing when a validation fails" do
-        @class.validate { |r| r.errors.add :textfile, "FAIL!" }
+        Event.validate { |r| r.errors.add :textfile, "FAIL!" }
         @event.image = stub_file('test.jpeg')
+
         expect(@event.save).to be_falsey
         expect(@event.image).to be_an_instance_of(@uploader)
         expect(@event.image.current_path).to match(/^#{public_path('uploads/tmp')}/)
@@ -375,8 +374,10 @@ describe CarrierWave::ActiveRecord do
       it "should preserve the image when nothing is assigned" do
         @event.image = stub_file('test.jpeg')
         expect(@event.save).to be_truthy
-        @event = @class.find(@event.id)
+
+        @event = Event.find(@event.id)
         @event.foo = "bar"
+
         expect(@event.save).to be_truthy
         expect(@event[:image]).to eq('test.jpeg')
         expect(@event.image_identifier).to eq('test.jpeg')
@@ -585,7 +586,7 @@ describe CarrierWave::ActiveRecord do
     describe 'with validates_presence_of' do
 
       before do
-        @class.validates_presence_of :image
+        Event.validates_presence_of :image
         allow(@event).to receive(:name).and_return('jonas')
       end
 
@@ -603,7 +604,7 @@ describe CarrierWave::ActiveRecord do
     describe 'with validates_size_of' do
 
       before do
-        @class.validates_size_of :image, :maximum => 40
+        Event.validates_size_of :image, maximum: 40
         allow(@event).to receive(:name).and_return('jonas')
       end
 
@@ -621,20 +622,15 @@ describe CarrierWave::ActiveRecord do
   end
 
   describe '#mount_uploader with mount_on' do
-    before do
-      @class = Class.new(Event)
-      @class.table_name = "events"
-      @uploader = Class.new(CarrierWave::Uploader::Base)
-      @class.mount_uploader(:avatar, @uploader, :mount_on => :image)
-      @event = @class.new
-    end
-
     describe '#avatar=' do
-
       it "should cache a file" do
+        reset_class("Event")
+        Event.mount_uploader(:avatar, @uploader, mount_on: :image)
+        @event = Event.new
         @event.avatar = stub_file('test.jpeg')
         @event.save
         @event.reload
+
         expect(@event.avatar).to be_an_instance_of(@uploader)
         expect(@event.image).to eq('test.jpeg')
       end
@@ -644,12 +640,11 @@ describe CarrierWave::ActiveRecord do
 
   describe '#mount_uploader removing old files' do
     before do
-      @class = Class.new(Event)
-      @class.table_name = "events"
-      @uploader = Class.new(CarrierWave::Uploader::Base)
-      @class.mount_uploader(:image, @uploader)
-      @event = @class.new
+      reset_class("Event")
+      Event.mount_uploader(:image, @uploader)
+      @event = Event.new
       @event.image = stub_file('old.jpeg')
+
       expect(@event.save).to be_truthy
       expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
     end
@@ -681,8 +676,9 @@ describe CarrierWave::ActiveRecord do
       end
 
       it "should not remove file if validations fail on save" do
-        @class.validate { |r| r.errors.add :textfile, "FAIL!" }
+        Event.validate { |r| r.errors.add :textfile, "FAIL!" }
         @event.image = stub_file('new.jpeg')
+
         expect(@event.save).to be_falsey
         expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
       end
@@ -729,13 +725,12 @@ describe CarrierWave::ActiveRecord do
 
   describe '#mount_uploader removing old files with versions' do
     before do
-      @class = Class.new(Event)
-      @class.table_name = "events"
-      @uploader = Class.new(CarrierWave::Uploader::Base)
       @uploader.version :thumb
-      @class.mount_uploader(:image, @uploader)
-      @event = @class.new
+      reset_class("Event")
+      Event.mount_uploader(:image, @uploader)
+      @event = Event.new
       @event.image = stub_file('old.jpeg')
+
       expect(@event.save).to be_truthy
       expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
       expect(File.exist?(public_path('uploads/thumb_old.jpeg'))).to be_truthy
@@ -775,15 +770,15 @@ describe CarrierWave::ActiveRecord do
 
   describe '#mount_uploader removing old files with multiple uploaders' do
     before do
-      @class = Class.new(Event)
-      @class.table_name = "events"
       @uploader = Class.new(CarrierWave::Uploader::Base)
-      @class.mount_uploader(:image, @uploader)
       @uploader1 = Class.new(CarrierWave::Uploader::Base)
-      @class.mount_uploader(:textfile, @uploader1)
-      @event = @class.new
+      reset_class("Event")
+      Event.mount_uploader(:image, @uploader)
+      Event.mount_uploader(:textfile, @uploader1)
+      @event = Event.new
       @event.image = stub_file('old.jpeg')
       @event.textfile = stub_file('old.txt')
+
       expect(@event.save).to be_truthy
       expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
       expect(File.exist?(public_path('uploads/old.txt'))).to be_truthy
@@ -823,12 +818,11 @@ describe CarrierWave::ActiveRecord do
 
   describe '#mount_uploader removing old files with with mount_on' do
     before do
-      @class = Class.new(Event)
-      @class.table_name = "events"
-      @uploader = Class.new(CarrierWave::Uploader::Base)
-      @class.mount_uploader(:avatar, @uploader, :mount_on => :image)
-      @event = @class.new
+      reset_class("Event")
+      Event.mount_uploader(:avatar, @uploader, mount_on: :image)
+      @event = Event.new
       @event.avatar = stub_file('old.jpeg')
+
       expect(@event.save).to be_truthy
       expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
     end
@@ -852,6 +846,10 @@ describe CarrierWave::ActiveRecord do
   end
 
   describe '#mount_uploaders' do
+    before do
+      Event.mount_uploaders(:images, @uploader)
+    end
+
     describe '#images' do
 
       it "should return blank uploader when nothing has been assigned" do
@@ -896,8 +894,9 @@ describe CarrierWave::ActiveRecord do
       end
 
       it "should return valid XML when to_xml is called when images is nil" do
+        hash = Hash.from_xml(@event.to_xml)["event"]
+
         expect(@event[:images]).to be_nil
-        hash = Hash.from_xml(@event.to_xml)["event#{$arclass}"]
         expect(hash.keys).to include("images")
         expect(hash["images"]).to be_empty
       end
@@ -907,7 +906,7 @@ describe CarrierWave::ActiveRecord do
         @event.save!
         @event.reload
 
-        expect(Hash.from_xml(@event.to_xml)["event#{$arclass}"]["images"]).to eq([{"url" => "/uploads/test.jpeg"}])
+        expect(Hash.from_xml(@event.to_xml)["event"]["images"]).to eq([{"url" => "/uploads/test.jpeg"}])
       end
 
       it "should respect options[:only] when passed to as_json for the serializable hash" do
@@ -938,7 +937,7 @@ describe CarrierWave::ActiveRecord do
         @event.save!
         @event.reload
 
-        expect(Hash.from_xml(@event.to_xml(:only => [:foo]))["event#{$arclass}"]["images"]).to be_nil
+        expect(Hash.from_xml(@event.to_xml(only: [:foo]))["event"]["images"]).to be_nil
       end
 
       it "should respect options[:except] when passed to to_xml for the serializable hash" do
@@ -946,7 +945,7 @@ describe CarrierWave::ActiveRecord do
         @event.save!
         @event.reload
 
-        expect(Hash.from_xml(@event.to_xml(:except => [:images]))["event#{$arclass}"]["images"]).to be_nil
+        expect(Hash.from_xml(@event.to_xml(except: [:images]))["event"]["images"]).to be_nil
       end
 
       it "should respect both options[:only] and options[:except] when passed to to_xml for the serializable hash" do
@@ -954,7 +953,7 @@ describe CarrierWave::ActiveRecord do
         @event.save!
         @event.reload
 
-        expect(Hash.from_xml(@event.to_xml(:only => [:foo], :except => [:id]))["event#{$arclass}"]["images"]).to be_nil
+        expect(Hash.from_xml(@event.to_xml(only: [:foo], except: [:id]))["event"]["images"]).to be_nil
       end
     end
 
@@ -1115,8 +1114,9 @@ describe CarrierWave::ActiveRecord do
       end
 
       it "should do nothing when a validation fails" do
-        @class.validate { |r| r.errors.add :textfile, "FAIL!" }
+        Event.validate { |r| r.errors.add :textfile, "FAIL!" }
         @event.images = [stub_file('test.jpeg')]
+
         expect(@event.save).to be_falsey
         expect(@event.images[0]).to be_an_instance_of(@uploader)
         expect(@event.images[0].current_path).to match(/^#{public_path('uploads/tmp')}/)
@@ -1133,8 +1133,10 @@ describe CarrierWave::ActiveRecord do
       it "should preserve the images when nothing is assigned" do
         @event.images = [stub_file('test.jpeg')]
         expect(@event.save).to be_truthy
-        @event = @class.find(@event.id)
+
+        @event = Event.find(@event.id)
         @event.foo = "bar"
+
         expect(@event.save).to be_truthy
         expect(@event[:images]).to eq(['test.jpeg'])
         expect(@event.images_identifiers[0]).to eq('test.jpeg')
@@ -1305,7 +1307,7 @@ describe CarrierWave::ActiveRecord do
     describe 'with validates_presence_of' do
 
       before do
-        @class.validates_presence_of :images
+        Event.validates_presence_of :images
         allow(@event).to receive(:name).and_return('jonas')
       end
 
@@ -1323,7 +1325,7 @@ describe CarrierWave::ActiveRecord do
     describe 'with validates_size_of' do
 
       before do
-        @class.validates_size_of :images, :maximum => 2
+        Event.validates_size_of :images, maximum: 2
         allow(@event).to receive(:name).and_return('jonas')
       end
 
@@ -1341,20 +1343,15 @@ describe CarrierWave::ActiveRecord do
   end
 
   describe '#mount_uploaders with mount_on' do
-    before do
-      @class = Class.new(Event)
-      @class.table_name = "events"
-      @uploader = Class.new(CarrierWave::Uploader::Base)
-      @class.mount_uploaders(:avatar, @uploader, :mount_on => :images)
-      @event = @class.new
-    end
-
     describe '#avatar=' do
-
       it "should cache a file" do
+        reset_class("Event")
+        Event.mount_uploaders(:avatar, @uploader, mount_on: :images)
+        @event = Event.new
         @event.avatar = [stub_file('test.jpeg')]
         @event.save
         @event.reload
+
         expect(@event.avatar[0]).to be_an_instance_of(@uploader)
         expect(@event.images).to eq(['test.jpeg'])
       end
@@ -1364,12 +1361,9 @@ describe CarrierWave::ActiveRecord do
 
   describe '#mount_uploaders removing old files' do
     before do
-      @class = Class.new(Event)
-      @class.table_name = "events"
-      @uploader = Class.new(CarrierWave::Uploader::Base)
-      @class.mount_uploaders(:images, @uploader)
-      @event = @class.new
+      Event.mount_uploaders(:images, @uploader)
       @event.images = [stub_file('old.jpeg')]
+
       expect(@event.save).to be_truthy
       expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
     end
@@ -1401,8 +1395,9 @@ describe CarrierWave::ActiveRecord do
       end
 
       it "should not remove file if validations fail on save" do
-        @class.validate { |r| r.errors.add :textfile, "FAIL!" }
+        Event.validate { |r| r.errors.add :textfile, "FAIL!" }
         @event.images = [stub_file('new.jpeg')]
+
         expect(@event.save).to be_falsey
         expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
       end
@@ -1441,13 +1436,10 @@ describe CarrierWave::ActiveRecord do
 
   describe '#mount_uploaders removing old files with versions' do
     before do
-      @class = Class.new(Event)
-      @class.table_name = "events"
-      @uploader = Class.new(CarrierWave::Uploader::Base)
       @uploader.version :thumb
-      @class.mount_uploaders(:images, @uploader)
-      @event = @class.new
+      Event.mount_uploaders(:images, @uploader)
       @event.images = [stub_file('old.jpeg')]
+
       expect(@event.save).to be_truthy
       expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
       expect(File.exist?(public_path('uploads/thumb_old.jpeg'))).to be_truthy
@@ -1476,15 +1468,15 @@ describe CarrierWave::ActiveRecord do
 
   describe '#mount_uploaders removing old files with multiple uploaders' do
     before do
-      @class = Class.new(Event)
-      @class.table_name = "events"
       @uploader = Class.new(CarrierWave::Uploader::Base)
-      @class.mount_uploaders(:images, @uploader)
       @uploader1 = Class.new(CarrierWave::Uploader::Base)
-      @class.mount_uploaders(:textfiles, @uploader1)
-      @event = @class.new
+      reset_class("Event")
+      Event.mount_uploaders(:images, @uploader)
+      Event.mount_uploaders(:textfiles, @uploader1)
+      @event = Event.new
       @event.images = [stub_file('old.jpeg')]
       @event.textfiles = [stub_file('old.txt')]
+
       expect(@event.save).to be_truthy
       expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
       expect(File.exist?(public_path('uploads/old.txt'))).to be_truthy
@@ -1524,12 +1516,10 @@ describe CarrierWave::ActiveRecord do
 
   describe '#mount_uploaders removing old files with mount_on' do
     before do
-      @class = Class.new(Event)
-      @class.table_name = "events"
-      @uploader = Class.new(CarrierWave::Uploader::Base)
-      @class.mount_uploaders(:avatar, @uploader, :mount_on => :images)
-      @event = @class.new
+      Event.mount_uploaders(:avatar, @uploader, mount_on: :images)
+      @event = Event.new
       @event.avatar = [stub_file('old.jpeg')]
+
       expect(@event.save).to be_truthy
       expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
     end
@@ -1558,8 +1548,10 @@ describe CarrierWave::ActiveRecord do
 
   describe "#dup" do
     it "appropriately removes the model reference from the new models uploader" do
+      Event.mount_uploader(:image, @uploader)
       @event.save
       new_event = @event.dup
+
       expect(new_event.image.model).not_to eq @event
     end
   end

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -1,20 +1,18 @@
 require 'spec_helper'
 require 'support/activerecord'
 
-class TestMigration < ActiveRecord::Migration
-  def self.up
-    create_table :events, :force => true do |t|
-      t.column :image, :string
-      t.column :images, :json
-      t.column :textfile, :string
-      t.column :textfiles, :json
-      t.column :foo, :string
-    end
+def create_table(name)
+  ActiveRecord::Base.connection.create_table(name, force: true) do |t|
+    t.column :image, :string
+    t.column :images, :json
+    t.column :textfile, :string
+    t.column :textfiles, :json
+    t.column :foo, :string
   end
+end
 
-  def self.down
-    drop_table :events
-  end
+def drop_table(name)
+  ActiveRecord::Base.connection.drop_table(name)
 end
 
 def reset_class(class_name)
@@ -23,8 +21,8 @@ def reset_class(class_name)
 end
 
 describe CarrierWave::ActiveRecord do
-  before(:all) { TestMigration.up }
-  after(:all) { TestMigration.down }
+  before(:all) { create_table("events") }
+  after(:all) { drop_table("events") }
 
   before do
     @uploader = Class.new(CarrierWave::Uploader::Base)


### PR DESCRIPTION
It all started when I read @jnicklas comment:
```ruby
# My god, what a horrible, horrible solution, but AR validations don't work
# unless the class has a name. This is the best I could come up with :S
```
I tried to make it better :bowtie:
This PR mainly refactor the way AR classes are reset in specs (e18499569792341d7f10665e226a9c1ca3fe0305).
It uses `Object#remove_const` and `Object#const_set` instead of initializing a new `Event{$counter}` before each spec example.
I think we could extract this support code to a separate module to make it even cleaner.

It also uses ShamRack only around a couple of specs examples that needs it, and not for each one.

I tried to reduce nested `before` callbacks in the examples concerned by this change to make those easier to read.

Minor changes:
- Remove unneeded AR config to not include root in JSON
- Replace AR migrations in specs by `ActiveRecord::Base.connection` calls