### PR TITLE
Fixed bug with the difference of key format between generate_cache_id and clean_cache!

### DIFF
--- a/lib/carrierwave/storage/file.rb
+++ b/lib/carrierwave/storage/file.rb
@@ -106,7 +106,8 @@ module CarrierWave
 
       def clean_cache!(seconds)
         Dir.glob(::File.expand_path(::File.join(uploader.cache_dir, '*'), CarrierWave.root)).each do |dir|
-          time = dir.scan(/(\d+)-\d+-\d+$/).first.map(&:to_i)
+          # generate_cache_id returns key formated TIMEINT-PID-COUNTER-RND
+          time = dir.scan(/(\d+)-\d+-\d+-\d+/).first.map(&:to_i)
           time = Time.at(*time)
           if time < (Time.now.utc - seconds)
             FileUtils.rm_rf(dir)

--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -136,7 +136,8 @@ module CarrierWave
           :key    => uploader.fog_directory,
           :public => uploader.fog_public
         ).files.all(:prefix => uploader.cache_dir).each do |file|
-          time = file.key.scan(/(\d+)-\d+-\d+/).first.map { |t| t.to_i }
+          # generate_cache_id returns key formated TIMEINT-PID-COUNTER-RND
+          time = file.key.scan(/(\d+)-\d+-\d+-\d+/).first.map { |t| t.to_i }
           time = Time.at(*time)
           file.destroy if time < (Time.now.utc - seconds)
         end

--- a/spec/storage/file_spec.rb
+++ b/spec/storage/file_spec.rb
@@ -54,9 +54,9 @@ describe CarrierWave::Storage::File do
     let(:cache_dir) { File.expand_path(uploader_class.cache_dir, CarrierWave.root) }
 
     before do
-      FileUtils.mkdir_p File.expand_path("#{five_days_ago_int}-234-2213", cache_dir)
-      FileUtils.mkdir_p File.expand_path("#{three_days_ago_int}-234-2213", cache_dir)
-      FileUtils.mkdir_p File.expand_path("#{yesterday_int}-234-2213", cache_dir)
+      FileUtils.mkdir_p File.expand_path("#{five_days_ago_int}-234-1234-2213", cache_dir)
+      FileUtils.mkdir_p File.expand_path("#{three_days_ago_int}-234-1234-2213", cache_dir)
+      FileUtils.mkdir_p File.expand_path("#{yesterday_int}-234-1234-2213", cache_dir)
     end
 
     after { FileUtils.rm_rf(cache_dir) }

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -268,7 +268,7 @@ end
           yesterday_int      = now - 21600
 
           [five_days_ago_int, three_days_ago_int, yesterday_int].each do |as_of|
-            @directory.files.create(:key => "uploads/tmp/#{as_of}-234-2213/test.jpg", :body => 'A test, 1234', :public => true)
+            @directory.files.create(:key => "uploads/tmp/#{as_of}-234-1234-2213/test.jpg", :body => 'A test, 1234', :public => true)
           end
         end
 

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -258,39 +258,49 @@ end
       end
 
       describe '#clean_cache!' do
-        let(:now){ Time.now.to_i }
+        let(:today) { '2016/10/09 10:00:00'.to_time }
+        let(:five_days_ago) { today.ago(5.days) }
+        let(:three_days_ago) { today.ago(3.days) }
+        let(:yesterday) { today.yesterday }
         before do
           # clean up
           @directory.files.each{|file| file.destroy }
           # We can't use simple time freezing because of AWS request time check
-          five_days_ago_int  = now - 367270
-          three_days_ago_int = now - 194400
-          yesterday_int      = now - 21600
-
-          [five_days_ago_int, three_days_ago_int, yesterday_int].each do |as_of|
-            @directory.files.create(:key => "uploads/tmp/#{as_of}-234-1234-2213/test.jpg", :body => 'A test, 1234', :public => true)
+          [five_days_ago, three_days_ago, yesterday, (today - 1.minute)].each do |created_date|
+            key = nil
+            Timecop.freeze created_date do
+              key = "uploads/tmp/#{CarrierWave.generate_cache_id}/test.jpg"
+            end
+            @directory.files.create(:key => key, :body => 'A test, 1234', :public => true)
           end
+        end
+
+        it "should clear all files older than now in the default cache directory" do
+          Timecop.freeze(today) do
+            @uploader.clean_cached_files!(0)
+          end
+          expect(@directory.files.all(:prefix => 'uploads/tmp').size).to eq(0)
         end
 
         it "should clear all files older than, by defaul, 24 hours in the default cache directory" do
-          Timecop.freeze(Time.at(now)) do
+          Timecop.freeze(today) do
             @uploader.clean_cached_files!
-          end
-          expect(@directory.files.all(:prefix => 'uploads/tmp').size).to eq(1)
-        end
-
-        it "should permit to set since how many seconds delete the cached files" do
-          Timecop.freeze(Time.at(now)) do
-            @uploader.clean_cached_files!(60*60*24*4)
           end
           expect(@directory.files.all(:prefix => 'uploads/tmp').size).to eq(2)
         end
 
+        it "should permit to set since how many seconds delete the cached files" do
+          Timecop.freeze(today) do
+            @uploader.clean_cached_files!(4.days)
+          end
+          expect(@directory.files.all(:prefix => 'uploads/tmp').size).to eq(3)
+        end
+
         it "should be aliased on the CarrierWave module" do
-          Timecop.freeze(Time.at(now)) do
+          Timecop.freeze(today) do
             CarrierWave.clean_cached_files!
           end
-          expect(@directory.files.all(:prefix => 'uploads/tmp').size).to eq(1)
+          expect(@directory.files.all(:prefix => 'uploads/tmp').size).to eq(2)
         end
       end
 


### PR DESCRIPTION
Hello, I found bug in `clean_cache!` method.

`CarrierWave::Storage::File.clean_cache!` always cleans all file caches before expired.

Because `CarrierWave::Storage::File.clean_cache!` doesn't refer TIMEINT but PID.
`CarrierWave::Uploader::Cache.generate_cache_id` returns key format like "TIMEINT-PID-COUNTER-RND".
It should refer 1st element(TIMEINT).
But `CarrierWave::Storage::File.clean_cache!` try match `/(\d+)-\d+-\d+$/` .
So it matched 2nd element(PID) which shows the time when cache directory created.
And `Time.at(*time)` always returns like `1970/mm/dd`, then cache directory is all expired.
