### PR TITLE
Add Rails 5.0 stable gemfile for testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ gemfile:
   - gemfiles/rails-4-0-stable.gemfile
   - gemfiles/rails-4-1-stable.gemfile
   - gemfiles/rails-4-2-stable.gemfile
+  - gemfiles/rails-5-0-stable.gemfile
   - gemfiles/rails-master.gemfile
 
 sudo: false
@@ -37,10 +38,16 @@ matrix:
       gemfile: Gemfile
     - rvm: 2.1
       gemfile: gemfiles/rails-master.gemfile
+    - rvm: 2.0
+      gemfile: gemfiles/rails-5-0-stable.gemfile
+    - rvm: 2.1
+      gemfile: gemfiles/rails-5-0-stable.gemfile
     - rvm: jruby
       gemfile: Gemfile
     - rvm: jruby
       gemfile: gemfiles/rails-master.gemfile
+    - rvm: jruby
+      gemfile: gemfiles/rails-5-0-stable.gemfile
     - rvm: jruby-head
       gemfile: gemfiles/rails-master.gemfile
   allow_failures:

--- a/gemfiles/rails-5-0-stable.gemfile
+++ b/gemfiles/rails-5-0-stable.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "rails", :github => "rails/rails", :branch => "5-0-stable"
+gem "activemodel-serializers-xml"
+
+gemspec :path => "../"


### PR DESCRIPTION
Fixes #2021.

Currently only Rails master is tested, which is now the development version of 5.1. This adds 5.0 to the test matrix.