### PR TITLE
Update CHANGELOG with post-0.10.0 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+* `cache_id` is now less collision-prone thanks to a counter (@stillwaiting and @mtsmfm [#1866](https://github.com/carrierwaveuploader/carrierwave/pull/1866))
 
 ### Removed
 
 ### Fixed
+* Fix require RMagick deprecation warning (@thomasfedb and @bensie [#1788](https://github.com/carrierwaveuploader/carrierwave/pull/1788))
 
 Please check [0.10-stable] for previous changes.
 
-[Unreleased]: https://github.com/carrierwaveuploader/carrierwave/compare/0.10-stable...0.11-stable
+[Unreleased]: https://github.com/carrierwaveuploader/carrierwave/compare/v0.10.0...0.11-stable
 [0.10-stable]: https://github.com/carrierwaveuploader/carrierwave/blob/0.10-stable/History.txt


### PR DESCRIPTION
Fixes https://github.com/carrierwaveuploader/carrierwave/issues/1875 so we can have a new stable release. Maybe it is an idea to only merge pull requests with an updated changelog?

Might be a little bit strange that the 0.10-stable branch now contains changes not included in the latest 0.10 release (0.10.0). Should we release two versions (0.10.1 and 0.11.0)? If so, should I backport the updated changelog with the 0.10-stable changes to the 0.10-stable branch as well?