### PR TITLE
Fixing #1977 Invalid locale in CarrierWave::MiniMagick#manipulate!

### DIFF
--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -303,8 +303,7 @@ module CarrierWave
         image.destroy!
       end
     rescue ::MiniMagick::Error, ::MiniMagick::Invalid => e
-      default = I18n.translate(:"errors.messages.mini_magick_processing_error", :e => e, :locale => :en)
-      message = I18n.translate(:"errors.messages.mini_magick_processing_error", :e => e, :default => default)
+      message = I18n.translate(:"errors.messages.mini_magick_processing_error", :e => e)
       raise CarrierWave::ProcessingError, message
     end
 

--- a/lib/carrierwave/processing/rmagick.rb
+++ b/lib/carrierwave/processing/rmagick.rb
@@ -355,7 +355,7 @@ module CarrierWave
 
       destroy_image(frames)
     rescue ::Magick::ImageMagickError => e
-      raise CarrierWave::ProcessingError, I18n.translate(:"errors.messages.rmagick_processing_error", :e => e, :default => I18n.translate(:"errors.messages.rmagick_processing_error", :e => e, :locale => :en))
+      raise CarrierWave::ProcessingError, I18n.translate(:"errors.messages.rmagick_processing_error", :e => e)
     end
 
   private

--- a/spec/processing/mini_magick_spec.rb
+++ b/spec/processing/mini_magick_spec.rb
@@ -205,6 +205,14 @@ describe CarrierWave::MiniMagick do
           expect { instance.resize_to_limit(200, 200) }.to raise_exception( CarrierWave::ProcessingError )
         end
       end
+
+      context ":en locale is not available and enforce_available_locales is true" do
+        it "doesn't suppress errors" do
+          change_and_enforece_available_locales(:nl, [:nl, :foo]) do
+            expect { instance.resize_to_limit(200, 200) }.to raise_exception(CarrierWave::ProcessingError)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/processing/rmagick_spec.rb
+++ b/spec/processing/rmagick_spec.rb
@@ -245,6 +245,14 @@ describe CarrierWave::RMagick, :rmagick => true do
           expect { instance.resize_to_limit(200, 200) }.to raise_exception( CarrierWave::ProcessingError )
         end
       end
+
+      context ":en locale is not available and enforce_available_locales is true" do
+        it "doesn't suppress errors" do
+          change_and_enforece_available_locales(:nl, [:nl, :foo]) do
+            expect { instance.resize_to_limit(200, 200) }.to raise_exception(CarrierWave::ProcessingError)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -82,6 +82,22 @@ module CarrierWave
           I18n.locale = current_locale
         end
       end
+
+      def change_and_enforece_available_locales(locale, available_locales, &block)
+        current_available_locales = I18n.available_locales
+        current_enforce_available_locales_value = I18n.enforce_available_locales
+        current_locale = I18n.locale
+        begin
+          I18n.available_locales = [:nl]
+          I18n.enforce_available_locales = true
+          I18n.locale = :nl
+          yield
+        ensure
+          I18n.available_locales = current_available_locales
+          I18n.enforce_available_locales = current_enforce_available_locales_value
+          I18n.locale = current_locale
+        end
+      end
     end
 
     module ManipulationHelpers


### PR DESCRIPTION
Fixing #1977 Invalid locale in CarrierWave::MiniMagick#manipulate!

Since ([commit on May 9, 2014](https://github.com/svenfuchs/i18n/commit/b5703d7431ecfc1b99409e16c6590448570718ac)) enforce_available_locales in I18n is true by default, the aproach which implies on default error messages from `:en` locale is broked for all apps where `:en` is not available locale. It's very suddenly when image processing raise `I18n::InvalidLocale` error.

In this pull request I propose to remove the "default fallback" and let carrierwave users decide themselves how to deal with missed locales and/or translations.
