### PR TITLE
Replace ShamRack by WebMock in specs

### DIFF
--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rails", ">= 4.0.0"
   s.add_development_dependency "cucumber", "~> 2.0.0"
   s.add_development_dependency "rspec", "~> 3.2.0"
-  s.add_development_dependency "sham_rack"
+  s.add_development_dependency "webmock"
   s.add_development_dependency "fog", ">= 1.28.0"
   s.add_development_dependency "mini_magick", ">= 3.6.0"
   if RUBY_ENGINE != 'jruby'

--- a/features/step_definitions/download_steps.rb
+++ b/features/step_definitions/download_steps.rb
@@ -1,12 +1,8 @@
 When /^I download the file '([^']+)'/ do |url|
   unless ENV['REMOTE'] == 'true'
-    sham_rack_app = ShamRack.at('s3.amazonaws.com').stub
-    sham_rack_app.register_resource('/Monkey/testfile.txt', 'S3 Remote File', 'text/plain')
+    stub_request(:get, "s3.amazonaws.com/Monkey/testfile.txt").
+      to_return(body: "S3 Remote File", headers: { "Content-Type" => "text/plain" })
   end
 
   @uploader.download!(url)
-
-  unless ENV['REMOTE'] == 'true'
-    ShamRack.unmount_all
-  end
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -4,7 +4,7 @@ require File.join(File.dirname(__FILE__), 'activerecord')
 
 require 'rspec'
 require 'carrierwave'
-require 'sham_rack'
+require "webmock/cucumber"
 
 alias :running :lambda
 

--- a/spec/mount_multiple_spec.rb
+++ b/spec/mount_multiple_spec.rb
@@ -282,50 +282,50 @@ describe CarrierWave::Mount do
       end
     end
 
-    describe 'with ShamRack' do
-
+    describe "#remote_images_urls" do
       before do
-        sham_rack_app = ShamRack.at('www.example.com').stub
-        sham_rack_app.register_resource('/test.jpg', File.read(file_path('test.jpg')), 'images/jpg')
+        stub_request(:get, "www.example.com/test.jpg").to_return(body: File.read(file_path("test.jpg")))
       end
 
-      after do
-        ShamRack.unmount_all
+      it "returns nil" do
+        expect(@instance.remote_images_urls).to be_nil
       end
 
-      describe '#remote_images_urls' do
-        it "should return nil" do
-          expect(@instance.remote_images_urls).to be_nil
-        end
+      it "returns previously cached URL" do
+        @instance.remote_images_urls = ["http://www.example.com/test.jpg"]
 
-        it "should return previously cached URL" do
-          @instance.remote_images_urls = ['http://www.example.com/test.jpg']
-          expect(@instance.remote_images_urls).to eq(['http://www.example.com/test.jpg'])
-        end
+        expect(@instance.remote_images_urls).to eq(["http://www.example.com/test.jpg"])
+      end
+    end
+
+    describe "#remote_images_urls=" do
+      before do
+        stub_request(:get, "www.example.com/test.jpg").to_return(body: File.read(file_path("test.jpg")))
       end
 
-      describe '#remote_images_urls=' do
+      it "does nothing when nil is assigned" do
+        @instance.remote_images_urls = nil
 
-        it "should do nothing when nil is assigned" do
-          @instance.remote_images_urls = nil
-          expect(@instance.images).to be_empty
-        end
+        expect(@instance.images).to be_empty
+      end
 
-        it "should do nothing when an empty string is assigned" do
-          @instance.remote_images_urls = ''
-          expect(@instance.images).to be_empty
-        end
+      it "does nothing when an empty string is assigned" do
+        @instance.remote_images_urls = ""
 
-        it "retrieve from cache when a cache name is assigned" do
-          @instance.remote_images_urls = ['http://www.example.com/test.jpg']
-          expect(@instance.images[0].current_path).to match(/test.jpg$/)
-        end
+        expect(@instance.images).to be_empty
+      end
 
