### PR TITLE
Remove json gem

### DIFF
--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", ">= 4.0.0"
   s.add_dependency "activemodel", ">= 4.0.0"
-  s.add_dependency "json", ">= 1.7"
   s.add_dependency "mime-types", ">= 1.16"
   if RUBY_ENGINE == 'jruby'
     s.add_development_dependency 'activerecord-jdbcpostgresql-adapter'


### PR DESCRIPTION
JSON support is in Ruby since 1.9 so there is no need to have json gem as a dependency.

Inspired by this Rack’s PR https://github.com/rack/rack/pull/1011