### PR TITLE
Update README: remove version specifier for fog

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,7 +570,7 @@ Processing can be enabled for a single version by setting the processing flag on
 [Fog](http://github.com/fog/fog) is used to support Amazon S3. Ensure you have it in your Gemfile:
 
 ```ruby
-gem "fog", "~> 1.3.1"
+gem "fog"
 ```
 
 You'll need to provide your fog_credentials and a fog_directory (also known as a bucket) in an initializer.


### PR DESCRIPTION
With fog "\~> 1.3.1", there is compatible versions issue for nokogiri if using capybara (2.11.0), fog (\~> 1.3.1) and rails (>= 5.0.0.1, \~> 5.0.0) with `bundler`.

Exemple after a `bundle install`:
```
Bundler could not find compatible versions for gem "nokogiri":
  In Gemfile:
    capybara was resolved to 2.11.0, which depends on
      nokogiri (>= 1.3.3)

    fog (~> 1.3.1) was resolved to 1.3.1, which depends on
      nokogiri (~> 1.5.0)

    rails (>= 5.0.0.1, ~> 5.0.0) was resolved to 5.0.0.1, which depends on
      actionpack (= 5.0.0.1) was resolved to 5.0.0.1, which depends on
        rails-dom-testing (~> 2.0) was resolved to 2.0.0, which depends on
          nokogiri (~> 1.6.0)

    capybara was resolved to 2.11.0, which depends on
      xpath (~> 2.0) was resolved to 2.0.0, which depends on
        nokogiri (~> 1.3)
```

My `Gemfile`: https://gist.github.com/jonathanpa/aed3e5ca80114f7376e6f8c73064eb25
My `Gemfile.lock`: https://gist.github.com/jonathanpa/4a0708002fdd65e9634c4fc545ab487e