-        it "should write over a previously assigned file" do
-          @instance.images = [stub_file('portrait.jpg')]
-          @instance.remote_images_urls = ['http://www.example.com/test.jpg']
-          expect(@instance.images[0].current_path).to match(/test.jpg$/)
-        end
+      it "retrieves from cache when a cache name is assigned" do
+        @instance.remote_images_urls = ["http://www.example.com/test.jpg"]
+
+        expect(@instance.images[0].current_path).to match(/test.jpg$/)
+      end
+
+      it "writes over a previously assigned file" do
+        @instance.images = [stub_file("portrait.jpg")]
+        @instance.remote_images_urls = ["http://www.example.com/test.jpg"]
+
+        expect(@instance.images[0].current_path).to match(/test.jpg$/)
       end
     end
 
@@ -444,11 +444,11 @@ describe CarrierWave::Mount do
         end
 
         it "should be an error instance if file was downloaded" do
-          sham_rack_app = ShamRack.at('www.example.com').stub
-          sham_rack_app.register_resource('/test.jpg', File.read(file_path('test.jpg')), 'images/jpg')
-
+          stub_request(:get, "www.example.com/test.jpg").to_return(body: File.read(file_path("test.jpg")))
           @instance.remote_images_urls = ["http://www.example.com/test.jpg"]
+
           e = @instance.images_integrity_error
+
           expect(e).to be_an_instance_of(CarrierWave::IntegrityError)
           expect(e.message.lines.grep(/^You are not allowed to upload/)).to be_truthy
         end
@@ -490,10 +490,9 @@ describe CarrierWave::Mount do
         end
 
         it "should be an error instance if file was downloaded" do
-          sham_rack_app = ShamRack.at('www.example.com').stub
-          sham_rack_app.register_resource('/test.jpg', File.read(file_path('test.jpg')), 'images/jpg')
-
+          stub_request(:get, "www.example.com/test.jpg").to_return(body: File.read(file_path("test.jpg")))
           @instance.remote_images_urls = ["http://www.example.com/test.jpg"]
+
           expect(@instance.images_processing_error).to be_an_instance_of(CarrierWave::ProcessingError)
         end
       end
@@ -501,8 +500,8 @@ describe CarrierWave::Mount do
 
     describe '#images_download_error' do
       before do
-        sham_rack_app = ShamRack.at('www.example.com').stub
-        sham_rack_app.register_resource('/test.jpg', File.read(file_path('test.jpg')), 'images/jpg')
+        stub_request(:get, "www.example.com/test.jpg").to_return(body: File.read(file_path("test.jpg")))
+        stub_request(:get, "www.example.com/missing.jpg").to_return(status: 404)
       end
 
       it "should be nil by default" do
@@ -522,8 +521,8 @@ describe CarrierWave::Mount do
 
     describe '#images_download_error' do
       before do
-        sham_rack_app = ShamRack.at('www.example.com').stub
-        sham_rack_app.register_resource('/test.jpg', File.read(file_path('test.jpg')), 'images/jpg')
+        stub_request(:get, "www.example.com/test.jpg").to_return(body: File.read(file_path("test.jpg")))
+        stub_request(:get, "www.example.com/missing.jpg").to_return(status: 404)
       end
 
       it "should be nil by default" do
@@ -679,8 +678,7 @@ describe CarrierWave::Mount do
     end
 
     it "should raise an error if the images fails an integrity check when downloaded" do
