### PR TITLE
Make extensions and content types white/blacklists take a string, regexp, or array of values

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@ end
 
 ## Securing uploads
 
-Certain files might be dangerous if uploaded to the wrong location, such as php
-files or other script files. CarrierWave allows you to specify a white-list of
+Certain files might be dangerous if uploaded to the wrong location, such as PHP
+files or other script files. CarrierWave allows you to specify a whitelist of
 allowed extensions or content types.
 
 If you're mounting the uploader, uploading a file with the wrong extension will
@@ -229,7 +229,7 @@ Let's say we need an uploader that accepts only images. This can be done like th
 ```ruby
 class MyUploader < CarrierWave::Uploader::Base
   def content_type_whitelist
-    [/image\//]
+    /image\//
   end
 end
 ```

--- a/lib/carrierwave/uploader/content_type_blacklist.rb
+++ b/lib/carrierwave/uploader/content_type_blacklist.rb
@@ -14,7 +14,7 @@ module CarrierWave
       #
       # === Returns
       #
-      # [NilClass, Array[String,Regexp]] a blacklist of content types which are not allowed to be uploaded
+      # [NilClass, String, Regexp, Array[String, Regexp]] a blacklist of content types which are not allowed to be uploaded
       #
       # === Examples
       #
@@ -40,7 +40,7 @@ module CarrierWave
       end
 
       def blacklisted_content_type?(content_type)
