### PR TITLE
Allow carrierwave to do safe or all redirections based on configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,9 @@ spec/test.log
 spec/tmp
 *.swp
 .rvmrc
+.ruby-version
 .idea
 .bundle
 Gemfile.lock
 gemfiles/*.lock
+

--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -42,4 +42,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "timecop", "0.7.1"
   s.add_development_dependency "generator_spec", ">= 0.9.1"
   s.add_development_dependency "pry"
+  s.add_development_dependency "open_uri_redirections"
 end

--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -37,6 +37,7 @@ module CarrierWave
         add_config :ignore_download_errors
         add_config :validate_integrity
         add_config :validate_processing
+        add_config :allow_download_redirections
         add_config :validate_download
         add_config :mount_on
         add_config :cache_only
@@ -156,6 +157,15 @@ module CarrierWave
 
         def configure
           yield self
+
+          if allow_download_redirections
+            unless %w(all safe).include?(allow_download_redirections.to_s)
+              raise ArgumentError,
+                    "Unsupported option for allow_download_redirections: #{allow_download_redirections}"
+            end
+
+            require "open_uri_redirections"
+          end
         end
 
         ##
@@ -188,6 +198,7 @@ module CarrierWave
             config.ignore_download_errors = true
             config.validate_integrity = true
             config.validate_processing = true
+            config.allow_download_redirections = false
             config.validate_download = true
             config.root = lambda { CarrierWave.root }
             config.base_path = CarrierWave.base_path
@@ -200,4 +211,3 @@ module CarrierWave
     end
   end
 end
-

--- a/lib/carrierwave/uploader/download.rb
+++ b/lib/carrierwave/uploader/download.rb
@@ -32,14 +32,14 @@ module CarrierWave
           @uri.scheme =~ /^https?$/
         end
 
-      private
+        private
 
         def file
           if @file.blank?
             headers = @remote_headers.
               reverse_merge('User-Agent' => "CarrierWave/#{CarrierWave::VERSION}")
 
-            @file = Kernel.open(@uri.to_s, headers)
+            @file = open_remote_file(@uri.to_s, headers)
             @file = @file.is_a?(String) ? StringIO.new(@file) : @file
           end
           @file
@@ -57,6 +57,13 @@ module CarrierWave
 
         def method_missing(*args, &block)
           file.send(*args, &block)
+        end
+
+        def open_remote_file(uri, headers)
+          allow_download_redirections = CarrierWave::Uploader::Base.allow_download_redirections
+          return Kernel.open(uri, headers) unless allow_download_redirections
+
+          Kernel.open(uri, headers.merge(allow_redirections: allow_download_redirections.to_sym))
         end
       end
 

--- a/spec/uploader/configuration_spec.rb
+++ b/spec/uploader/configuration_spec.rb
@@ -13,6 +13,30 @@ describe CarrierWave do
     it "proxies to Uploader configuration" do
       expect(CarrierWave::Uploader::Base.test_config).to eq('foo')
     end
+
+    context "with allow_download_redirections option set" do
+      def configure_with_allow_download_redirections(value)
+        CarrierWave.configure { |config| config.allow_download_redirections = value }
+      end
+
+      context "for existing redirection option" do
+        it "does not raise error" do
+          expect { configure_with_allow_download_redirections(:all) }
+            .not_to raise_error
+        end
+      end
+
+      context "for non existing redirection option" do
+        it "raises an error" do
+          expect { configure_with_allow_download_redirections(:non_existing) }
+            .to raise_error(ArgumentError, /Unsupported option for allow_download_redirections: non_existing/)
+        end
+      end
+
+      after do
+        CarrierWave.configure { |config| config.allow_download_redirections = false }
+      end
+    end
   end
 end
 


### PR DESCRIPTION
I see plenty of historical issues to implement this and the best approach I see is [this PR](https://github.com/carrierwaveuploader/carrierwave/pull/2051) which seems to be opened in 2015. 

I've implemented my idea of option about download safety, so if you like it you can merge.

All the best from snowy Bulgaria folks! Keep doing such good work 😄 
