### PR TITLE
Fix content type being reset when using file cache storage

### DIFF
--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -186,9 +186,9 @@ module CarrierWave
       move!(new_path)
       chmod!(new_path, permissions)
       if keep_filename
-        self.file = {:tempfile => new_path, :filename => original_filename}
+        self.file = {:tempfile => new_path, :filename => original_filename, :content_type => content_type}
       else
-        self.file = new_path
+        self.file = {:tempfile => new_path, :content_type => content_type}
       end
       self
     end

--- a/spec/sanitized_file_spec.rb
+++ b/spec/sanitized_file_spec.rb
@@ -307,6 +307,13 @@ describe CarrierWave::SanitizedFile do
       it "should return itself" do
         expect(sanitized_file.move_to(file_path("gurr.png"))).to eq(sanitized_file)
       end
+
+      it "should preserve the file's content type" do
+        content_type = sanitized_file.content_type
+        sanitized_file.move_to(file_path("new_dir","gurr.png"))
+
+        expect(sanitized_file.content_type).to eq(content_type)
+      end
     end
 
     describe "#copy_to" do

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -64,8 +64,8 @@ end
         end
 
         it "should have a content_type" do
-          expect(@fog_file.content_type).to eq('image/jpeg')
-          expect(@directory.files.get(store_path).content_type).to eq('image/jpeg')
+          expect(@fog_file.content_type).to eq(file.content_type)
+          expect(@directory.files.get(store_path).content_type).to eq(file.content_type)
         end
 
         it "should have an extension" do
@@ -244,6 +244,10 @@ end
         it "should upload the file", focus: true do
           expect(@directory.files.get('uploads/tmp/test+.jpg').body).to eq('this is stuff')
         end
+
+        it 'should preserve content type' do
+          expect(@fog_file.content_type).to eq(file.content_type)
+        end
       end
 
       describe '#retrieve_from_cache!' do
@@ -413,6 +417,16 @@ end
 
       it_should_behave_like "#{fog_credentials[:provider]} storage"
 
+    end
+
+    describe "with a valid File object with an explicit content type" do
+      let(:file) do
+        CarrierWave::SanitizedFile.new(stub_file('test.jpg', 'image/jpeg')).tap do |f|
+          f.content_type = 'image/jpg'
+        end
+      end
+
+      it_should_behave_like "#{fog_credentials[:provider]} storage"
     end
 
     describe "with a valid path" do


### PR DESCRIPTION
There has been a longstanding issue in `SanitizedFile#move_to` where an existing content type would be lost. This was exacerbated by the changes in #1312, which made the file cache store use `move_to` all the time.

Prior to this fix, anyone using the file cache store will lose any explicitly set content type. This can be seen in: #1841.

This PR solves the underlying `SanitizedFile` issue, and adds some specs to ensure the same issue isn't present in the fog storage.