### PR TITLE
Include the asset_host in default_url if it returns a relative url

### DIFF
--- a/lib/carrierwave/uploader/default_url.rb
+++ b/lib/carrierwave/uploader/default_url.rb
@@ -3,7 +3,7 @@ module CarrierWave
     module DefaultUrl
 
       def url(*args)
-        super || default_url(*args)
+        super || determine_default_url(*args)
       end
 
       ##
@@ -11,6 +11,21 @@ module CarrierWave
       # in case no file has been cached/stored yet.
       #
       def default_url(*args); end
+
+      private
+
+      def determine_default_url(*args)
+        path_or_url = default_url(*args)
+        if asset_host && is_relative_url?(path_or_url)
+          add_asset_host_to_path(path_or_url)
+        else
+          path_or_url
+        end
+      end
+
+      def is_relative_url?(url)
+        !url.match(/^https?:\/\//)
+      end
 
     end # DefaultPath
   end # Uploader

--- a/lib/carrierwave/uploader/default_url.rb
+++ b/lib/carrierwave/uploader/default_url.rb
@@ -27,6 +27,6 @@ module CarrierWave
         !url.match(/^https?:\/\//)
       end
 
-    end # DefaultPath
+    end # DefaultUrl
   end # Uploader
 end # CarrierWave

--- a/lib/carrierwave/uploader/url.rb
+++ b/lib/carrierwave/uploader/url.rb
@@ -20,12 +20,8 @@ module CarrierWave
         elsif file.respond_to?(:path)
           path = encode_path(file.path.sub(File.expand_path(root), ''))
 
-          if host = asset_host
-            if host.respond_to? :call
-              "#{host.call(file)}#{path}"
-            else
-              "#{host}#{path}"
-            end
+          if asset_host
+            add_asset_host_to_path(path)
           else
             (base_path || "") + path
           end
@@ -34,6 +30,16 @@ module CarrierWave
 
       def to_s
         url || ''
+      end
+
+      private
+
+      def add_asset_host_to_path(path)
+        if asset_host.respond_to? :call
+          "#{asset_host.call(file)}#{path}"
+        else
+          "#{asset_host}#{path}"
+        end
       end
 
     end # Url

--- a/spec/uploader/default_url_spec.rb
+++ b/spec/uploader/default_url_spec.rb
@@ -40,6 +40,38 @@ describe CarrierWave::Uploader do
       it "returns the default url with version when given" do
         expect(uploader.url(:thumb)).to eq("#{url_example}/thumb")
       end
+
+      it "adds the asset_host to default_url if configured" do
+        tests = [
+          [
+            nil,
+            "/logo.png",
+            "/logo.png"
+          ],
+          [
+            nil,
+            "http://full.example.com/logo.png",
+            "http://full.example.com/logo.png"
+          ],
+          [
+            "http://assets.example.com",
+            "/logo.png",
+            "http://assets.example.com/logo.png"
+          ],
+          [
+            "http://assets.example.com",
+            "http://full.example.com/logo.png",
+            "http://full.example.com/logo.png"
+          ],
+        ]
+        tests.each do |(asset_host, default_url, result)|
+          uploader_class.configure { |config| config.asset_host = asset_host }
+          uploader_class.class_eval <<-CODE
+            def default_url; #{default_url.inspect}; end
+          CODE
+          expect(uploader.url).to eq(result)
+        end
+      end
     end
 
     describe '#cache!' do


### PR DESCRIPTION
If #default_url retuns a relative url, then it makes sense to add the
asset_host to it, if configured.