### PR TITLE
README update for Skipping ActiveRecord callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -952,8 +952,8 @@ after_save :store_avatar!
 before_save :write_avatar_identifier
 after_commit :remove_avatar!, on: :destroy
 after_commit :mark_remove_avatar_false, on: :update
-after_save :store_previous_changes_for_avatar
-after_commit :remove_previously_stored_avatar, on: :update
+before_update :store_previous_model_for_avatar
+after_save :remove_previously_stored_avatar
 ```
 
 If you want to skip any of these callbacks (eg. you want to keep the existing


### PR DESCRIPTION
Small doc update as the README to bring the AR callbacks mentioned in line with what it's 0.10 and 0.11.