### PR TITLE
Fix returning a new instance of the uploader on every uploader call

### DIFF
--- a/lib/carrierwave/mount.rb
+++ b/lib/carrierwave/mount.rb
@@ -139,7 +139,7 @@ module CarrierWave
       mod.class_eval <<-RUBY, __FILE__, __LINE__+1
 
         def #{column}
-          _mounter(:#{column}).uploaders[0] or _mounter(:#{column}).blank_uploader
+          _mounter(:#{column}).uploaders[0] ||= _mounter(:#{column}).blank_uploader
         end
 
         def #{column}=(new_file)

--- a/spec/mount_single_spec.rb
+++ b/spec/mount_single_spec.rb
@@ -100,6 +100,11 @@ describe CarrierWave::Mount do
         expect(@instance.image).to be_blank
       end
 
+      it "should return the same object every time when nothing has been assigned" do
+        expect(@instance).to receive(:read_uploader).with(:image).and_return(nil)
+        expect(@instance.image.object_id).to eq @instance.image.object_id
+      end
+
       it "should return a blank uploader when an empty string has been assigned" do
         expect(@instance).to receive(:read_uploader).with(:image).and_return('')
         expect(@instance.image).to be_an_instance_of(@uploader)


### PR DESCRIPTION
How to reproduce:
```ruby
class Picture < ActiveRecord::Base
  mount_uploader :image, ImageUploader
end

pic = Picture.new
pic.image.object_id # => 70317811568320
pic.image.object_id # => 70317821530860
```

First of all, this bug generates new objects every time, and this is definitely not good. Also this affects on actions with uploader. For example:
```ruby
pic = Picture.new
pic.image.retrieve_from_cache!("1454349370-83816-0001-5310/image.jpg")
pic.image.blank? # => true
```