### PR TITLE
Changed public URL method to support empty fog_directory.

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -343,7 +343,11 @@ module CarrierWave
             when 'AWS'
               # check if some endpoint is set in fog_credentials
               if @uploader.fog_credentials.has_key?(:endpoint)
-                "#{@uploader.fog_credentials[:endpoint]}/#{@uploader.fog_directory}/#{encoded_path}"
+                if @uploader.fog_directory
+                  "#{@uploader.fog_credentials[:endpoint]}/#{@uploader.fog_directory}/#{encoded_path}"
+                else
+                  "#{@uploader.fog_credentials[:endpoint]}/#{encoded_path}"
+                end
               else
                 protocol = @uploader.fog_use_ssl_for_aws ? "https" : "http"
                 # if directory is a valid subdomain, use that style for access


### PR DESCRIPTION
This pull request fixes #1971 by avoiding a double forward slash when fog_directory is empty.