### PR TITLE
Allow read to accept bytes as parameter

### DIFF
--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -156,14 +156,14 @@ module CarrierWave
     #
     # [String] contents of the file
     #
-    def read
+    def read(bytes = nil)
       if @content
         @content
       elsif is_path?
-        File.open(@file, "rb") {|file| file.read}
+        File.open(@file, "rb") { |file| file.read(bytes) }
       else
         @file.try(:rewind)
-        @content = @file.read
+        @content = @file.read(bytes)
         @file.try(:close) unless @file.try(:closed?)
         @content
       end

--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -273,7 +273,7 @@ module CarrierWave
         # === Returns
         #
         # [String] contents of file
-        def read
+        def read(bytes = nil)
           file.body
         end
 

--- a/lib/carrierwave/uploader/proxy.rb
+++ b/lib/carrierwave/uploader/proxy.rb
@@ -40,8 +40,8 @@ module CarrierWave
       #
       # [String] contents of the file
       #
-      def read
-        file.try(:read)
+      def read(bytes = nil)
+        file.try(:read, bytes)
       end
 
       ##

--- a/spec/uploader/proxy_spec.rb
+++ b/spec/uploader/proxy_spec.rb
@@ -36,6 +36,13 @@ describe CarrierWave::Uploader do
       it { is_expected.to be nil }
     end
 
+    context "when reading chunks of bytes" do
+      before { uploader.cache!(test_file) }
+      subject { uploader.read(1) }
+
+      it { is_expected.to eq("t") }
+    end
+
     context "when file is cached" do
       before { uploader.cache!(test_file) }
 


### PR DESCRIPTION
Technically you should be able to call #read(bytes) with IO objects for
things like Zlib::GzipReader etc since they are chunked.

I have been able to do that with files that are locally although I doubt
that it would ever work with Fog just how it's built. This at least gets
over the issue I found related to the following code snippet.

```ruby
page = Page.first
page.carrierwave_obj = File.open('./file.gz', 'rb')
page.save!

Zlib::GzipReader.new(page.carrierwave_obj)
```

Thanks for reading this. Please let me know if there's anything else I can do to assist with this.