### PR TITLE
Optimization: avoid calling `file.url` twice.

### DIFF
--- a/lib/carrierwave/uploader/url.rb
+++ b/lib/carrierwave/uploader/url.rb
@@ -15,8 +15,8 @@ module CarrierWave
       # [String] the location where this file is accessible via a url
       #
       def url(options = {})
-        if file.respond_to?(:url) and not file.url.blank?
-          file.method(:url).arity == 0 ? file.url : file.url(options)
+        if file.respond_to?(:url) and not (tmp_url = file.url).blank?
+          file.method(:url).arity == 0 ? tmp_url : file.url(options)
         elsif file.respond_to?(:path)
           path = encode_path(file.path.sub(File.expand_path(root), ''))
 


### PR DESCRIPTION
Since `file.url` does somewhat costly operations, we should avoid calling it twice. More aggressive caching may be possible, but this is an easy and straightforward win.