### PR TITLE
Close file in SanitizedFile#mime_magic_content_type

### DIFF
--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -315,7 +315,11 @@ module CarrierWave
     end
 
     def mime_magic_content_type
-      MimeMagic.by_magic(File.open(path)).try(:type) if path
+      if path
+        File.open(path) do |file|
+          MimeMagic.by_magic(file).try(:type)
+        end
+      end
     rescue Errno::ENOENT
       nil
     end


### PR DESCRIPTION
Fixes bug where file handles are being left open. This was introduced in #1934
and #1936