### PR TITLE
Backport #1797 to 0.10-stable

### DIFF
--- a/features/caching.feature
+++ b/features/caching.feature
@@ -23,6 +23,6 @@ Feature: uploader with file storage
   Scenario: retrieving a file from cache
     Given an uploader class that uses the 'file' storage
     And an instance of that class
-    And the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/bork.txt'
-    When I retrieve the cache name '1369894322-345-2255/bork.txt' from the cache
-    Then the uploader should have 'public/uploads/tmp/1369894322-345-2255/bork.txt' as its current path
+    And the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/bork.txt'
+    When I retrieve the cache name '1369894322-345-1234-2255/bork.txt' from the cache
+    Then the uploader should have 'public/uploads/tmp/1369894322-345-1234-2255/bork.txt' as its current path

--- a/features/file_storage.feature
+++ b/features/file_storage.feature
@@ -30,8 +30,8 @@ Feature: uploader with file storage
     And the file at 'public/uploads/bork.txt' should be identical to the file at 'fixtures/bork.txt'
 
   Scenario: retrieving a file from cache then storing
-    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/bork.txt'
-    When I retrieve the cache name '1369894322-345-2255/bork.txt' from the cache
+    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/bork.txt'
+    When I retrieve the cache name '1369894322-345-1234-2255/bork.txt' from the cache
     And I store the file
     Then there should be a file at 'public/uploads/bork.txt'
     And the file at 'public/uploads/bork.txt' should be identical to the file at 'fixtures/bork.txt'

--- a/features/file_storage_overridden_filename.feature
+++ b/features/file_storage_overridden_filename.feature
@@ -31,8 +31,8 @@ Feature: uploader with file storage and overriden filename
     And the file at 'public/uploads/txt.krob' should be identical to the file at 'fixtures/bork.txt'
 
   Scenario: retrieving a file from cache then storing
-    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/bork.txt'
-    When I retrieve the cache name '1369894322-345-2255/bork.txt' from the cache
+    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/bork.txt'
+    When I retrieve the cache name '1369894322-345-1234-2255/bork.txt' from the cache
     And I store the file
     Then there should be a file at 'public/uploads/txt.krob'
     And the file at 'public/uploads/txt.krob' should be identical to the file at 'fixtures/bork.txt'

--- a/features/file_storage_overridden_store_dir.feature
+++ b/features/file_storage_overridden_store_dir.feature
@@ -31,8 +31,8 @@ Feature: uploader with file storage and overridden store dir
     And the file at 'public/monkey/llama/bork.txt' should be identical to the file at 'fixtures/bork.txt'
 
   Scenario: retrieving a file from cache then storing
-    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/bork.txt'
-    When I retrieve the cache name '1369894322-345-2255/bork.txt' from the cache
+    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/bork.txt'
+    When I retrieve the cache name '1369894322-345-1234-2255/bork.txt' from the cache
     And I store the file
     Then there should be a file at 'public/monkey/llama/bork.txt'
     And the file at 'public/monkey/llama/bork.txt' should be identical to the file at 'fixtures/bork.txt'

--- a/features/file_storage_reversing_processor.feature
+++ b/features/file_storage_reversing_processor.feature
@@ -36,8 +36,8 @@ Feature: uploader with file storage and a processor that reverses the file
     And the file at 'public/uploads/bork.txt' should be the reverse of the file at 'fixtures/bork.txt'
 
   Scenario: retrieving a file from cache then storing
-    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/bork.txt'
-    When I retrieve the cache name '1369894322-345-2255/bork.txt' from the cache
+    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/bork.txt'
+    When I retrieve the cache name '1369894322-345-1234-2255/bork.txt' from the cache
     And I store the file
     Then there should be a file at 'public/uploads/bork.txt'
     And the file at 'public/uploads/bork.txt' should be identical to the file at 'fixtures/bork.txt'

--- a/features/versions_basics.feature
+++ b/features/versions_basics.feature
@@ -33,9 +33,9 @@ Feature: uploader with file storage and versions
     And the uploader's version 'thumb' should have the url '/uploads/thumb_bork.txt'
 
   Scenario: retrieving a file from cache then storing
-    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/bork.txt'
-    Given the file 'fixtures/monkey.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/thumb_bork.txt'
-    When I retrieve the cache name '1369894322-345-2255/bork.txt' from the cache
+    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/bork.txt'
+    Given the file 'fixtures/monkey.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/thumb_bork.txt'
+    When I retrieve the cache name '1369894322-345-1234-2255/bork.txt' from the cache
     And I store the file
     Then there should be a file at 'public/uploads/bork.txt'
     Then there should be a file at 'public/uploads/thumb_bork.txt'

--- a/features/versions_nested_versions.feature
+++ b/features/versions_nested_versions.feature
@@ -43,11 +43,11 @@ Feature: uploader with nested versions
     And the uploader's nested version 'micro' nested in 'thumb' should have the url '/uploads/thumb_micro_bork.txt'
 
   Scenario: retrieving a file from cache then storing
-    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/bork.txt'
-    Given the file 'fixtures/monkey.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/thumb_bork.txt'
-    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/thumb_mini_bork.txt'
-    Given the file 'fixtures/monkey.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/thumb_micro_bork.txt'
-    When I retrieve the cache name '1369894322-345-2255/bork.txt' from the cache
+    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/bork.txt'
+    Given the file 'fixtures/monkey.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/thumb_bork.txt'
+    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/thumb_mini_bork.txt'
+    Given the file 'fixtures/monkey.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/thumb_micro_bork.txt'
+    When I retrieve the cache name '1369894322-345-1234-2255/bork.txt' from the cache
     And I store the file
     Then there should be a file at 'public/uploads/bork.txt'
     Then there should be a file at 'public/uploads/thumb_bork.txt'

