### PR TITLE
Avoids a GET for Google Cloud storage public_urls

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -355,8 +355,8 @@ module CarrierWave
                 end
               end
             when 'Google'
-              file = directory.files.get(encoded_path)
-              file.nil?? "" : file.public_url
+              # https://cloud.google.com/storage/docs/access-public-data
+              "https://storage.googleapis.com/#{@uploader.fog_directory}/#{encoded_path}"
             else
               # avoid a get by just using local reference
               directory.files.new(:key => path).public_url

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -111,6 +111,13 @@ end
               expect(@fog_file.public_url).to start_with 'http://'
             end
           end
+
+          it "should use the google public url if available" do
+            if @provider == 'Google'
+              allow(@uploader).to receive(:fog_directory).and_return('SiteAssets')
+              expect(@fog_file.public_url).to include('https://storage.googleapis.com/SiteAssets')
+            end
+          end
         end
 
         context "with asset_host" do


### PR DESCRIPTION
Hiya!

As I understand it, the `public_url` method on the Storage class is intended to return a URL without requiring a GET to the backend. At the moment this is how it works for AWS, but for Google Storage the `directory.files.get` call will make an HTTP request.

I've modified this to use the public access URL as [per Google's documentation](https://cloud.google.com/storage/docs/access-public-data). 

I've also added a very simple spec that's similar to the AWS-specific ones. 

Hope this is helpful!

Nik