### PR TITLE
Normalize gem version

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ gem 'carrierwave'
 Finally, restart the server to apply the changes.
 
 As of version 1.0.0 (forthcoming), CarrierWave requires Rails 4.0 or higher and Ruby 2.0
-or higher. If you're on Rails 3, you should use v0.10.0.
+or higher. If you're on Rails 3, you should use v0.11.0.
 
 ## Getting Started
 
@@ -263,7 +263,7 @@ plugins or client-side software.
 
 ## Setting the content type
 
-As of v0.10.0, the `mime-types` gem is a runtime dependency and the content type is set automatically.
+As of v0.11.0, the `mime-types` gem is a runtime dependency and the content type is set automatically.
 You no longer need to do this manually.
 
 ## Adding versions

--- a/lib/carrierwave/version.rb
+++ b/lib/carrierwave/version.rb
@@ -1,3 +1,3 @@
 module CarrierWave
-  VERSION = "0.10.0"
+  VERSION = "0.11.0"
 end


### PR DESCRIPTION
I was previously pointing to master, which claims to be version
`0.10.0`. Then I realized `0.11.0` had been released so I upgraded the
gem without realizing I was actually downgrading it... :(

Let's fix it and put something in the version number that makes more sense.

I've also updated `0.10.0` references in the README, but I'm not sure about those. They might be right. Let me know and I'll update the PR.