### PR TITLE
Allow non-argument options to be passed in mini magick combine_options

### DIFF
--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -312,7 +312,11 @@ module CarrierWave
 
       def append_combine_options(cmd, combine_options)
         combine_options.each do |method, options|
-          cmd.send(method, options)
+          if options.nil?
+            cmd.send(method)
+          else
+            cmd.send(method, options)
+          end
         end
       end
 

--- a/spec/processing/mini_magick_spec.rb
+++ b/spec/processing/mini_magick_spec.rb
@@ -117,6 +117,15 @@ describe CarrierWave::MiniMagick do
       expect(instance).to have_dimensions(1000, 1000)
       expect(::MiniMagick::Tool::Identify.new.verbose(instance.current_path).call).to include('Quality: 70')
     end
+
+    it 'accepts non-argument option as combine_options' do
+      expect(::MiniMagick::Tool::Identify.new.verbose(instance.current_path).call).to include('exif:ColorSpace: 1')
+
+      instance.resize_and_pad(1000, 1000, combine_options: {strip: nil})
+
+      expect(instance).to have_dimensions(1000, 1000)
+      expect(::MiniMagick::Tool::Identify.new.verbose(instance.current_path).call).to_not include('exif:ColorSpace: 1')
+    end
   end
 
   describe '#resize_to_fit' do


### PR DESCRIPTION
When a non-argument option is passed to mini magick processing using combine_options, the processing fails.

For example:

```
resize_to_fill(320, 320, combine_options: {strip: nil})
```

generates this command:

```
mogrify -resize 320 -gravity Center -background rgba(255,255,255,0.0) -strip  /var/folders/1_/tdx0fnfx32g1hqv94s3ttkw00000gn/T/mini_magick20170113-86521-eezfq7.jpg
```

But processing is failing with mini_magick_processing_error. Changing `strip: nil` to `strip: ""` (empty string) also did not solve the problem.

The only way I can get it to work is by changing the [append_combine_options](https://github.com/carrierwaveuploader/carrierwave/blob/master/lib/carrierwave/processing/mini_magick.rb#L313) method to invoke the method without any arguments if nil options is passed:

```
def append_combine_options(cmd, combine_options)
    combine_options.each do |method, options|
        if options.nil?
            cmd.send(method)
        else
            cmd.send(method, options)
        end
    end
end
```