### PR TITLE
Link to CarrierWave questions on Stack Overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It works well with Rack based web applications, such as Ruby on Rails.
 
 ## Getting Help
 
-* Please ask the community on [Stack Overflow](http://stackoverflow.com/) for help if you have any questions. Please do not post usage questions on the issue tracker.
+* Please ask the community on [Stack Overflow](https://stackoverflow.com/questions/tagged/carrierwave) for help if you have any questions. Please do not post usage questions on the issue tracker.
 * Please report bugs on the [issue tracker](http://github.com/carrierwaveuploader/carrierwave/issues) but read the "getting help" section in the wiki first.
 
 ## Installation


### PR DESCRIPTION
I clicked on the link in the readme and got really confused when I saw a bunch of questions about ASP.net. I propose that the readme links to the `carrierwave` tag on Stack Overflow.

Thoughts?