### PR TITLE
Set `fast_finish: true` in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ matrix:
     - rvm: ruby-head
     - rvm: jruby-head
     - gemfile: gemfiles/rails-master.gemfile
+  fast_finish: true
 
 notifications:
   email: false


### PR DESCRIPTION
Now, a build will finish as soon as a job has failed, or when the only
jobs left allow failures.
This let us have faster builds feedbacks.

Ref: https://blog.travis-ci.com/2013-11-27-fast-finishing-builds/