### PR TITLE
mini_magick_image now reads file stream

### DIFF
--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -317,11 +317,7 @@ module CarrierWave
       end
 
       def mini_magick_image
-        if url
-          ::MiniMagick::Image.open(url)
-        else
-          ::MiniMagick::Image.open(current_path)
-        end
+        ::MiniMagick::Image.read(file.read)
       end
 
   end # MiniMagick


### PR DESCRIPTION
This fixes not being able to read temporary files during processing a remote file.

Steps to reproduce:

```ruby
class Model < ActiveRecord::Base
  mount_uploader :file, FileUploader
end

class FileUploader < CarrierWave::Uploader::Base
  include CarrierWave::MiniMagick

  process :save_dimensions

  def save_dimensions
    model.file_width = width
    model.file_height = height
  end
end

@model.update_attributes(remote_file_url: 'http://www.example.com/image.png')
# => Errno::ENOENT: No such file or directory @ rb_sysopen - /uploads/tmp/path_to/image.png
```