### PR TITLE
Add content type whitelist/blacklist translations

### DIFF
--- a/lib/carrierwave/locale/cs.yml
+++ b/lib/carrierwave/locale/cs.yml
@@ -6,6 +6,8 @@ cs:
       carrierwave_download_error: nemůže být stažen
       extension_whitelist_error: "Není možné nahrávat %{extension} soubory, povolené typy: %{allowed_types}"
       extension_blacklist_error: "Není možné nahrávat %{extension} soubory, zakázané typy: %{prohibited_types}"
+      content_type_whitelist_error: "Není možné nahrávat %{content_type} soubory"
+      content_type_blacklist_error: "Není možné nahrávat %{content_type} soubory"
       rmagick_processing_error: "Nepodařilo se upravit pomocí rmagick, možná se nejedná o obrázek? Hlášená Chyba: %{e}"
       mini_magick_processing_error: "Nepodařilo se upravit pomocí MiniMagick, možná se nejedná o obrázek? Hlášená Chyba: %{e}"
       min_size_error: "Velikost souboru by měla být větší než %{min_size}"

--- a/lib/carrierwave/locale/de.yml
+++ b/lib/carrierwave/locale/de.yml
@@ -6,6 +6,8 @@ de:
       carrierwave_download_error: konnte nicht heruntergeladen werden
       extension_whitelist_error: "Sie sind nicht berechtigt %{extension} Dateien hochzuladen, erlaubte Typen: %{allowed_types}"
       extension_blacklist_error: "Sie sind nicht berechtigt %{extension} Dateien hochzuladen, verbotene Typen: %{prohibited_types}"
+      content_type_whitelist_error: "Sie sind nicht berechtigt %{content_type} Dateien hochzuladen"
+      content_type_blacklist_error: "Sie sind nicht berechtigt %{content_type} Dateien hochzuladen"
       rmagick_processing_error: "Verarbeitung mit rmagick fehlgeschlagen, vielleicht ist es kein Bild? Original Fehler: %{e}"
       mini_magick_processing_error: "Verarbeitung mit MiniMagick fehlgeschlagen, vielleicht ist es kein Bild? Original Fehler: %{e}"
       min_size_error: "Die dateigröße sollte größer sein als %{min_size}"

--- a/lib/carrierwave/locale/es.yml
+++ b/lib/carrierwave/locale/es.yml
@@ -6,6 +6,8 @@ es:
       carrierwave_download_error: no pudo ser descargado
       extension_whitelist_error: "No se pueden subir archivos de la extensión %{extension}. Las extensiones permitidas son: %{allowed_types}"
       extension_blacklist_error: "No se pueden subir archivos de la extensión %{extension}. Las extensiones prohibidas son: %{prohibited_types}"
+      content_type_whitelist_error: "No se pueden subir archivos de la extensión %{content_type}"
+      content_type_blacklist_error: "No se pueden subir archivos de la extensión %{content_type}"
       rmagick_processing_error: "No se pudo manipular con rmagick, quizá porque no es una imágen? Error original: %{e}"
       mini_magick_processing_error: "No se pudo manipular con MiniMagick, quizá porque no es una imágen? Error original: %{e}"
       min_size_error: "El tamaño del archivo debe ser mayor que %{min_size}"

--- a/lib/carrierwave/locale/fr-CA.yml
+++ b/lib/carrierwave/locale/fr-CA.yml
@@ -6,6 +6,8 @@ fr_CA:
       carrierwave_download_error: "Impossible de télécharger l'image."
       extension_whitelist_error: "Vous n'êtes pas autorisé à uploader des fichiers %{extension}, types autorisés: %{allowed_types}"
       extension_blacklist_error: "Vous n'êtes pas autorisé à uploader des fichiers %{extension}, types interdits: %{prohibited_types}"
+      content_type_whitelist_error: "Vous n'êtes pas autorisé à uploader des fichiers %{content_type}"
+      content_type_blacklist_error: "Vous n'êtes pas autorisé à uploader des fichiers %{content_type}"
       rmagick_processing_error: "La manipulation d'image avec rmagick a échoué. Peut-être que ce n'est pas une image? Erreur originale: %{e}"
       mini_magick_processing_error: "La manipulation d'image avec MiniMagick a échoué. Peut-être que ce n'est pas une image? Erreur originale: %{e}"
       min_size_error: "La taille du fichier doit être supérieure à %{min_size}"

