### PR TITLE
Forgotten the "_" inside some keys in i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -903,8 +903,8 @@ errors:
     carrierwave_processing_error: "Cannot resize image."
     carrierwave_integrity_error: "Not an image."
     carrierwave_download_error: "Couldn't download image."
-    extension_whitelist_error: "You are not allowed to upload %{extension} files, allowed types: %{allowed_types}"
-    extension_blacklist_error: "You are not allowed to upload %{extension} files, prohibited types: %{prohibited_types}"
+    extension_white_list_error: "You are not allowed to upload %{extension} files, allowed types: %{allowed_types}"
+    extension_black_list_error: "You are not allowed to upload %{extension} files, prohibited types: %{prohibited_types}"
 ```
 
 ## Large files


### PR DESCRIPTION
- `extension_white_list_error` not `extension_whitelist_error`
- `extension_black_list_error` not `extension_blacklist_error`