### PR TITLE
Fix args of `default_url` in templates

### DIFF
--- a/lib/generators/templates/uploader.rb
+++ b/lib/generators/templates/uploader.rb
@@ -15,7 +15,7 @@ class <%= class_name %>Uploader < CarrierWave::Uploader::Base
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:
-  # def default_url
+  # def default_url(*args)
   #   # For Rails 3.1+ asset pipeline compatibility:
   #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
   #


### PR DESCRIPTION
README says `def default_url(*args)` instead of `def default_url`