### PR TITLE
Remove potentially redundant HEAD request

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -297,7 +297,7 @@ module CarrierWave
         #
         # [Boolean] true if file exists or false
         def exists?
-          !!directory.files.head(path)
+          !!file
         end
 
         ##


### PR DESCRIPTION
When you check if a file exists using Fog, you can potentially end up with an extra HEAD request to the remote server: one request to check its existence and another to read the file.

Consider the following code:
```
if fog_file.exists?
  fog_file.read
end
```
It will produce two HEAD request and one GET
With this PR, it will produce only one HEAD and one GET.