--- a/lib/carrierwave/locale/ja.yml
+++ b/lib/carrierwave/locale/ja.yml
@@ -6,6 +6,8 @@ ja:
       carrierwave_download_error: はダウンロードできません
       extension_whitelist_error: "%{extension}ファイルのアップロードは許可されていません。アップロードできるファイルタイプ: %{allowed_types}"
       extension_blacklist_error: "%{extension}ファイルのアップロードは許可されていません。アップロードできないファイルタイプ: %{prohibited_types}"
+      content_type_whitelist_error: "%{content_type}ファイルのアップロードは許可されていません"
+      content_type_blacklist_error: "%{content_type}ファイルのアップロードは許可されていません"
       rmagick_processing_error: "rmagickがファイルを処理できませんでした。画像を確認してください。エラーメッセージ: %{e}"
       mini_magick_processing_error: "MiniMagickがファイルを処理できませんでした。画像を確認してください。エラーメッセージ: %{e}"
       min_size_error: "ファイルを%{min_size}バイト以上のサイズにしてください"

--- a/lib/carrierwave/locale/nb.yml
+++ b/lib/carrierwave/locale/nb.yml
@@ -6,6 +6,8 @@ nb:
       carrierwave_download_error: kunne ikke lastes ned
       extension_whitelist_error: "Du kan ikke laste opp %{extension}-filer, tillatte filtyper: %{allowed_types}"
       extension_blacklist_error: "Du kan ikke laste opp %{extension}-filer, forbudte filtyper: %{prohibited_types}"
+      content_type_whitelist_error: "Du kan ikke laste opp %{content_type}-filer"
+      content_type_blacklist_error: "Du kan ikke laste opp %{content_type}-filer"
       rmagick_processing_error: "Kunne ikke manipulere med rmagick. Er du sikker på at det er et bilde? Feilmelding: %{e}"
       mini_magick_processing_error: "Kunne ikke manipulere med MiniMagick. Er du sikker på at det er et bilde? Feilmelding: %{e}"
       min_size_error: "Filen størrelse bør være større enn %{min_size}"

--- a/lib/carrierwave/locale/nl.yml
+++ b/lib/carrierwave/locale/nl.yml
@@ -6,6 +6,8 @@ nl:
       carrierwave_download_error: kon niet gedownload worden
       extension_whitelist_error: "Het is niet toegestaan om %{extension} bestanden te uploaden; toegestane bestandstypes: %{allowed_types}"
       extension_blacklist_error: "Het is niet toegestaan om %{extension} bestanden te uploaden; verboden bestandstypes: %{prohibited_types}"
+      content_type_whitelist_error: "Het is niet toegestaan om %{content_type} bestanden te uploaden"
+      content_type_blacklist_error: "Het is niet toegestaan om %{content_type} bestanden te uploaden"
       rmagick_processing_error: "Bewerking met rmagick is mislukt, misschien is het geen afbeelding? Originele foutmelding: %{e}"
       mini_magick_processing_error: "Bewerking met MiniMagick is mislukt, misschien is het geen afbeelding? Originele foutmelding: %{e}"
       min_size_error: "De bestandsgrootte moet groter zijn dan %{min_size}"

--- a/lib/carrierwave/locale/pl.yml
+++ b/lib/carrierwave/locale/pl.yml
@@ -6,6 +6,8 @@ pl:
       carrierwave_download_error: nie można pobrać pliku
       extension_whitelist_error: "Nie można wgrać pliku o rozszerzeniu %{extension}, dozwolone typy plików: %{allowed_types}"
       extension_blacklist_error: "Nie można wgrać pliku o rozszerzeniu %{extension}, zakazane typy plików: %{prohibited_types}"
