### PR TITLE
attempt to solve the negative_failure_message rspec warnings

### DIFF
--- a/lib/carrierwave/test/matchers.rb
+++ b/lib/carrierwave/test/matchers.rb
@@ -23,9 +23,10 @@ module CarrierWave
           "expected #{@actual.inspect} to be identical to #{@expected.inspect}"
         end
 
-        def negative_failure_message
+        def failure_message_when_negated
           "expected #{@actual.inspect} to not be identical to #{@expected.inspect}"
         end
+        alias negative_failure_message failure_message_when_negated
 
         def description
           "be identical to #{@expected.inspect}"
@@ -51,9 +52,10 @@ module CarrierWave
           "expected #{@actual.current_path.inspect} to have permissions #{@expected.to_s(8)}, but they were #{(File.stat(@actual.path).mode & 0777).to_s(8)}"
         end
 
-        def negative_failure_message
+        def failure_message_when_negated
           "expected #{@actual.current_path.inspect} not to have permissions #{@expected.to_s(8)}, but it did"
         end
+        alias negative_failure_message failure_message_when_negated
 
         def description
           "have permissions #{@expected.to_s(8)}"
@@ -79,9 +81,10 @@ module CarrierWave
           "expected #{File.dirname @actual.current_path.inspect} to have permissions #{@expected.to_s(8)}, but they were #{(File.stat(@actual.path).mode & 0777).to_s(8)}"
         end
 
-        def negative_failure_message
+        def failure_message_when_negated
           "expected #{File.dirname @actual.current_path.inspect} not to have permissions #{@expected.to_s(8)}, but it did"
         end
+        alias negative_failure_message failure_message_when_negated
 
         def description
           "have permissions #{@expected.to_s(8)}"
@@ -110,9 +113,10 @@ module CarrierWave
           "expected #{@actual.current_path.inspect} to be no larger than #{@width} by #{@height}, but it was #{@actual_width} by #{@actual_height}."
         end
 
-        def negative_failure_message
+        def failure_message_when_negated
           "expected #{@actual.current_path.inspect} to be larger than #{@width} by #{@height}, but it wasn't."
         end
+        alias negative_failure_message failure_message_when_negated
 
         def description
           "be no larger than #{@width} by #{@height}"
@@ -141,9 +145,10 @@ module CarrierWave
           "expected #{@actual.current_path.inspect} to have an exact size of #{@width} by #{@height}, but it was #{@actual_width} by #{@actual_height}."
         end
 
-        def negative_failure_message
+        def failure_message_when_negated
           "expected #{@actual.current_path.inspect} not to have an exact size of #{@width} by #{@height}, but it did."
         end
+        alias negative_failure_message failure_message_when_negated
 
         def description
           "have an exact size of #{@width} by #{@height}"
@@ -171,9 +176,10 @@ module CarrierWave
           "expected #{@actual.current_path.inspect} to have an exact size of #{@height}, but it was #{@actual_height}."
         end
 
-        def negative_failure_message
+        def failure_message_when_negated
           "expected #{@actual.current_path.inspect} not to have an exact size of #{@height}, but it did."
         end
+        alias negative_failure_message failure_message_when_negated
 
         def description
           "have an exact height of #{@height}"
@@ -201,9 +207,10 @@ module CarrierWave
           "expected #{@actual.current_path.inspect} to have an exact size of #{@width}, but it was #{@actual_width}."
         end
 
-        def negative_failure_message
+        def failure_message_when_negated
           "expected #{@actual.current_path.inspect} not to have an exact size of #{@width}, but it did."
         end
+        alias negative_failure_message failure_message_when_negated
 
         def description
           "have an exact width of #{@width}"
@@ -231,9 +238,10 @@ module CarrierWave
           "expected #{@actual.current_path.inspect} to be no wider than #{@width}, but it was #{@actual_width}."
         end
 
-        def negative_failure_message
+        def failure_message_when_negated
           "expected #{@actual.current_path.inspect} not to be wider than #{@width}, but it is."
         end
+        alias negative_failure_message failure_message_when_negated
 
         def description
           "have a width less than or equal to #{@width}"
@@ -261,9 +269,10 @@ module CarrierWave
           "expected #{@actual.current_path.inspect} to be no taller than #{@height}, but it was #{@actual_height}."
         end
 
-        def negative_failure_message
+        def failure_message_when_negated
           "expected #{@actual.current_path.inspect} not to be taller than #{@height}, but it is."
         end
+        alias negative_failure_message failure_message_when_negated
 
         def description
           "have a height less than or equal to #{@height}"


### PR DESCRIPTION
(over v0.11.2 while keeping the negative_failure_message method available for older builds)