-        content_type_blacklist.any? { |item| content_type =~ /#{item}/ }
+        Array(content_type_blacklist).any? { |item| content_type =~ /#{item}/ }
       end
 
     end # ContentTypeBlacklist

--- a/lib/carrierwave/uploader/content_type_whitelist.rb
+++ b/lib/carrierwave/uploader/content_type_whitelist.rb
@@ -14,7 +14,7 @@ module CarrierWave
       #
       # === Returns
       #
-      # [NilClass, Array[String,Regexp]] a whitelist of content types which are allowed to be uploaded
+      # [NilClass, String, Regexp, Array[String, Regexp]] a whitelist of content types which are allowed to be uploaded
       #
       # === Examples
       #
@@ -40,7 +40,7 @@ module CarrierWave
       end
 
       def whitelisted_content_type?(content_type)
-        content_type_whitelist.any? { |item| content_type =~ /#{item}/ }
+        Array(content_type_whitelist).any? { |item| content_type =~ /#{item}/ }
       end
 
     end # ContentTypeWhitelist

--- a/lib/carrierwave/uploader/extension_blacklist.rb
+++ b/lib/carrierwave/uploader/extension_blacklist.rb
@@ -17,7 +17,7 @@ module CarrierWave
       #
       # === Returns
 
-      # [NilClass, Array[String,Regexp]] a black list of extensions which are prohibited to be uploaded
+      # [NilClass, String, Regexp, Array[String, Regexp]] a black list of extensions which are prohibited to be uploaded
       #
       # === Examples
       #
@@ -44,7 +44,7 @@ module CarrierWave
       end
 
       def blacklisted_extension?(extension)
-        extension_blacklist.any? { |item| extension =~ /\A#{item}\z/i }
+        Array(extension_blacklist).any? { |item| extension =~ /\A#{item}\z/i }
       end
     end
   end

--- a/lib/carrierwave/uploader/extension_whitelist.rb
+++ b/lib/carrierwave/uploader/extension_whitelist.rb
@@ -17,7 +17,7 @@ module CarrierWave
       #
       # === Returns
       #
-      # [NilClass, Array[String,Regexp]] a white list of extensions which are allowed to be uploaded
+      # [NilClass, String, Regexp, Array[String, Regexp]] a white list of extensions which are allowed to be uploaded
       #
       # === Examples
       #
@@ -43,7 +43,7 @@ module CarrierWave
       end
 
       def whitelisted_extension?(extension)
-        extension_whitelist.any? { |item| extension =~ /\A#{item}\z/i }
+        Array(extension_whitelist).any? { |item| extension =~ /\A#{item}\z/i }
       end
 
     end # ExtensionWhitelist

--- a/spec/uploader/content_type_blacklist_spec.rb
+++ b/spec/uploader/content_type_blacklist_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe CarrierWave::Uploader do
-
   before do
     @uploader_class = Class.new(CarrierWave::Uploader::Base)
     @uploader = @uploader_class.new
@@ -12,7 +11,6 @@ describe CarrierWave::Uploader do
   end
 
   describe '#cache!' do
-
     before do
       allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-1234-2255')
     end
@@ -28,28 +26,48 @@ describe CarrierWave::Uploader do
     end
 
     context "when there is a blacklist" do
-      it "does not raise an integrity error when the file has not a blacklisted content type" do
-        allow(@uploader).to receive(:content_type_blacklist).and_return(['image/gif'])
+      context "when the blacklist is an array of values" do
+        it "does not raise an integrity error when the file has not a blacklisted content type" do
+          allow(@uploader).to receive(:content_type_blacklist).and_return(['image/gif'])
 
-        expect {
-          @uploader.cache!(File.open(file_path('bork.txt')))
-        }.not_to raise_error
+          expect {
+            @uploader.cache!(File.open(file_path('bork.txt')))
+          }.not_to raise_error
+        end
+
+        it "raises an integrity error if the file has a blacklisted content type" do
+          allow(@uploader).to receive(:content_type_blacklist).and_return(['image/gif'])
+
+          expect {
+            @uploader.cache!(File.open(file_path('ruby.gif')))
+          }.to raise_error(CarrierWave::IntegrityError)
+        end
+
+        it "accepts content types as regular expressions" do
+          allow(@uploader).to receive(:content_type_blacklist).and_return([/image\//])
+
+          expect {
+            @uploader.cache!(File.open(file_path('ruby.gif')))
+          }.to raise_error(CarrierWave::IntegrityError)
+        end
       end
 
-      it "raises an integrity error the file has a blacklisted content type" do
-        allow(@uploader).to receive(:content_type_blacklist).and_return(['image/gif'])
+      context "when the blacklist is a single value" do
+        it "accepts a single extension string value" do
+          allow(@uploader).to receive(:extension_whitelist).and_return('jpeg')
 
-        expect {
-          @uploader.cache!(File.open(file_path('ruby.gif')))
-        }.to raise_error(CarrierWave::IntegrityError)
-      end
+          expect(running {
+            @uploader.cache!(File.open(file_path('test.jpeg')))
+          }).not_to raise_error
+        end
 
-      it "accepts content types as regular expressions" do
-        allow(@uploader).to receive(:content_type_blacklist).and_return([/image\//])
+        it "accepts a single extension regular expression value" do
+          allow(@uploader).to receive(:extension_whitelist).and_return(/jpe?g/)
 
-        expect {
-          @uploader.cache!(File.open(file_path('ruby.gif')))
-        }.to raise_error(CarrierWave::IntegrityError)
+          expect(running {
+            @uploader.cache!(File.open(file_path('test.jpeg')))
+          }).not_to raise_error
+        end
       end
     end
   end

--- a/spec/uploader/content_type_whitelist_spec.rb
+++ b/spec/uploader/content_type_whitelist_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe CarrierWave::Uploader do
-
   before do
     @uploader_class = Class.new(CarrierWave::Uploader::Base)
     @uploader = @uploader_class.new
@@ -12,7 +11,6 @@ describe CarrierWave::Uploader do
   end
 
   describe '#cache!' do
-
     before do
       allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-1234-2255')
     end
@@ -28,28 +26,48 @@ describe CarrierWave::Uploader do
     end
 
     context "when there is a whitelist" do
-      it "does not raise an integrity error when the file has a whitelisted content type" do
-        allow(@uploader).to receive(:content_type_whitelist).and_return(['image/gif'])
+      context "when the whitelist is an array of values" do
+        it "does not raise an integrity error when the file has a whitelisted content type" do
+          allow(@uploader).to receive(:content_type_whitelist).and_return(['image/gif'])
 
-        expect {
-          @uploader.cache!(File.open(file_path('ruby.gif')))
-        }.not_to raise_error
+          expect {
+            @uploader.cache!(File.open(file_path('ruby.gif')))
+          }.not_to raise_error
+        end
+
+        it "raises an integrity error the file has not a whitelisted content type" do
+          allow(@uploader).to receive(:content_type_whitelist).and_return(['image/gif'])
+
+          expect {
+            @uploader.cache!(File.open(file_path('bork.txt')))
+          }.to raise_error(CarrierWave::IntegrityError)
+        end
+
+        it "accepts content types as regular expressions" do
+          allow(@uploader).to receive(:content_type_whitelist).and_return([/image\//])
+
+          expect {
+            @uploader.cache!(File.open(file_path('bork.txt')))
+          }.to raise_error(CarrierWave::IntegrityError)
+        end
       end
 
-      it "raises an integrity error the file has not a whitelisted content type" do
-        allow(@uploader).to receive(:content_type_whitelist).and_return(['image/gif'])
+      context "when the whitelist is a single value" do
+        it "accepts a single extension string value" do
+          allow(@uploader).to receive(:extension_whitelist).and_return('jpeg')
 
-        expect {
-          @uploader.cache!(File.open(file_path('bork.txt')))
-        }.to raise_error(CarrierWave::IntegrityError)
-      end
+          expect(running {
+            @uploader.cache!(File.open(file_path('test.jpeg')))
+          }).not_to raise_error
+        end
 
-      it "accepts content types as regular expressions" do
-        allow(@uploader).to receive(:content_type_whitelist).and_return([/image\//])
+        it "accepts a single extension regular expression value" do
+          allow(@uploader).to receive(:extension_whitelist).and_return(/jpe?g/)
 
-        expect {
-          @uploader.cache!(File.open(file_path('bork.txt')))
-        }.to raise_error(CarrierWave::IntegrityError)
+          expect(running {
+            @uploader.cache!(File.open(file_path('test.jpeg')))
+          }).not_to raise_error
+        end
       end
     end
   end

--- a/spec/uploader/extension_blacklist_spec.rb
+++ b/spec/uploader/extension_blacklist_spec.rb
@@ -11,66 +11,96 @@ describe CarrierWave::Uploader do
   end
 
   describe '#cache!' do
-
     before do
       allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-1234-2255')
     end
 
-    it "should not raise an integrity error if there is no blacklist" do
-      allow(@uploader).to receive(:extension_blacklist).and_return(nil)
-      expect(running {
-        @uploader.cache!(File.open(file_path('test.jpg')))
-      }).not_to raise_error
+    context "when there is no blacklist" do
+      it "should not raise an integrity error" do
+        allow(@uploader).to receive(:extension_blacklist).and_return(nil)
+
+        expect(running {
+          @uploader.cache!(File.open(file_path('test.jpg')))
+        }).not_to raise_error
+      end
     end
 
-    it "should raise an integrity error if there is a blacklist and the file is on it" do
-      allow(@uploader).to receive(:extension_blacklist).and_return(%w(jpg gif png))
-      expect(running {
-        @uploader.cache!(File.open(file_path('test.jpg')))
-      }).to raise_error(CarrierWave::IntegrityError)
-    end
+    context "when there is a blacklist" do
+      context "when the blacklist is an array of values" do
+        it "raises an integrity error if the file has a blacklisted extension" do
+          allow(@uploader).to receive(:extension_blacklist).and_return(%w(jpg gif png))
 
-    it "should not raise an integrity error if there is a blacklist and the file is not on it" do
-      allow(@uploader).to receive(:extension_blacklist).and_return(%w(txt doc xls))
-      expect(running {
-        @uploader.cache!(File.open(file_path('test.jpg')))
-      }).not_to raise_error
-    end
+          expect(running {
+            @uploader.cache!(File.open(file_path('test.jpg')))
+          }).to raise_error(CarrierWave::IntegrityError)
+        end
 
-    it "should not raise an integrity error if there is a blacklist and the file is not on it, using start of string matcher" do
-      allow(@uploader).to receive(:extension_blacklist).and_return(%w(txt))
-      expect(running {
-        @uploader.cache!(File.open(file_path('bork.ttxt')))
-      }).not_to raise_error
-    end
+        it "does not raise an integrity error if the file has a blacklisted extension" do
+          allow(@uploader).to receive(:extension_blacklist).and_return(%w(txt doc xls))
 
-    it "should not raise an integrity error if there is a blacklist and the file is not on it, using end of string matcher" do
-      allow(@uploader).to receive(:extension_blacklist).and_return(%w(txt))
-      expect(running {
-        @uploader.cache!(File.open(file_path('bork.txtt')))
-      }).not_to raise_error
-    end
+          expect(running {
+            @uploader.cache!(File.open(file_path('test.jpg')))
+          }).not_to raise_error
+        end
 
-    it "should compare blacklist in a case insensitive manner when capitalized extension provided" do
-      allow(@uploader).to receive(:extension_blacklist).and_return(%w(jpg gif png))
-      expect(running {
-        @uploader.cache!(File.open(file_path('case.JPG')))
-      }).to raise_error(CarrierWave::IntegrityError)
-    end
+        it "does not raise an integrity error if the file has a blacklisted extension, using start of string matcher" do
+          allow(@uploader).to receive(:extension_blacklist).and_return(%w(txt))
 
-    it "should compare blacklist in a case insensitive manner when lowercase extension provided" do
-      allow(@uploader).to receive(:extension_blacklist).and_return(%w(JPG GIF PNG))
-      expect(running {
-        @uploader.cache!(File.open(file_path('test.jpg')))
-      }).to raise_error(CarrierWave::IntegrityError)
-    end
+          expect(running {
+            @uploader.cache!(File.open(file_path('bork.ttxt')))
+          }).not_to raise_error
+        end
 
-    it "should accept and check regular expressions" do
-      allow(@uploader).to receive(:extension_blacklist).and_return([/jpe?g/, 'gif', 'png'])
-      expect(running {
-        @uploader.cache!(File.open(file_path('test.jpeg')))
-      }).to raise_error(CarrierWave::IntegrityError)
+        it "does not raise an integrity error if the file has a blacklisted extension, using end of string matcher" do
+          allow(@uploader).to receive(:extension_blacklist).and_return(%w(txt))
+
+          expect(running {
+            @uploader.cache!(File.open(file_path('bork.txtt')))
+          }).not_to raise_error
+        end
+
+        it "compares extensions in a case insensitive manner when capitalized extension provided" do
+          allow(@uploader).to receive(:extension_blacklist).and_return(%w(jpg gif png))
+
+          expect(running {
+            @uploader.cache!(File.open(file_path('case.JPG')))
+          }).to raise_error(CarrierWave::IntegrityError)
+        end
+
+        it "compares extensions in a case insensitive manner when lowercase extension provided" do
+          allow(@uploader).to receive(:extension_blacklist).and_return(%w(JPG GIF PNG))
+
+          expect(running {
+            @uploader.cache!(File.open(file_path('test.jpg')))
+          }).to raise_error(CarrierWave::IntegrityError)
+        end
+
+        it "accepts extensions as regular expressions" do
+          allow(@uploader).to receive(:extension_blacklist).and_return([/jpe?g/, 'gif', 'png'])
+
+          expect(running {
+            @uploader.cache!(File.open(file_path('test.jpeg')))
+          }).to raise_error(CarrierWave::IntegrityError)
+        end
+      end
+
+      context "when the blacklist is a single value" do
+        it "accepts a single extension string value" do
+          allow(@uploader).to receive(:extension_whitelist).and_return('jpeg')
+
+          expect(running {
+            @uploader.cache!(File.open(file_path('test.jpeg')))
+          }).not_to raise_error
+        end
+
+        it "accepts a single extension regular expression value" do
+          allow(@uploader).to receive(:extension_whitelist).and_return(/jpe?g/)
+
+          expect(running {
+            @uploader.cache!(File.open(file_path('test.jpeg')))
+          }).not_to raise_error
+        end
+      end
     end
   end
-
 end

--- a/spec/uploader/extension_whitelist_spec.rb
+++ b/spec/uploader/extension_whitelist_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe CarrierWave::Uploader do
-
   before do
     @uploader_class = Class.new(CarrierWave::Uploader::Base)
     @uploader = @uploader_class.new
@@ -12,66 +11,96 @@ describe CarrierWave::Uploader do
   end
 
   describe '#cache!' do
-
     before do
       allow(CarrierWave).to receive(:generate_cache_id).and_return('1369894322-345-1234-2255')
     end
 
-    it "should not raise an integrity error if there is no whitelist" do
-      allow(@uploader).to receive(:extension_whitelist).and_return(nil)
-      expect(running {
-        @uploader.cache!(File.open(file_path('test.jpg')))
-      }).not_to raise_error
+    context "when there is no whitelist" do
+      it "does not raise an integrity error" do
+        allow(@uploader).to receive(:extension_whitelist).and_return(nil)
+
+        expect(running {
+          @uploader.cache!(File.open(file_path('test.jpg')))
+        }).not_to raise_error
+      end
     end
 
-    it "should not raise an integrity error if there is a whitelist and the file is on it" do
-      allow(@uploader).to receive(:extension_whitelist).and_return(%w(jpg gif png))
-      expect(running {
-        @uploader.cache!(File.open(file_path('test.jpg')))
-      }).not_to raise_error
-    end
+    context "when there is a whitelist" do
+      context "when the whitelist is an array of values" do
+        it "does not raise an integrity error when the file has a whitelisted extension" do
+          allow(@uploader).to receive(:extension_whitelist).and_return(%w(jpg gif png))
 
-    it "should raise an integrity error if there is a whitelist and the file is not on it" do
-      allow(@uploader).to receive(:extension_whitelist).and_return(%w(txt doc xls))
-      expect(running {
-        @uploader.cache!(File.open(file_path('test.jpg')))
-      }).to raise_error(CarrierWave::IntegrityError)
-    end
+          expect(running {
+            @uploader.cache!(File.open(file_path('test.jpg')))
+          }).not_to raise_error
+        end
 
-    it "should raise an integrity error if there is a whitelist and the file is not on it, using start of string matcher" do
-      allow(@uploader).to receive(:extension_whitelist).and_return(%w(txt))
-      expect(running {
-        @uploader.cache!(File.open(file_path('bork.ttxt')))
-      }).to raise_error(CarrierWave::IntegrityError)
-    end
+        it "raises an integrity error if the file has not a whitelisted extension" do
+          allow(@uploader).to receive(:extension_whitelist).and_return(%w(txt doc xls))
 
-    it "should raise an integrity error if there is a whitelist and the file is not on it, using end of string matcher" do
-      allow(@uploader).to receive(:extension_whitelist).and_return(%w(txt))
-      expect(running {
-        @uploader.cache!(File.open(file_path('bork.txtt')))
-      }).to raise_error(CarrierWave::IntegrityError)
-    end
+          expect(running {
+            @uploader.cache!(File.open(file_path('test.jpg')))
+          }).to raise_error(CarrierWave::IntegrityError)
+        end
 
-    it "should compare whitelist in a case insensitive manner when capitalized extension provided" do
-      allow(@uploader).to receive(:extension_whitelist).and_return(%w(jpg gif png))
-      expect(running {
-        @uploader.cache!(File.open(file_path('case.JPG')))
-      }).not_to raise_error
-    end
+        it "raises an integrity error if the file has not a whitelisted extension, using start of string matcher" do
+          allow(@uploader).to receive(:extension_whitelist).and_return(%w(txt))
 
-    it "should compare whitelist in a case insensitive manner when lowercase extension provided" do
-      allow(@uploader).to receive(:extension_whitelist).and_return(%w(JPG GIF PNG))
-      expect(running {
-        @uploader.cache!(File.open(file_path('test.jpg')))
-      }).not_to raise_error
-    end
+          expect(running {
+            @uploader.cache!(File.open(file_path('bork.ttxt')))
+          }).to raise_error(CarrierWave::IntegrityError)
+        end
 
-    it "should accept and check regular expressions" do
-      allow(@uploader).to receive(:extension_whitelist).and_return([/jpe?g/, 'gif', 'png'])
-      expect(running {
-        @uploader.cache!(File.open(file_path('test.jpeg')))
-      }).not_to raise_error
+        it "raises an integrity error if the file has not a whitelisted extension, using end of string matcher" do
+          allow(@uploader).to receive(:extension_whitelist).and_return(%w(txt))
+
+          expect(running {
+            @uploader.cache!(File.open(file_path('bork.txtt')))
+          }).to raise_error(CarrierWave::IntegrityError)
+        end
+
+        it "compares extensions in a case insensitive manner when capitalized extension provided" do
+          allow(@uploader).to receive(:extension_whitelist).and_return(%w(jpg gif png))
+
+          expect(running {
+            @uploader.cache!(File.open(file_path('case.JPG')))
+          }).not_to raise_error
+        end
+
+        it "compares extensions in a case insensitive manner when lowercase extension provided" do
+          allow(@uploader).to receive(:extension_whitelist).and_return(%w(JPG GIF PNG))
+
+          expect(running {
+            @uploader.cache!(File.open(file_path('test.jpg')))
+          }).not_to raise_error
+        end
+
+        it "accepts extensions as regular expressions" do
+          allow(@uploader).to receive(:extension_whitelist).and_return([/jpe?g/, 'gif', 'png'])
+
+          expect(running {
+            @uploader.cache!(File.open(file_path('test.jpeg')))
+          }).not_to raise_error
+        end
+      end
+
+      context "when the whitelist is a single value" do
+        it "accepts a single extension string value" do
+          allow(@uploader).to receive(:extension_whitelist).and_return('jpeg')
+
+          expect(running {
+            @uploader.cache!(File.open(file_path('test.jpeg')))
+          }).not_to raise_error
+        end
+
+        it "accepts a single extension regular expression value" do
+          allow(@uploader).to receive(:extension_whitelist).and_return(/jpe?g/)
+
+          expect(running {
+            @uploader.cache!(File.open(file_path('test.jpeg')))
+          }).not_to raise_error
+        end
+      end
     end
   end
-
 end


### PR DESCRIPTION
Writing

```ruby
def content_type_whitelist
  [/image\//]
end
```
isn't very convenient or intuitive due to the array.

This PR suggests to let `#content_type_whitelist` and `extension_whitelist` takes either a
string, a regexp, or an array of values (same thing for blacklists).