+      content_type_whitelist_error: "Nie można wgrać pliku o rozszerzeniu %{content_type}"
+      content_type_blacklist_error: "Nie można wgrać pliku o rozszerzeniu %{content_type}"
       rmagick_processing_error: "Nie udało się przetworzyć pliku przy pomocy rmagick, może to nie jest obrazek? Oryginalna treść błędu: %{e}"
       mini_magick_processing_error: "Nie udało się przetworzyć pliku przy pomocy MiniMagick, może to nie jest obrazek? Oryginalna treść błędu: %{e}"
       min_size_error: "Rozmiar pliku powinna być większa niż %{min_size}"

--- a/lib/carrierwave/locale/pt-BR.yml
+++ b/lib/carrierwave/locale/pt-BR.yml
@@ -6,6 +6,8 @@ pt-BR:
       carrierwave_download_error: não pôde ser baixado
       extension_whitelist_error: "Não é permitido o envio de arquivos %{extension}, tipos permitidos: %{allowed_types}"
       extension_blacklist_error: "Não é permitido o envio de arquivos %{extension}, tipos proibidos: %{prohibited_types}"
+      content_type_whitelist_error: "Não é permitido o envio de arquivos %{content_type}"
+      content_type_blacklist_error: "Não é permitido o envio de arquivos %{content_type}"
       rmagick_processing_error: "Falha ao manipular com RMagick, talvez arquivo não seja uma imagem? Erro original: %{e}"
       mini_magick_processing_error: "Falha ao manipular com MiniMagick, talvez arquivo não seja uma imagem? Erro original: %{e}"
       min_size_error: "O tamanho do arquivo deve ser maior do que %{min_size}"

--- a/lib/carrierwave/locale/pt-PT.yml
+++ b/lib/carrierwave/locale/pt-PT.yml
@@ -6,6 +6,8 @@ pt-PT:
       carrierwave_download_error: não pôde ser transferido
       extension_whitelist_error: "Não é permitido o envio de ficheiros com a extensão %{extension}, tipos de ficheiro permitidos: %{allowed_types}"
       extension_blacklist_error: "Não é permitido o envio de ficheiros com a extensão %{extension}, tipos de ficheiro proibidos: %{prohibited_types}"
+      content_type_whitelist_error: "Não é permitido o envio de ficheiros com a extensão %{content_type}"
+      content_type_blacklist_error: "Não é permitido o envio de ficheiros com a extensão %{content_type}"
       rmagick_processing_error: "Ocorreu uma falha ao processar com rmagick, talvez o ficheiro não seja uma imagem? Erro original: %{e}"
       mini_magick_processing_error: "Ocorreu uma falha ao processar com MiniMagick, talvez o ficheiro não seja uma imagem? Erro original: %{e}"
       min_size_error: "O tamanho do arquivo deve ser maior do que %{min_size}"

--- a/lib/carrierwave/locale/ru.yml
+++ b/lib/carrierwave/locale/ru.yml
@@ -6,6 +6,8 @@ ru:
       carrierwave_download_error: Невозможно скачать файл
       extension_whitelist_error: "Вы не можете загружать файлы типа %{extension}, разрешенные типы: %{allowed_types}"
       extension_blacklist_error: "Вы не можете загружать файлы типа %{extension}, запрещенные типы: %{prohibited_types}"
+      content_type_whitelist_error: "Вы не можете загружать файлы типа %{content_type}"
+      content_type_blacklist_error: "Вы не можете загружать файлы типа %{content_type}"
       rmagick_processing_error: "Ошибка взаимодействия с RMagick, может быть это не изображение? Исходная ошибка: %{e}"
       mini_magick_processing_error: "Ошибка взаимодействия с MiniMagick, может быть это не изображение? Исходная ошибка: %{e}"
       min_size_error: "Размер файла должен быть больше, чем %{min_size}"

--- a/lib/carrierwave/locale/sk.yml
+++ b/lib/carrierwave/locale/sk.yml
@@ -6,6 +6,8 @@ sk:
       carrierwave_download_error: nie je možné stiahnuť
       extension_whitelist_error: "Nie je možné nahrávať %{extension} súbory, povolené typy: %{allowed_types}"
       extension_blacklist_error: "Nie je možné nahrávať %{extension} súbory, zakázané typy: %{prohibited_types}"
