### PR TITLE
Remove 'config.fog_provider' from the 'Using Amazon S3' section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,7 +652,6 @@ You can also pass in additional options, as documented fully in lib/carrierwave/
 
 ```ruby
 CarrierWave.configure do |config|
-  config.fog_provider = 'fog/aws'                        # required
   config.fog_credentials = {
     provider:              'AWS',                        # required
     aws_access_key_id:     'xxx',                        # required


### PR DESCRIPTION
Removed the `config.fog_provider = 'fog/aws' ` line from the `Using Amazon S3` section because it leads to an error :

`undefined_method 'fog_provider=' for CarrierWave::Uploader::Base:Class (NoMethodError)`


The setup works completely fine without that line.