### PR TITLE
improve the performance to access AWS and Google

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -339,7 +339,7 @@ module CarrierWave
             end
           else
             # AWS/Google optimized for speed over correctness
-            case @uploader.fog_credentials[:provider]
+            case @uploader.fog_credentials[:provider].to_s
             when 'AWS'
               # check if some endpoint is set in fog_credentials
               if @uploader.fog_credentials.has_key?(:endpoint)


### PR DESCRIPTION
When using :AWS or :Google in the configuration file, access the images stored on AWS or Google are very slow. This is because when using :AWS or :Google, this public_url will return nil, and carrierwave will retrive the public_url by a service call.