### PR TITLE
replaces requiring all of fog with requiring just the supported providers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ notifications:
   email: false
 
 rvm:
- - 1.9.3
  - 2.0
  - 2.1
 
@@ -16,15 +15,6 @@ gemfile:
   - gemfiles/rails-3-2-stable.gemfile
   - gemfiles/rails-4-0-stable.gemfile
   - gemfiles/rails-4-1-stable.gemfile
-
-matrix:
-  include:
-    - rvm: 1.8.7
-      gemfile: gemfiles/rails-3-2-stable.gemfile
-    - rvm: 1.9.2
-      gemfile: gemfiles/rails-3-2-stable.gemfile
-    - rvm: ree
-      gemfile: gemfiles/rails-3-2-stable.gemfile
 
 before_script:
   - psql -c 'create database carrierwave_test;' -U postgres

--- a/lib/carrierwave/storage.rb
+++ b/lib/carrierwave/storage.rb
@@ -1,9 +1,11 @@
 require "carrierwave/storage/abstract"
 require "carrierwave/storage/file"
 
-begin
-  require "fog"
-rescue LoadError
+%w(aws google openstack rackspace).each do |fog_dependency|
+  begin
+    require "fog/#{fog_dependency}"
+  rescue LoadError
+  end
 end
 
 require "carrierwave/storage/fog" if defined?(Fog)

--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require "fog"
-
 module CarrierWave
   module Storage
 


### PR DESCRIPTION
this way, an app can depend on only for example fog-aws, instead of all 24 fog provider gems.