### PR TITLE
use File.exist? not File.exists? as it's depricated

### DIFF
--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -143,7 +143,7 @@ module CarrierWave
     # [Boolean] Whether the file exists
     #
     def exists?
-      return File.exists?(self.path) if self.path
+      return File.exist?(self.path) if self.path
       return false
     end
 


### PR DESCRIPTION
in order to avoid annoying console deprecation output

```
/home/tomi/.rvm/gems/ruby-2.2.4@copy_carrierwave_file/gems/carrierwave-0.11.2/lib/carrierwave/sanitized_file.rb:146: warning: File.exists? is a deprecated name, use File.exist? instead
/home/tomi/.rvm/gems/ruby-2.2.4@copy_carrierwave_file/gems/carrierwave-0.11.2/lib/carrierwave/mount.rb:243: warning: instance variable @previous_model_for_file not initialized
/home/tomi/.rvm/gems/ruby-2.2.4@copy_carrierwave_file/gems/carrierwave-0.11.2/lib/carrierwave/sanitized_file.rb:146: warning: File.exists? is a deprecated name, use File.exist? instead
/home/tomi/.rvm/gems/ruby-2.2.4@copy_carrierwave_file/gems/carrierwave-0.11.2/lib/carrierwave/sanitized_file.rb:146: warning: File.exists? is a deprecated name, use File.exist? instead
```

gaaah ! :rage2:

e.g. in `ruby 2.2.4`