### PR TITLE
Backport Content Type checkers to 0.11 (ImageTragick)

### DIFF
--- a/lib/carrierwave/uploader.rb
+++ b/lib/carrierwave/uploader.rb
@@ -11,6 +11,8 @@ require "carrierwave/uploader/download"
 require "carrierwave/uploader/remove"
 require "carrierwave/uploader/extension_whitelist"
 require "carrierwave/uploader/extension_blacklist"
+require "carrierwave/uploader/content_type_whitelist"
+require "carrierwave/uploader/content_type_blacklist"
 require "carrierwave/uploader/processing"
 require "carrierwave/uploader/versions"
 require "carrierwave/uploader/default_url"
@@ -53,6 +55,8 @@ module CarrierWave
       include CarrierWave::Uploader::Remove
       include CarrierWave::Uploader::ExtensionWhitelist
       include CarrierWave::Uploader::ExtensionBlacklist
+      include CarrierWave::Uploader::ContentTypeWhitelist
+      include CarrierWave::Uploader::ContentTypeBlacklist
       include CarrierWave::Uploader::Processing
       include CarrierWave::Uploader::Versions
       include CarrierWave::Uploader::DefaultUrl

--- a/lib/carrierwave/uploader/content_type_blacklist.rb
+++ b/lib/carrierwave/uploader/content_type_blacklist.rb
@@ -1,0 +1,48 @@
+module CarrierWave
+  module Uploader
+    module ContentTypeBlacklist
+      extend ActiveSupport::Concern
+
+      included do
+        before :cache, :check_content_type_blacklist!
+      end
+
+      ##
+      # Override this method in your uploader to provide a blacklist of files content types
+      # which are not allowed to be uploaded.
+      # Not only strings but Regexp are allowed as well.
+      #
+      # === Returns
+      #
+      # [NilClass, String, Regexp, Array[String, Regexp]] a blacklist of content types which are not allowed to be uploaded
+      #
+      # === Examples
+      #
+      #     def content_type_blacklist
+      #       %w(text/json application/json)
+      #     end
+      #
+      # Basically the same, but using a Regexp:
+      #
+      #     def content_type_blacklist
+      #       [/(text|application)\/json/]
+      #     end
+      #
+      def content_type_blacklist; end
+
+    private
+
+      def check_content_type_blacklist!(new_file)
+        content_type = new_file.content_type
+        if content_type_blacklist && blacklisted_content_type?(content_type)
+          raise CarrierWave::IntegrityError, I18n.translate(:"errors.messages.content_type_blacklist_error", content_type: content_type)
+        end
+      end
+
+      def blacklisted_content_type?(content_type)
+        Array(content_type_blacklist).any? { |item| content_type =~ /#{item}/ }
+      end
+
+    end # ContentTypeBlacklist
+  end # Uploader
+end # CarrierWave

--- a/lib/carrierwave/uploader/content_type_whitelist.rb
+++ b/lib/carrierwave/uploader/content_type_whitelist.rb
@@ -1,0 +1,48 @@
+module CarrierWave
+  module Uploader
+    module ContentTypeWhitelist
+      extend ActiveSupport::Concern
+
+      included do
+        before :cache, :check_content_type_whitelist!
+      end
+
+      ##
+      # Override this method in your uploader to provide a whitelist of files content types
+      # which are allowed to be uploaded.
+      # Not only strings but Regexp are allowed as well.
+      #
+      # === Returns
+      #
+      # [NilClass, String, Regexp, Array[String, Regexp]] a whitelist of content types which are allowed to be uploaded
+      #
+      # === Examples
+      #
+      #     def content_type_whitelist
+      #       %w(text/json application/json)
+      #     end
+      #
+      # Basically the same, but using a Regexp:
+      #
+      #     def content_type_whitelist
+      #       [/(text|application)\/json/]
+      #     end
+      #
+      def content_type_whitelist; end
+
+    private
+
+      def check_content_type_whitelist!(new_file)
+        content_type = new_file.content_type
+        if content_type_whitelist && !whitelisted_content_type?(content_type)
+          raise CarrierWave::IntegrityError, I18n.translate(:"errors.messages.content_type_whitelist_error", content_type: content_type)
+        end
+      end
+
+      def whitelisted_content_type?(content_type)
+        Array(content_type_whitelist).any? { |item| content_type =~ /#{item}/ }
+      end
+
+    end # ContentTypeWhitelist
+  end # Uploader
+end # CarrierWave

--- a/spec/uploader/callback_spec.rb
+++ b/spec/uploader/callback_spec.rb
@@ -8,16 +8,16 @@ describe CarrierWave::Uploader do
     @uploader_class_1 = Class.new(CarrierWave::Uploader::Base)
 
     # First Uploader only has default before-callback
-    @uploader_class_1._before_callbacks[:cache].should == [:check_whitelist!, :check_blacklist!]
+    @uploader_class_1._before_callbacks[:cache].should == [:check_whitelist!, :check_blacklist!, :check_content_type_whitelist!, :check_content_type_blacklist!]
 
     @uploader_class_2 = Class.new(CarrierWave::Uploader::Base)
     @uploader_class_2.before :cache, :before_cache_callback
 
     # Second Uploader defined with another callback
-    @uploader_class_2._before_callbacks[:cache].should == [:check_whitelist!, :check_blacklist!, :before_cache_callback]
+    @uploader_class_2._before_callbacks[:cache].should == [:check_whitelist!, :check_blacklist!, :check_content_type_whitelist!, :check_content_type_blacklist!, :before_cache_callback]
 
     # Make sure the first Uploader doesn't inherit the same callback
-    @uploader_class_1._before_callbacks[:cache].should == [:check_whitelist!, :check_blacklist!]
+    @uploader_class_1._before_callbacks[:cache].should == [:check_whitelist!, :check_blacklist!, :check_content_type_whitelist!, :check_content_type_blacklist!]
   end
 
 

--- a/spec/uploader/content_type_blacklist_spec.rb
+++ b/spec/uploader/content_type_blacklist_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe CarrierWave::Uploader do
+  let(:uploader_class) { Class.new(CarrierWave::Uploader::Base) }
+  let(:uploader) { uploader_class.new }
+  let(:landscape_file) { File.open(file_path('landscape.jpg')) }
+  let(:bork_file) { File.open(file_path('bork.txt')) }
+  let(:test_file) { File.open(file_path('test.jpeg')) }
+
+  after { FileUtils.rm_rf(public_path) }
+
+  describe '#cache!' do
+    before do
+      CarrierWave.stub(:generate_cache_id).and_return('1369894322-345-1234-2255')
+    end
+
+    context "when there is no blacklist" do
+      it "does not raise an integrity error" do
+        uploader.stub(:content_type_blacklist).and_return(nil)
+
+        lambda { uploader.cache!(landscape_file) }.should_not raise_error
+      end
+    end
+
+    context "when there is a blacklist" do
+      context "when the blacklist is an array of values" do
+        it "does not raise an integrity error when the file has not a blacklisted content type" do
+          uploader.stub(:content_type_blacklist).and_return(['image/gif'])
+
+          lambda { uploader.cache!(bork_file) }.should_not raise_error
+        end
+
+        it "raises an integrity error if the file has a blacklisted content type" do
+          uploader.stub(:content_type_blacklist).and_return(['image/jpeg'])
+
+          lambda { uploader.cache!(landscape_file) }.should raise_error(CarrierWave::IntegrityError)
+        end
+
+        it "accepts content types as regular expressions" do
+          uploader.stub(:content_type_blacklist).and_return([/image\//])
+
+          lambda { uploader.cache!(landscape_file) }.should raise_error(CarrierWave::IntegrityError)
+        end
+      end
+    end
+  end
+end

--- a/spec/uploader/content_type_whitelist_spec.rb
+++ b/spec/uploader/content_type_whitelist_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe CarrierWave::Uploader do
+  let(:uploader_class) { Class.new(CarrierWave::Uploader::Base) }
+  let(:uploader) { uploader_class.new }
+  let(:image_file) { File.open(file_path('landscape.jpg')) }
+
+  after { FileUtils.rm_rf(public_path) }
+
+  describe '#cache!' do
+    before do
+      CarrierWave.stub(:generate_cache_id).and_return('1369894322-345-1234-2255')
+    end
+
+    context "when there is no whitelist" do
+      it "does not raise an integrity error" do
+        uploader.stub(:content_type_whitelist).and_return(nil)
+
+        lambda { uploader.cache!(image_file) }.should_not raise_error
+      end
+    end
+
+    context "when there is a whitelist" do
+      context "when the whitelist is an array of values" do
+        let(:bork_file) { File.open(file_path('bork.txt')) }
+
+        it "does not raise an integrity error when the file has a whitelisted content type" do
+          uploader.stub(:content_type_whitelist).and_return(['image/jpeg'])
+
+          lambda { uploader.cache!(image_file) }.should_not raise_error
+        end
+
+        it "raises an integrity error the file has not a whitelisted content type" do
+          uploader.stub(:content_type_whitelist).and_return(['image/jpeg'])
+
+          lambda { uploader.cache!(bork_file) }.should raise_error(CarrierWave::IntegrityError)
+        end
+
+        it "accepts content types as regular expressions" do
+          uploader.stub(:content_type_whitelist).and_return([/image\//])
+
+          lambda { uploader.cache!(bork_file) }.should raise_error(CarrierWave::IntegrityError)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Backport the content_type_(whitelist|blacklist) functionality to allow mitigation against ImageTragick to actually work.