### PR TITLE
Headers for download by url

### DIFF
--- a/lib/carrierwave/mount.rb
+++ b/lib/carrierwave/mount.rb
@@ -166,6 +166,10 @@ module CarrierWave
           _mounter(:#{column}).remote_urls = [url]
         end
 
+        def remote_#{column}_request_header=(header)
+          _mounter(:#{column}).remote_request_headers = [header]
+        end
+
         def write_#{column}_identifier
           return if frozen?
           mounter = _mounter(:#{column})
@@ -314,6 +318,10 @@ module CarrierWave
 
         def remote_#{column}_urls=(urls)
           _mounter(:#{column}).remote_urls = urls
+        end
+
+        def remote_#{column}_request_headers=(headers)
+          _mounter(:#{column}).remote_request_headers = headers
         end
 
         def write_#{column}_identifier

--- a/lib/carrierwave/mounter.rb
+++ b/lib/carrierwave/mounter.rb
@@ -78,7 +78,7 @@ module CarrierWave
 
       @uploaders = urls.zip(remote_request_headers || []).map do |url, header|
         uploader = blank_uploader
-        uploader.download!(url, header)
+        uploader.download!(url, header || {})
         uploader
       end
 

--- a/lib/carrierwave/mounter.rb
+++ b/lib/carrierwave/mounter.rb
@@ -3,8 +3,9 @@ module CarrierWave
   # this is an internal class, used by CarrierWave::Mount so that
   # we don't pollute the model with a lot of methods.
   class Mounter #:nodoc:
-    attr_reader :column, :record, :remote_urls, :integrity_error, :processing_error, :download_error
-    attr_accessor :remove
+    attr_reader :column, :record, :remote_urls, :integrity_error,
+      :processing_error, :download_error
+    attr_accessor :remove, :remote_request_headers
 
     def initialize(record, column, options={})
       @record = record
@@ -75,9 +76,9 @@ module CarrierWave
       @download_error = nil
       @integrity_error = nil
 
-      @uploaders = urls.map do |url|
+      @uploaders = urls.zip(remote_request_headers || []).map do |url, header|
         uploader = blank_uploader
-        uploader.download!(url)
+        uploader.download!(url, header)
         uploader
       end
 

--- a/lib/carrierwave/uploader/download.rb
+++ b/lib/carrierwave/uploader/download.rb
@@ -37,7 +37,7 @@ module CarrierWave
         def file
           if @file.blank?
             headers = @remote_headers.
-              merge('User-Agent' => "CarrierWave/#{CarrierWave::VERSION}")
+              reverse_merge('User-Agent' => "CarrierWave/#{CarrierWave::VERSION}")
 
             @file = Kernel.open(@uri.to_s, headers)
             @file = @file.is_a?(String) ? StringIO.new(@file) : @file

--- a/lib/carrierwave/uploader/download.rb
+++ b/lib/carrierwave/uploader/download.rb
@@ -10,8 +10,9 @@ module CarrierWave
       include CarrierWave::Uploader::Cache
 
       class RemoteFile
-        def initialize(uri)
+        def initialize(uri, remote_headers = {})
           @uri = uri
+          @remote_headers = remote_headers
         end
 
         def original_filename
@@ -35,7 +36,10 @@ module CarrierWave
 
         def file
           if @file.blank?
-            @file = Kernel.open(@uri.to_s, "User-Agent" => "CarrierWave/#{CarrierWave::VERSION}")
+            headers = @remote_headers.
+              merge('User-Agent' => "CarrierWave/#{CarrierWave::VERSION}")
+
+            @file = Kernel.open(@uri.to_s, headers)
             @file = @file.is_a?(String) ? StringIO.new(@file) : @file
           end
           @file
@@ -62,10 +66,11 @@ module CarrierWave
       # === Parameters
       #
       # [url (String)] The URL where the remote file is stored
+      # [remote_headers (Hash)] Request headers
       #
-      def download!(uri)
+      def download!(uri, remote_headers = {})
         processed_uri = process_uri(uri)
-        file = RemoteFile.new(processed_uri)
+        file = RemoteFile.new(processed_uri, remote_headers)
         raise CarrierWave::DownloadError, "trying to download a file which is not served over HTTP" unless file.http?
         cache!(file)
       end

--- a/spec/mount_multiple_spec.rb
+++ b/spec/mount_multiple_spec.rb
@@ -863,7 +863,7 @@ describe CarrierWave::Mount do
 
     before do
       uploader.class_eval do
-        def download! uri
+        def download! uri, headers = {}
           raise CarrierWave::DownloadError
         end
       end

--- a/spec/mount_single_spec.rb
+++ b/spec/mount_single_spec.rb
@@ -740,7 +740,7 @@ describe CarrierWave::Mount do
 
     it "should raise an error if the image fails to be processed" do
       @uploader.class_eval do
-        def download! uri
+        def download! uri, headers = {}
           raise CarrierWave::DownloadError
         end
       end

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -488,7 +488,7 @@ describe CarrierWave::ActiveRecord do
       context 'when validating download' do
         before do
           @uploader.class_eval do
-            def download! file
+            def download! file, headers = {}
               raise CarrierWave::DownloadError
             end
           end
@@ -1209,7 +1209,7 @@ describe CarrierWave::ActiveRecord do
       context 'when validating download' do
         before do
           @uploader.class_eval do
-            def download! file
+            def download! file, headers = {}
               raise CarrierWave::DownloadError
             end
           end


### PR DESCRIPTION
Hi. I use CarrierWave in my project, where I need to download some images using authorization token in header. I haven't found support of sending custom headers in request, so I've implement it in this pull request.

Here is the example of usage:
```ruby
class Content
  extend CarrierWave::Mount
  mount_uploader :image, ImageUploader
end

c = Content.new
c.remote_image_request_header = {'Authorization' => 'Bearer QWERTY'}
c.remote_image_url = 'http://example.com/1.jpg'
```