-      sham_rack_app = ShamRack.at('www.example.com').stub
-      sham_rack_app.register_resource('/test.jpg', File.read(file_path('test.jpg')), 'images/jpg')
+      stub_request(:get, "www.example.com/test.jpg").to_return(body: File.read(file_path("test.jpg")))
 
       expect(running {
         @instance.remote_images_urls = ["http://www.example.com/test.jpg"]
@@ -714,8 +712,7 @@ describe CarrierWave::Mount do
     end
 
     it "should raise an error if the images fails to be processed when downloaded" do
-      sham_rack_app = ShamRack.at('www.example.com').stub
-      sham_rack_app.register_resource('/test.jpg', File.read(file_path('test.jpg')), 'images/jpg')
+      stub_request(:get, "www.example.com/test.jpg").to_return(body: File.read(file_path("test.jpg")))
 
       expect(running {
         @instance.remote_images_urls = ["http://www.example.com/test.jpg"]

--- a/spec/mount_single_spec.rb
+++ b/spec/mount_single_spec.rb
@@ -285,50 +285,50 @@ describe CarrierWave::Mount do
       end
     end
 
-    describe 'with ShamRack' do
-
+    describe "#remote_image_url" do
       before do
-        sham_rack_app = ShamRack.at('www.example.com').stub
-        sham_rack_app.register_resource('/test.jpg', File.read(file_path('test.jpg')), 'image/jpg')
+        stub_request(:get, "www.example.com/test.jpg").to_return(body: File.read(file_path("test.jpg")))
       end
 
-      after do
-        ShamRack.unmount_all
+      it "returns nil" do
+        expect(@instance.remote_image_url).to be_nil
       end
 
-      describe '#remote_image_url' do
-        it "should return nil" do
-          expect(@instance.remote_image_url).to be_nil
-        end
+      it "returns previously cached URL" do
+        @instance.remote_image_url = "http://www.example.com/test.jpg"
 
-        it "should return previously cached URL" do
-          @instance.remote_image_url = 'http://www.example.com/test.jpg'
-          expect(@instance.remote_image_url).to eq('http://www.example.com/test.jpg')
-        end
+        expect(@instance.remote_image_url).to eq("http://www.example.com/test.jpg")
+      end
+    end
+
+    describe "#remote_image_url=" do
+      before do
+        stub_request(:get, "www.example.com/test.jpg").to_return(body: File.read(file_path("test.jpg")))
       end
 
-      describe '#remote_image_url=' do
+      it "does nothing when nil is assigned" do
+        @instance.remote_image_url = nil
 
-        it "should do nothing when nil is assigned" do
-          @instance.remote_image_url = nil
-          expect(@instance.image).to be_blank
-        end
+        expect(@instance.image).to be_blank
+      end
 
-        it "should do nothing when an empty string is assigned" do
-          @instance.remote_image_url = ''
-          expect(@instance.image).to be_blank
-        end
+      it "does nothing when an empty string is assigned" do
+        @instance.remote_image_url = ""
 
-        it "retrieve from cache when a cache name is assigned" do
-          @instance.remote_image_url = 'http://www.example.com/test.jpg'
-          expect(@instance.image.current_path).to match(/test.jpg$/)
-        end
+        expect(@instance.image).to be_blank
+      end
 
-        it "should write over a previously assigned file" do
-          @instance.image = stub_file('portrait.jpg')
-          @instance.remote_image_url = 'http://www.example.com/test.jpg'
-          expect(@instance.image.current_path).to match(/test.jpg$/)
-        end
+      it "retrieves from cache when a cache name is assigned" do
+        @instance.remote_image_url = "http://www.example.com/test.jpg"
+
+        expect(@instance.image.current_path).to match(/test.jpg$/)
+      end
+
+      it "writes over a previously assigned file" do
+        @instance.image = stub_file("portrait.jpg")
+        @instance.remote_image_url = "http://www.example.com/test.jpg"
+
+        expect(@instance.image.current_path).to match(/test.jpg$/)
       end
     end
 
@@ -447,11 +447,10 @@ describe CarrierWave::Mount do
         end
 
         it "should be an error instance if file was downloaded" do
-          sham_rack_app = ShamRack.at('www.example.com').stub
-          sham_rack_app.register_resource('/test.jpg', File.read(file_path('test.jpg')), 'image/jpg')
-
+          stub_request(:get, "www.example.com/test.jpg").to_return(body: File.read(file_path("test.jpg")))
           @instance.remote_image_url = "http://www.example.com/test.jpg"
           e = @instance.image_integrity_error
+
           expect(e).to be_an_instance_of(CarrierWave::IntegrityError)
           expect(e.message.lines.grep(/^You are not allowed to upload/)).to be_truthy
         end
@@ -493,10 +492,9 @@ describe CarrierWave::Mount do
         end
 
         it "should be an error instance if file was downloaded" do
-          sham_rack_app = ShamRack.at('www.example.com').stub
-          sham_rack_app.register_resource('/test.jpg', File.read(file_path('test.jpg')), 'image/jpg')
-
+          stub_request(:get, "www.example.com/test.jpg").to_return(body: File.read(file_path("test.jpg")))
           @instance.remote_image_url = "http://www.example.com/test.jpg"
+
           expect(@instance.image_processing_error).to be_an_instance_of(CarrierWave::ProcessingError)
         end
       end
@@ -504,8 +502,8 @@ describe CarrierWave::Mount do
 
     describe '#image_download_error' do
       before do
-        sham_rack_app = ShamRack.at('www.example.com').stub
-        sham_rack_app.register_resource('/test.jpg', File.read(file_path('test.jpg')), 'image/jpg')
+        stub_request(:get, "www.example.com/test.jpg").to_return(body: File.read(file_path("test.jpg")))
+        stub_request(:get, "www.example.com/missing.jpg").to_return(status: 404)
       end
 
       it "should be nil by default" do
@@ -525,8 +523,8 @@ describe CarrierWave::Mount do
 
     describe '#image_download_error' do
       before do
-        sham_rack_app = ShamRack.at('www.example.com').stub
-        sham_rack_app.register_resource('/test.jpg', File.read(file_path('test.jpg')), 'image/jpg')
+        stub_request(:get, "www.example.com/test.jpg").to_return(body: File.read(file_path("test.jpg")))
+        stub_request(:get, "www.example.com/missing.jpg").to_return(status: 404)
       end
 
       it "should be nil by default" do
@@ -680,8 +678,7 @@ describe CarrierWave::Mount do
     end
 
     it "should raise an error if the image fails an integrity check when downloaded" do
-      sham_rack_app = ShamRack.at('www.example.com').stub
-      sham_rack_app.register_resource('/test.jpg', File.read(file_path('test.jpg')), 'image/jpg')
+      stub_request(:get, "www.example.com/test.jpg").to_return(body: File.read(file_path("test.jpg")))
 
       expect(running {
         @instance.remote_image_url = "http://www.example.com/test.jpg"
@@ -715,8 +712,7 @@ describe CarrierWave::Mount do
     end
 
     it "should raise an error if the image fails to be processed when downloaded" do
-      sham_rack_app = ShamRack.at('www.example.com').stub
-      sham_rack_app.register_resource('/test.jpg', File.read(file_path('test.jpg')), 'image/jpg')
+      stub_request(:get, "www.example.com/test.jpg").to_return(body: File.read(file_path("test.jpg")))
 
       expect(running {
         @instance.remote_image_url = "http://www.example.com/test.jpg"

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -25,9 +25,6 @@ describe CarrierWave::ActiveRecord do
   after(:all) { TestMigration.down }
 
   before do
-    sham_rack_app = ShamRack.at('www.example.com').stub
-    sham_rack_app.register_resource('/test.jpg', File.read(file_path('test.jpg')), 'images/jpg')
-
     # Rails 4 defaults to no root in JSON, join the party
     ActiveRecord::Base.include_root_in_json = false
     # My god, what a horrible, horrible solution, but AR validations don't work
@@ -46,7 +43,6 @@ describe CarrierWave::ActiveRecord do
   end
 
   after do
-    ShamRack.unmount_all
     Event.delete_all
   end
 
@@ -478,6 +474,9 @@ describe CarrierWave::ActiveRecord do
     end
 
     describe "#remote_image_url=" do
+      before do
+        stub_request(:get, "www.example.com/test.jpg").to_return(body: File.read(file_path("test.jpg")))
+      end
 
       # FIXME ideally image_changed? and remote_image_url_changed? would return true
       it "should mark image as changed when setting remote_image_url" do
@@ -1195,6 +1194,9 @@ describe CarrierWave::ActiveRecord do
     end
 
     describe "#remote_images_urls=" do
+      before do
+        stub_request(:get, "www.example.com/test.jpg").to_return(body: File.read(file_path("test.jpg")))
+      end
 
       # FIXME ideally images_changed? and remote_images_urls_changed? would return true
       it "should mark images as changed when setting remote_images_urls" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@ require 'logger'
 require 'carrierwave'
 require 'timecop'
 require 'open-uri'
-require 'sham_rack'
+require "webmock/rspec"
 require 'mini_magick'
 
 I18n.enforce_available_locales = false


### PR DESCRIPTION
WebMock provides a cleaner API that helps to simplify some specs
examples.

This PR comes as a follow up to this discussion https://github.com/carrierwaveuploader/carrierwave/pull/1824#discussion_r48693179