### PR TITLE
Fixing #1889 Cache ID should not fail from negative time stamp

### DIFF
--- a/lib/carrierwave/uploader/cache.rb
+++ b/lib/carrierwave/uploader/cache.rb
@@ -190,7 +190,7 @@ module CarrierWave
       def cache_id=(cache_id)
         # Earlier version used 3 part cache_id. Thus we should allow for
         # the cache_id to have both 3 part and 4 part formats.
-        raise CarrierWave::InvalidParameter, "invalid cache id" unless cache_id =~ /\A[\d]+\-[\d]+(\-[\d]{4})?\-[\d]{4}\z/
+        raise CarrierWave::InvalidParameter, "invalid cache id" unless cache_id =~ /\A(-)?[\d]+\-[\d]+(\-[\d]{4})?\-[\d]{4}\z/
         @cache_id = cache_id
       end
 

--- a/spec/uploader/cache_spec.rb
+++ b/spec/uploader/cache_spec.rb
@@ -112,6 +112,21 @@ describe CarrierWave::Uploader do
       it "does nothing when trying to cache an empty file" do
         uploader.cache!(nil)
       end
+
+
+      context 'negative cache id' do
+        let(:cache_id) { '-1369894322-345-1234-2255' }
+
+        before do
+          allow(CarrierWave).to receive(:generate_cache_id).and_return(cache_id)
+        end
+
+        it "doesn't raise an error when caching" do
+          expect(running {
+                   uploader.cache!(test_file)
+          }).not_to raise_error
+        end
+      end
     end
 
     describe "with the move_to_cache option" do


### PR DESCRIPTION
Fix for #1889 adjusted regex to allow for negative time stamps.