### PR TITLE
Fix Rails 5.1.0 deprecation warnings

### DIFF
--- a/lib/carrierwave/mount.rb
+++ b/lib/carrierwave/mount.rb
@@ -186,7 +186,8 @@ module CarrierWave
         end
 
         def store_previous_changes_for_#{column}
-          @_previous_changes_for_#{column} = changes[_mounter(:#{column}).serialization_column]
+          attribute_changes = ::ActiveRecord.version.to_s.to_f >= 5.1 ? saved_changes : changes
+          @_previous_changes_for_#{column} = attribute_changes[_mounter(:#{column}).serialization_column]
         end
 
         def remove_previously_stored_#{column}
@@ -340,7 +341,8 @@ module CarrierWave
         end
 
         def store_previous_changes_for_#{column}
-          @_previous_changes_for_#{column} = changes[_mounter(:#{column}).serialization_column]
+          attribute_changes = ::ActiveRecord.version.to_s.to_f >= 5.1 ? saved_changes : changes
+          @_previous_changes_for_#{column} = attribute_changes[_mounter(:#{column}).serialization_column]
         end
 
         def remove_previously_stored_#{column}


### PR DESCRIPTION
Firstly thanks for a great gem! This is my first PR, so hopefully I'm on the right lines here.

Rails 5.1.0 introduces deprecation warnings for methods around dirty attributes in ActiveRecord as outlined here: https://github.com/rails/rails/commit/16ae3db5a5c6a08383b974ae6c96faac5b4a3c81

This PR fixes the deprecation warnings by switching the dirty attribute method used, based on the ActiveRecord version in use.