### PR TITLE
Don't raise an error when content_type is called on a deleted file

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -209,7 +209,7 @@ module CarrierWave
         # [String] value of content-type
         #
         def content_type
-          @content_type || file.content_type
+          @content_type || !file.nil? && file.content_type
         end
 
         ##

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -183,15 +183,16 @@ end
           @fog_file.delete
           expect(@directory.files.head(store_path)).to eq(nil)
         end
+
         context "when the file has been deleted" do
-          before do
-            @fog_file.delete
-          end
+          before { @fog_file.delete }
 
           it "should not error getting the file size" do
-            expect {
-              @fog_file.size
-            }.not_to raise_error
+            expect { @fog_file.size }.not_to raise_error
+          end
+
+          it "should not error getting the content type" do
+            expect { @fog_file.content_type }.not_to raise_error
           end
         end
       end


### PR DESCRIPTION
Related to https://github.com/carrierwaveuploader/carrierwave/pull/1561
Same problem, with `content_type`.