### PR TITLE
Define methods instead of alias

### DIFF
--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -58,15 +58,18 @@ module CarrierWave
       after_save :"store_previous_changes_for_#{column}"
       after_commit :"remove_previously_stored_#{column}", :on => :update
 
-      def read_uploader(column)
-        read_attribute(column)
-      end
-
-      def write_uploader(column, identifier)
-        write_attribute(column, identifier)
-      end
-
       class_eval <<-RUBY, __FILE__, __LINE__+1
+
+        def read_uploader(column)
+          return super if defined?(super)
+          read_attribute(column)
+        end
+
+        def write_uploader(column, identifier)
+          return super if defined?(super)
+          write_attribute(column, identifier)
+        end
+
         def #{column}=(new_file)
           column = _mounter(:#{column}).serialization_column
           if !(new_file.blank? && send(:#{column}).blank?)

--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -41,6 +41,14 @@ module CarrierWave
     def mount_base(column, uploader=nil, options={}, &block)
       super
 
+      def read_uploader(column)
+        read_attribute(column)
+      end
+
+      def write_uploader(column, identifier)
+        write_attribute(column, identifier)
+      end
+
       public :read_uploader
       public :write_uploader
 
@@ -59,17 +67,6 @@ module CarrierWave
       after_commit :"remove_previously_stored_#{column}", :on => :update
 
       class_eval <<-RUBY, __FILE__, __LINE__+1
-
-        def read_uploader(column)
-          return super if defined?(super)
-          read_attribute(column)
-        end
-
-        def write_uploader(column, identifier)
-          return super if defined?(super)
-          write_attribute(column, identifier)
-        end
-
         def #{column}=(new_file)
           column = _mounter(:#{column}).serialization_column
           if !(new_file.blank? && send(:#{column}).blank?)

--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -41,8 +41,6 @@ module CarrierWave
     def mount_base(column, uploader=nil, options={}, &block)
       super
 
-      alias_method :read_uploader, :read_attribute
-      alias_method :write_uploader, :write_attribute
       public :read_uploader
       public :write_uploader
 
@@ -59,6 +57,14 @@ module CarrierWave
 
       after_save :"store_previous_changes_for_#{column}"
       after_commit :"remove_previously_stored_#{column}", :on => :update
+
+      def read_uploader(column)
+        read_attribute(column)
+      end
+
+      def write_uploader(column, identifier)
+        write_attribute(column, identifier)
+      end
 
       class_eval <<-RUBY, __FILE__, __LINE__+1
         def #{column}=(new_file)


### PR DESCRIPTION
I ran into this issue when trying the multi file uploads feature. When I defined read_uploader and write_uploader, they were not being overriden, so it seems alias_method creates a wire that can't be overriden.