### PR TITLE
URI.decode (URI.unescape) is obsolete

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -392,7 +392,7 @@ module CarrierWave
         #
         def filename(options = {})
           return unless file_url = url(options)
-          URI.decode(file_url.split('?').first).gsub(/.*\/(.*?$)/, '\1')
+          CGI.unescape(file_url.split('?').first).gsub(/.*\/(.*?$)/, '\1')
         end
 
         ##

--- a/spec/storage/fog_spec.rb
+++ b/spec/storage/fog_spec.rb
@@ -36,5 +36,16 @@ describe CarrierWave::Storage::Fog::File do
         expect(subject.filename).to eq('foo.txt')
       end
     end
+
+    context "when url contains multi-byte characters ('日本語') in query string" do
+      before do
+        # Ruby 2.3.0 is returning a string with ASCII-8BIT encoding.
+        allow(subject).to receive(:url){ 'http://example.com/path/to/%E6%97%A5%E6%9C%AC%E8%AA%9E.txt?bar=baz/fubar'.force_encoding('ASCII-8BIT') }
+      end
+
+      it "should extract correct part" do
+        expect(subject.filename).to eq('日本語.txt')
+      end
+    end
   end
 end


### PR DESCRIPTION
[URI.decode is obsolete](https://github.com/ruby/ruby/blob/ruby_2_3/lib/uri/common.rb#L125).
And `CarrierWave::Storage::Fog::File#filename` method is returning a string with ASCII-8BIT encoding on Ruby 2.3.0.

The problem is that it can't decode a multi-byte characters containing URL.

Thanks.
