### PR TITLE
Do not allow file type spoofing if the header bytes are not recognized

### DIFF
--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -315,7 +315,7 @@ module CarrierWave
     end
 
     def mime_magic_content_type
-      MimeMagic.by_magic(File.open(path)).try(:type) if path
+      MimeMagic.by_magic(File.open(path)).try(:type) || 'invalid/invalid' if path
     rescue Errno::ENOENT
       nil
     end

--- a/spec/fixtures/spoof.png
+++ b/spec/fixtures/spoof.png
@@ -1,0 +1,4 @@
+push graphic-context
+viewbox 0 0 640 480
+fill 'url(https://example.com/image.jpg";|ls "-la)'
+pop graphic-context

--- a/spec/sanitized_file_spec.rb
+++ b/spec/sanitized_file_spec.rb
@@ -207,6 +207,17 @@ describe CarrierWave::SanitizedFile do
       sanitized_file.content_type.should == 'image/jpeg'
     end
 
+    it 'does not allow spoofing of the mime type if the mime type is not detectable' do
+      file = File.open(file_path('spoof.png'))
+
+      sanitized_file = CarrierWave::SanitizedFile.new(file)
+
+      lambda { sanitized_file.content_type }.should_not raise_error
+
+      sanitized_file.content_type.should_not == 'image/png'
+      sanitized_file.content_type.should == 'invalid/invalid'
+    end
+
     it 'does not raise an error if the path is not present' do
       sanitized_file = CarrierWave::SanitizedFile.new(nil)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -90,6 +90,7 @@ module CarrierWave
 
       def stub_file(filename, mime_type=nil, fake_name=nil)
         f = File.open(file_path(filename))
+        f.stub(:content_type) { mime_type } if mime_type
         return f
       end
     end

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -309,6 +309,7 @@ end
     describe "with a valid path" do
       before do
         @file = CarrierWave::SanitizedFile.new(file_path('test.jpg'))
+        @file.file.stub(:content_type) { 'image/jpeg' }
         @file.should_not be_empty
       end
 
@@ -318,6 +319,7 @@ end
     describe "with a valid Pathname" do
       before do
         @file = CarrierWave::SanitizedFile.new(Pathname.new(file_path('test.jpg')))
+        @file.file.stub(:content_type) { 'image/jpeg' }
         @file.should_not be_empty
       end
 

--- a/spec/uploader/proxy_spec.rb
+++ b/spec/uploader/proxy_spec.rb
@@ -57,7 +57,7 @@ describe CarrierWave::Uploader do
     end
 
     it "should get the content type when the file has been cached" do
-      @uploader.cache!(File.open(file_path('test.jpg')))
+      @uploader.cache!(File.open(file_path('landscape.jpg')))
       @uploader.content_type.should == 'image/jpeg'
     end
 


### PR DESCRIPTION
This fixes an issue raised in https://github.com/carrierwaveuploader/carrierwave/pull/1934, where a malicious user could bypass the stricter mime-type checking by choosing header bytes that are not recognized by the `mimemagic` gem.
