### PR TITLE
Added fog_aws_accelerate options for fog storage provider

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -16,6 +16,8 @@ module CarrierWave
     # [:fog_authenticated_url_expiration] (optional) time (in seconds) that authenticated urls
     #   will be valid, when fog_public is false and provider is AWS or Google, defaults to 600
     # [:fog_use_ssl_for_aws]              (optional) #public_url will use https for the AWS generated URL]
+    # [:fog_aws_accelerate]               (optional) #public_url will use s3-accelerate subdomain
+    #   instead of s3, defaults to false
     #
     #
     # AWS credentials contain the following keys:
@@ -349,7 +351,8 @@ module CarrierWave
                 protocol = @uploader.fog_use_ssl_for_aws ? "https" : "http"
                 # if directory is a valid subdomain, use that style for access
                 if @uploader.fog_directory.to_s =~ /^(?:[a-z]|\d(?!\d{0,2}(?:\d{1,3}){3}$))(?:[a-z0-9\.]|(?![\-])|\-(?![\.])){1,61}[a-z0-9]$/
-                  "#{protocol}://#{@uploader.fog_directory}.s3.amazonaws.com/#{encoded_path}"
+                  s3_subdomain = @uploader.fog_aws_accelerate ? "s3-accelerate" : "s3"
+                  "#{protocol}://#{@uploader.fog_directory}.#{s3_subdomain}.amazonaws.com/#{encoded_path}"
                 else
                   # directory is not a valid subdomain, so use path style for access
                   "#{protocol}://s3.amazonaws.com/#{@uploader.fog_directory}/#{encoded_path}"

--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -30,6 +30,7 @@ module CarrierWave
         add_config :fog_public
         add_config :fog_authenticated_url_expiration
         add_config :fog_use_ssl_for_aws
+        add_config :fog_aws_accelerate
 
         # Mounting
         add_config :ignore_integrity_errors
@@ -177,6 +178,7 @@ module CarrierWave
             config.fog_public = true
             config.fog_authenticated_url_expiration = 600
             config.fog_use_ssl_for_aws = true
+            config.fog_aws_accelerate = false
             config.store_dir = 'uploads'
             config.cache_dir = 'uploads/tmp'
             config.delete_tmp_file_after_storage = true
@@ -200,4 +202,3 @@ module CarrierWave
     end
   end
 end
-

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -85,10 +85,22 @@ end
             end
           end
 
-          it "should use a subdomain URL for AWS if the directory is a valid subdomain" do
-            if @provider == 'AWS'
+          context "directory is a valid subdomain" do
+            before do
               allow(@uploader).to receive(:fog_directory).and_return('assets.site.com')
-              expect(@fog_file.public_url).to include('https://assets.site.com.s3.amazonaws.com')
+            end
+
+            it "should use a subdomain URL for AWS" do
+              if @provider == 'AWS'
+                expect(@fog_file.public_url).to include('https://assets.site.com.s3.amazonaws.com')
+              end
+            end
+
+            it "should use accelerate domain if fog_aws_accelerate is true" do
+              if @provider == 'AWS'
+                allow(@uploader).to receive(:fog_aws_accelerate).and_return(true)
+                expect(@fog_file.public_url).to include('https://assets.site.com.s3-accelerate.amazonaws.com')
+              end
             end
           end
 


### PR DESCRIPTION
AWS S3 supports accelerated file transfers to and from S3.
[Transfer Acceleration](http://amzn.to/2jQmpAX)

This introduces ability to configure Carrierwave to return
accelerated public urls since Carrierwave constructs them
by itself for speed concerns.

To enable this feauture you need to set fog_aws_accelerate
to true. It is false by default.

Changes added:

* fog_aws_accelerate added to fog aws configuration options
* corresponding specs updated
* corresponding docs updated