--- a/features/versions_overridden_filename.feature
+++ b/features/versions_overridden_filename.feature
@@ -34,9 +34,9 @@ Feature: uploader with file storage and overriden filename
       And the uploader's version 'thumb' should have the url '/uploads/thumb_grark.png'
 
     Scenario: retrieving a file from cache then storing
-      Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/bork.txt'
-      Given the file 'fixtures/monkey.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/thumb_bork.txt'
-      When I retrieve the cache name '1369894322-345-2255/bork.txt' from the cache
+      Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/bork.txt'
+      Given the file 'fixtures/monkey.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/thumb_bork.txt'
+      When I retrieve the cache name '1369894322-345-1234-2255/bork.txt' from the cache
       And I store the file
       Then there should be a file at 'public/uploads/grark.png'
       Then there should be a file at 'public/uploads/thumb_grark.png'

--- a/features/versions_overriden_store_dir.feature
+++ b/features/versions_overriden_store_dir.feature
@@ -31,9 +31,9 @@ Feature: uploader with file storage and versions with overridden store dir
     And the file at 'public/monkey/llama/thumb_bork.txt' should be identical to the file at 'fixtures/bork.txt'
 
   Scenario: retrieving a file from cache then storing
-    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/bork.txt'
-    Given the file 'fixtures/monkey.txt' is cached file at 'public/uploads/tmp/1369894322-345-2255/thumb_bork.txt'
-    When I retrieve the cache name '1369894322-345-2255/bork.txt' from the cache
+    Given the file 'fixtures/bork.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/bork.txt'
+    Given the file 'fixtures/monkey.txt' is cached file at 'public/uploads/tmp/1369894322-345-1234-2255/thumb_bork.txt'
+    When I retrieve the cache name '1369894322-345-1234-2255/bork.txt' from the cache
     And I store the file
     Then there should be a file at 'public/uploads/bork.txt'
     Then there should be a file at 'public/monkey/llama/thumb_bork.txt'

--- a/lib/carrierwave/uploader/cache.rb
+++ b/lib/carrierwave/uploader/cache.rb
@@ -8,15 +8,27 @@ module CarrierWave
     end
   end
 
+  class CacheCounter
+    @@counter = 0
+
+    def self.increment
+      @@counter += 1
+    end
+  end
+
   ##
   # Generates a unique cache id for use in the caching system
   #
   # === Returns
   #
-  # [String] a cache id in the format TIMEINT-PID-RND
+  # [String] a cache id in the format TIMEINT-PID-COUNTER-RND
   #
   def self.generate_cache_id
-    Time.now.utc.to_i.to_s + '-' + Process.pid.to_s + '-' + ("%04d" % rand(9999))
+    [Time.now.utc.to_i,
+      Process.pid,
+      '%04d' % (CarrierWave::CacheCounter.increment % 1000),
+      '%04d' % rand(9999)
+    ].map(&:to_s).join('-')
   end
 
   module Uploader
@@ -91,7 +103,7 @@ module CarrierWave
       #
       # === Returns
       #
-      # [String] a cache name, in the format YYYYMMDD-HHMM-PID-RND/filename.txt
+      # [String] a cache name, in the format TIMEINT-PID-COUNTER-RND/filename.txt
       #
       def cache_name
         File.join(cache_id, full_original_filename) if cache_id and original_filename
@@ -165,7 +177,9 @@ module CarrierWave
       alias_method :full_original_filename, :original_filename
 
       def cache_id=(cache_id)
-        raise CarrierWave::InvalidParameter, "invalid cache id" unless cache_id =~ /\A[\d]+\-[\d]+\-[\d]{4}\z/
+        # Earlier version used 3 part cache_id. Thus we should allow for
+        # the cache_id to have both 3 part and 4 part formats.
+        raise CarrierWave::InvalidParameter, "invalid cache id" unless cache_id =~ /\A[\d]+\-[\d]+(\-[\d]{4})?\-[\d]{4}\z/
         @cache_id = cache_id
       end
 

--- a/spec/mount_spec.rb
+++ b/spec/mount_spec.rb
@@ -242,7 +242,7 @@ describe CarrierWave::Mount do
 
       it "should be the cache name when a file has been cached" do
         @instance.image = stub_file('test.jpg')
-        @instance.image_cache.should =~ %r(^[\d]+\-[\d]+\-[\d]{4}/test\.jpg$)
+        @instance.image_cache.should =~ %r(^[\d]+\-[\d]+\-[\d]{4}\-[\d]{4}/test\.jpg$)
       end
 
     end

--- a/spec/uploader/cache_spec.rb
+++ b/spec/uploader/cache_spec.rb
@@ -322,7 +322,7 @@ describe CarrierWave::Uploader do
   describe '.generate_cache_id' do
     it 'should generate dir name bsed on UTC time' do
       Timecop.travel(Time.at(1369896000)) do
-        CarrierWave.generate_cache_id.should match(/\A1369896000-\d+-\d+\Z/)
+        CarrierWave.generate_cache_id.should match(/\A1369896000-\d+-\d+-\d+\Z/)
       end
     end
   end


### PR DESCRIPTION
Backport #1797 to 0.10-stable

------------------

Add counter to cache_id

Old version of generate_cache_id was collision-prone: for complex factories with multiple uploaders we had quite a few flaky specs because of that. With a counter, this (and similar situations like https://github.com/carrierwaveuploader/carrierwave/issues/1232) should be resolved completely.