### PR TITLE
Don't error if updated record

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -234,7 +234,7 @@ module CarrierWave
         # [Integer] size of file body
         #
         def size
-          file.content_length
+          file.nil? ? 0 : file.content_length
         end
 
         ##


### PR DESCRIPTION
Fixes issue here: http://stackoverflow.com/questions/21853367/undefined-method-content-length-for-nilnilclass-fog-storage-carrierwave

```
undefined method `content_length' for nil:NilClass
```