### PR TITLE
Add MIT license badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ It works well with Rack based web applications, such as Ruby on Rails.
 
 [![Build Status](https://travis-ci.org/carrierwaveuploader/carrierwave.svg?branch=master)](http://travis-ci.org/carrierwaveuploader/carrierwave)
 [![Code Climate](http://img.shields.io/codeclimate/github/carrierwaveuploader/carrierwave.svg)](https://codeclimate.com/github/carrierwaveuploader/carrierwave)
+[![git.legal](https://git.legal/projects/1363/badge.svg "Number of libraries approved")](https://git.legal/projects/1363)
 
 
 > ## carrierwave version disclaimer


### PR DESCRIPTION
There aren't too many (non-dev/non-test) dependencies in Carrierwave, but I still I ran a scan for compatibility with MIT and all the included gems check out as compatible.

The badge here gives a quick indicator that the license is MIT, and that the libraries used are compliant with that.