+      content_type_whitelist_error: "Nie je možné nahrávať %{content_type} súbory"
+      content_type_blacklist_error: "Nie je možné nahrávať %{content_type} súbory"
       rmagick_processing_error: "Nepodarilo sa upraviť pomocou rmagick, možno nejde o obrázok? Hlásená chyba: %{e}"
       mini_magick_processing_error: "Nepodarilo sa upraviť pomocou MiniMagick, možno nejde o obrázok? Hlásená chyba: %{e}"
       min_size_error: "Filstorleken ska vara större än %{min_size}"

--- a/lib/carrierwave/locale/tr.yml
+++ b/lib/carrierwave/locale/tr.yml
@@ -6,6 +6,8 @@ tr:
       carrierwave_download_error: indirilemedi
       extension_whitelist_error: "%{extension} uzantılı dosyaları yükleme izniniz yok, izin verilen uzantılar: %{allowed_types}"
       extension_blacklist_error: "%{extension} uzantılı dosyaları yükleme izniniz yok, izin verilmeyen uzantılar: %{prohibited_types}"
+      content_type_whitelist_error: "%{content_type} uzantılı dosyaları yükleme izniniz yok"
+      content_type_blacklist_error: "%{content_type} uzantılı dosyaları yükleme izniniz yok"
       rmagick_processing_error: "Resim rmagick ile düzenlenemedi, belkide resim değildir? Orjinal Hata: %{e}"
       mini_magick_processing_error: "Resim MiniMagick ile düzenlenemedi, belkide resim değildir? Orjinal Hata: %{e}"
       min_size_error: "Dosya boyutu daha büyük olmalıdır %{min_size}"

--- a/lib/carrierwave/locale/zh-CN.yml
+++ b/lib/carrierwave/locale/zh-CN.yml
@@ -6,6 +6,8 @@ zh-CN:
       carrierwave_download_error: 下载错误
       extension_whitelist_error: "不可上传 %{extension} 文件, 可上传文件类型为: %{allowed_types}"
       extension_blacklist_error: "不可上传 %{extension} 文件, 不可上传文件类型为: %{prohibited_types}"
+      content_type_whitelist_error: "不可上传 %{content_type} 文件"
+      content_type_blacklist_error: "不可上传 %{content_type} 文件"
       rmagick_processing_error: "rmagick 错误, 也许上传的文件不是图片? 原错误: %{e}"
       mini_magick_processing_error: "MiniMagick 错误, 也许上传的文件不是图片? 原错误: %{e}"
       min_size_error: "文件大小应大于 %{min_size}"

--- a/lib/carrierwave/locale/zh-TW.yml
+++ b/lib/carrierwave/locale/zh-TW.yml
@@ -6,6 +6,8 @@ zh-TW:
       carrierwave_download_error: 下載錯誤
       extension_whitelist_error: "不可上傳 %{extension} 文件, 可上傳文件類型為: %{allowed_types}"
       extension_blacklist_error: "不可上傳 %{extension} 文件, 不可上傳文件類型為: %{prohibited_types}"
+      content_type_whitelist_error: "不可上傳 %{content_type} 文件"
+      content_type_blacklist_error: "不可上傳 %{content_type} 文件"
       rmagick_processing_error: "rmagick 錯誤, 也許上傳的的文件不是圖片? 原錯誤: %{e}"
       mini_magick_processing_error: "MiniMagick 錯誤, 也許上傳的文件不是圖片? 原錯誤: %{e}"
       min_size_error: "文件大小應大於 %{min_size}"


### PR DESCRIPTION
Add content type whitelist/blacklist translations, just like [local/el.yml](https://github.com/carrierwaveuploader/carrierwave/blob/b893859067d6aea497809ace68293633e1d64672/lib/carrierwave/locale/el.yml#L9-L10), [en.yml](https://github.com/carrierwaveuploader/carrierwave/blob/b893859067d6aea497809ace68293633e1d64672/lib/carrierwave/locale/en.yml#L9-L10), [id.yml](https://github.com/carrierwaveuploader/carrierwave/blob/b893859067d6aea497809ace68293633e1d64672/lib/carrierwave/locale/id.yml#L9-L10) and [fr.yml](https://github.com/carrierwaveuploader/carrierwave/blob/b893859067d6aea497809ace68293633e1d64672/lib/carrierwave/locale/fr.yml#L9-L10).
