### PR TITLE
Add support for callbacks on :proccess

### DIFF
--- a/lib/carrierwave/uploader/processing.rb
+++ b/lib/carrierwave/uploader/processing.rb
@@ -71,15 +71,17 @@ module CarrierWave
       def process!(new_file=nil)
         return unless enable_processing
 
-        self.class.processors.each do |method, args, condition|
-          if(condition)
-            if condition.respond_to?(:call)
-              next unless condition.call(self, :args => args, :method => method, :file => new_file)
-            else
-              next unless self.send(condition, new_file)
+        with_callbacks(:process, new_file) do
+          self.class.processors.each do |method, args, condition|
+            if(condition)
+              if condition.respond_to?(:call)
+                next unless condition.call(self, :args => args, :method => method, :file => new_file)
+              else
+                next unless self.send(condition, new_file)
+              end
             end
+            self.send(method, *args)
           end
-          self.send(method, *args)
         end
       end
 


### PR DESCRIPTION
This PR adds support to running callbacks before and after proccessing a file. The original motivation was to help adding another mitigation tool for exploits that haunt ImageMagick, like this one: https://www.exploit-db.com/exploits/39767/

Some help to writing proper tests would be appreciated, but no other callbacks are tested specifically, and it was tested manually.
