### PR TITLE
JSON nested mount

### DIFF
--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", ">= 4.0.0"
   s.add_dependency "activemodel", ">= 4.0.0"
   s.add_dependency "mime-types", ">= 1.16"
+  s.add_dependency "hana", ">= 1.3.2"
   if RUBY_ENGINE == 'jruby'
     s.add_development_dependency 'activerecord-jdbcpostgresql-adapter'
   else

--- a/lib/carrierwave/mount.rb
+++ b/lib/carrierwave/mount.rb
@@ -175,9 +175,17 @@ module CarrierWave
           mounter = _mounter(:#{column})
 
           if mounter.remove?
-            write_uploader(mounter.serialization_column, nil)
+            if method(:write_uploader).arity == 2
+              write_uploader(mounter.serialization_column, nil)
+            else
+              write_uploader(mounter.serialization_column, nil, mount_path: "#{options[:mount_path].to_s}")
+            end
           elsif mounter.identifiers.first
-            write_uploader(mounter.serialization_column, mounter.identifiers.first)
+            if method(:write_uploader).arity == 2
+              write_uploader(mounter.serialization_column, mounter.identifiers.first)
+            else
+              write_uploader(mounter.serialization_column, mounter.identifiers.first, mount_path: "#{options[:mount_path].to_s}")
+            end
           end
         end
 
@@ -330,9 +338,17 @@ module CarrierWave
           mounter = _mounter(:#{column})
 
           if mounter.remove?
-            write_uploader(mounter.serialization_column, nil)
+            if method(:write_uploader).arity == 2
+              write_uploader(mounter.serialization_column, nil)
+            else
+              write_uploader(mounter.serialization_column, nil, mount_path: "#{options[:mount_path].to_s}")
+            end
           elsif mounter.identifiers.any?
-            write_uploader(mounter.serialization_column, mounter.identifiers)
+            if method(:write_uploader).arity == 2
+              write_uploader(mounter.serialization_column, mounter.identifiers)
+            else
+              write_uploader(mounter.serialization_column, mounter.identifiers, mount_path: "#{options[:mount_path].to_s}")
+            end
           end
         end
 

--- a/lib/carrierwave/mount.rb
+++ b/lib/carrierwave/mount.rb
@@ -354,6 +354,10 @@ module CarrierWave
     private
 
     def mount_base(column, uploader=nil, options={}, &block)
+      if options[:mount_path] && (!options[:mount_on] || options[:mount_on] == column)
+        raise CarrierWave::InvalidParameter.new("When using mount_path, you must also use the mount_on option and the mount_on column must be different from the column parameter.")
+      end
+
       include CarrierWave::Mount::Extension
 
       uploader = build_uploader(uploader, &block)

--- a/lib/carrierwave/mounter.rb
+++ b/lib/carrierwave/mounter.rb
@@ -1,3 +1,5 @@
+require 'hana'
+
 module CarrierWave
 
   # this is an internal class, used by CarrierWave::Mount so that
@@ -128,10 +130,13 @@ module CarrierWave
 
     def remove_previous(before=nil, after=nil)
       after ||= []
+      pointer = Hana::Pointer.new(mount_path || '')
       return unless before
 
       # both 'before' and 'after' can be string when 'mount_on' option is set
       before = before.reject(&:blank?).map do |value|
+        value = (pointer.eval(value) or "") if value.is_a?(Hash)
+
         if value.is_a?(String)
           uploader = blank_uploader
           uploader.retrieve_from_store!(value)
@@ -141,6 +146,8 @@ module CarrierWave
         end
       end
       after_paths = after.reject(&:blank?).map do |value|
+        value = (pointer.eval(value) or "") if value.is_a?(Hash)
+
         if value.is_a?(String)
           uploader = blank_uploader
           uploader.retrieve_from_store!(value)

--- a/lib/carrierwave/mounter.rb
+++ b/lib/carrierwave/mounter.rb
@@ -28,7 +28,11 @@ module CarrierWave
     end
 
     def read_identifiers
-      [record.read_uploader(serialization_column)].flatten.reject(&:blank?)
+      if record.method(:read_uploader).arity == 1
+        [record.read_uploader(serialization_column)].flatten.reject(&:blank?)
+      else
+        [record.read_uploader(serialization_column, mount_path: option(:mount_path))].flatten.reject(&:blank?)
+      end
     end
 
     def uploaders

--- a/lib/carrierwave/mounter.rb
+++ b/lib/carrierwave/mounter.rb
@@ -122,6 +122,10 @@ module CarrierWave
       option(:mount_on) || column
     end
 
+    def mount_path
+      option(:mount_path)
+    end
+
     def remove_previous(before=nil, after=nil)
       after ||= []
       return unless before

--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -97,6 +97,7 @@ module CarrierWave
           else
             pointer = ::Hana::Pointer.new mount_path
             attribute = read_attribute(serialization_column)
+            attribute.deep_stringify_keys! if attribute.is_a? Hash
 
             pointer.eval(attribute)
           end
@@ -107,6 +108,7 @@ module CarrierWave
             write_attribute(serialization_column, identifier)
           else
             attribute = read_attribute(serialization_column) || {}
+            attribute.deep_stringify_keys! if attribute.is_a? Hash
 
             parent_path = mount_path.split("/")[0..-2].reject(&:blank?)
             attribute = create_path_in_hash(attribute, parent_path)

--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -93,7 +93,7 @@ module CarrierWave
 
         def read_uploader(serialization_column, mount_path: nil)
           if mount_path.nil?
-            attribute
+            read_attribute(serialization_column)
           else
             pointer = ::Hana::Pointer.new mount_path
             attribute = read_attribute(serialization_column)
@@ -103,7 +103,7 @@ module CarrierWave
         end
 
         def write_uploader(serialization_column, identifier, mount_path: nil)
-          if mount_path.blank?
+          if mount_path.nil?
             write_attribute(serialization_column, identifier)
           else
             attribute = read_attribute(serialization_column) || {}

--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -91,22 +91,18 @@ module CarrierWave
           super
         end
 
-        def read_uploader(serialization_column)
-          attribute = read_attribute(serialization_column)
-
-          if attribute.is_a? Hash
-            mount_path = _mounter(:#{column}).mount_path.to_s
+        def read_uploader(serialization_column, mount_path: nil)
+          if mount_path.nil?
+            attribute
+          else
             pointer = ::Hana::Pointer.new mount_path
+            attribute = read_attribute(serialization_column)
 
             pointer.eval(attribute)
-          else
-            attribute
           end
         end
 
-        def write_uploader(serialization_column, identifier)
-          mount_path = _mounter(:#{column}).mount_path.to_s
-
+        def write_uploader(serialization_column, identifier, mount_path: nil)
           if mount_path.blank?
             write_attribute(serialization_column, identifier)
           else

--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -40,6 +40,7 @@ module CarrierWave
         add_config :validate_processing
         add_config :validate_download
         add_config :mount_on
+        add_config :mount_path
         add_config :cache_only
 
         # set default values

--- a/spec/mount_multiple_spec.rb
+++ b/spec/mount_multiple_spec.rb
@@ -129,7 +129,7 @@ describe CarrierWave::Mount do
     describe '#images' do
       context "return an empty array when nothing has been assigned" do
         before do
-          allow(instance).to receive(:read_uploader).with(:images).and_return(nil)
+          allow(instance).to receive(:read_uploader).with(:images, anything).and_return(nil)
         end
 
         it { expect(instance.images).to eq [] }
@@ -137,7 +137,7 @@ describe CarrierWave::Mount do
 
       context "returns an empty array when an empty string has been assigned" do
         before do
-          allow(instance).to receive(:read_uploader).with(:images).and_return('')
+          allow(instance).to receive(:read_uploader).with(:images, anything).and_return('')
         end
 
         it { expect(instance.images).to eq [] }
@@ -147,7 +147,7 @@ describe CarrierWave::Mount do
         subject(:images) { instance.images }
 
         before do
-          allow(instance).to receive(:read_uploader).with(:images).at_least(:once).and_return([test_file_name, new_file_name])
+          allow(instance).to receive(:read_uploader).with(:images, anything).at_least(:once).and_return([test_file_name, new_file_name])
         end
 
         it { expect(images[0]).to be_an_instance_of(uploader) }
@@ -158,7 +158,7 @@ describe CarrierWave::Mount do
         subject(:image) { instance.images.first }
 
         before do
-          allow(instance).to receive(:read_uploader).with(:images).at_least(:once).and_return(test_file_name)
+          allow(instance).to receive(:read_uploader).with(:images, anything).at_least(:once).and_return(test_file_name)
         end
 
         it { expect(image.current_path).to eq(public_path("uploads/#{test_file_name}")) }
@@ -265,7 +265,7 @@ describe CarrierWave::Mount do
 
       describe "returns nil when nothing has been assigned" do
         before do
-          allow(instance).to receive(:read_uploader).with(:images).and_return(nil)
+          allow(instance).to receive(:read_uploader).with(:images, anything).and_return(nil)
         end
 
         it { is_expected.to be_empty }
@@ -273,7 +273,7 @@ describe CarrierWave::Mount do
 
       describe "should return nil when an empty string has been assigned" do
         before do
-          allow(instance).to receive(:read_uploader).with(:images).and_return('')
+          allow(instance).to receive(:read_uploader).with(:images, anything).and_return('')
         end
 
         it { is_expected.to be_empty }
@@ -281,7 +281,7 @@ describe CarrierWave::Mount do
 
       describe "gets the url from a retrieved file" do
         before do
-          allow(instance).to receive(:read_uploader).at_least(:once).with(:images).and_return(test_file_name)
+          allow(instance).to receive(:read_uploader).at_least(:once).with(:images, anything).and_return(test_file_name)
         end
 
         it { expect(images_urls.first).to eq("/uploads/#{test_file_name}") }
@@ -666,7 +666,7 @@ describe CarrierWave::Mount do
       after { instance.write_images_identifier }
 
       it "writes to the column" do
-        expect(instance).to receive(:write_uploader).with(:images, [test_file_name]).at_least(:once)
+        expect(instance).to receive(:write_uploader).with(:images, [test_file_name], anything).at_least(:once)
         instance.images = [test_file_stub]
         instance.write_images_identifier
       end
@@ -679,14 +679,14 @@ describe CarrierWave::Mount do
         end
 
         it "removes from the column when remove_images is true" do
-          expect(instance).to receive(:write_uploader).with(:images, nil)
+          expect(instance).to receive(:write_uploader).with(:images, nil, anything)
         end
       end
     end
 
     describe '#images_identifiers' do
       it "returns the identifier from the mounted column" do
-        expect(instance).to receive(:read_uploader).with(:images).and_return(test_file_name)
+        expect(instance).to receive(:read_uploader).with(:images, anything).and_return(test_file_name)
         expect(instance.images_identifiers).to eq([test_file_name])
       end
     end
@@ -887,7 +887,7 @@ describe CarrierWave::Mount do
     describe '#images' do
       context "when a value is store in the database" do
         it "retrieves a file from the storage" do
-          expect(instance).to receive(:read_uploader).at_least(:once).with(:monkey).and_return([test_file_name])
+          expect(instance).to receive(:read_uploader).at_least(:once).with(:monkey, anything).and_return([test_file_name])
           expect(instance.images[0]).to be_an_instance_of(uploader)
           expect(instance.images[0].current_path).to eq(public_path("uploads/#{test_file_name}"))
         end
@@ -896,7 +896,7 @@ describe CarrierWave::Mount do
 
     describe '#write_images_identifier' do
       it "writes to the given column" do
-        expect(instance).to receive(:write_uploader).with(:monkey, [test_file_name])
+        expect(instance).to receive(:write_uploader).with(:monkey, [test_file_name], anything)
         instance.images = [test_file_stub]
         instance.write_images_identifier
       end
@@ -905,7 +905,7 @@ describe CarrierWave::Mount do
         instance.images = [test_file_stub]
         instance.store_images!
         instance.remove_images = true
-        expect(instance).to receive(:write_uploader).with(:monkey, nil)
+        expect(instance).to receive(:write_uploader).with(:monkey, nil, anything)
         instance.write_images_identifier
       end
     end

--- a/spec/mount_single_spec.rb
+++ b/spec/mount_single_spec.rb
@@ -95,29 +95,29 @@ describe CarrierWave::Mount do
     describe '#image' do
 
       it "should return a blank uploader when nothing has been assigned" do
-        expect(@instance).to receive(:read_uploader).with(:image).and_return(nil)
+        expect(@instance).to receive(:read_uploader).with(:image, anything).and_return(nil)
         expect(@instance.image).to be_an_instance_of(@uploader)
         expect(@instance.image).to be_blank
       end
 
       it "should return the same object every time when nothing has been assigned" do
-        expect(@instance).to receive(:read_uploader).with(:image).and_return(nil)
+        expect(@instance).to receive(:read_uploader).with(:image, anything).and_return(nil)
         expect(@instance.image.object_id).to eq @instance.image.object_id
       end
 
       it "should return a blank uploader when an empty string has been assigned" do
-        expect(@instance).to receive(:read_uploader).with(:image).and_return('')
+        expect(@instance).to receive(:read_uploader).with(:image, anything).and_return('')
         expect(@instance.image).to be_an_instance_of(@uploader)
         expect(@instance.image).to be_blank
       end
 
       it "should retrieve a file from the storage if a value is stored in the database" do
-        expect(@instance).to receive(:read_uploader).with(:image).at_least(:once).and_return('test.jpg')
+        expect(@instance).to receive(:read_uploader).with(:image, anything).at_least(:once).and_return('test.jpg')
         expect(@instance.image).to be_an_instance_of(@uploader)
       end
 
       it "should set the path to the store dir" do
-        expect(@instance).to receive(:read_uploader).with(:image).at_least(:once).and_return('test.jpg')
+        expect(@instance).to receive(:read_uploader).with(:image, anything).at_least(:once).and_return('test.jpg')
         expect(@instance.image.current_path).to eq(public_path('uploads/test.jpg'))
       end
 
@@ -199,7 +199,7 @@ describe CarrierWave::Mount do
     describe '#image_url' do
 
       it "should return nil when nothing has been assigned" do
-        expect(@instance).to receive(:read_uploader).with(:image).and_return(nil)
+        expect(@instance).to receive(:read_uploader).with(:image, anything).and_return(nil)
         expect(@instance.image_url).to be_nil
       end
 
@@ -209,17 +209,17 @@ describe CarrierWave::Mount do
             "foo/bar.jpg"
           end
         end
-        expect(@instance).to receive(:read_uploader).with(:image).and_return(nil)
+        expect(@instance).to receive(:read_uploader).with(:image, anything).and_return(nil)
         expect(@instance.image_url).to eq("foo/bar.jpg")
       end
 
       it "should return nil when an empty string has been assigned" do
-        expect(@instance).to receive(:read_uploader).with(:image).and_return('')
+        expect(@instance).to receive(:read_uploader).with(:image, anything).and_return('')
         expect(@instance.image_url).to be_nil
       end
 
       it "should get the url from a retrieved file" do
-        expect(@instance).to receive(:read_uploader).at_least(:once).with(:image).and_return('test.jpg')
+        expect(@instance).to receive(:read_uploader).at_least(:once).with(:image, anything).and_return('test.jpg')
         expect(@instance.image_url).to eq('/uploads/test.jpg')
       end
 
@@ -568,7 +568,7 @@ describe CarrierWave::Mount do
 
     describe '#write_image_identifier' do
       it "should write to the column" do
-        expect(@instance).to receive(:write_uploader).with(:image, "test.jpg")
+        expect(@instance).to receive(:write_uploader).with(:image, "test.jpg", anything)
         @instance.image = stub_file('test.jpg')
         @instance.write_image_identifier
       end
@@ -577,14 +577,14 @@ describe CarrierWave::Mount do
         @instance.image = stub_file('test.jpg')
         @instance.store_image!
         @instance.remove_image = true
-        expect(@instance).to receive(:write_uploader).with(:image, nil)
+        expect(@instance).to receive(:write_uploader).with(:image, nil, anything)
         @instance.write_image_identifier
       end
     end
 
     describe '#image_identifier' do
       it "should return the identifier from the mounted column" do
-        expect(@instance).to receive(:read_uploader).with(:image).and_return("test.jpg")
+        expect(@instance).to receive(:read_uploader).with(:image, anything).and_return("test.jpg")
         expect(@instance.image_identifier).to eq('test.jpg')
       end
     end
@@ -785,7 +785,7 @@ describe CarrierWave::Mount do
 
     describe '#image' do
       it "should retrieve a file from the storage if a value is stored in the database" do
-        expect(@instance).to receive(:read_uploader).at_least(:once).with(:monkey).and_return('test.jpg')
+        expect(@instance).to receive(:read_uploader).at_least(:once).with(:monkey, anything).and_return('test.jpg')
         expect(@instance.image).to be_an_instance_of(@uploader)
         expect(@instance.image.current_path).to eq(public_path('uploads/test.jpg'))
       end
@@ -793,7 +793,7 @@ describe CarrierWave::Mount do
 
     describe '#write_image_identifier' do
       it "should write to the given column" do
-        expect(@instance).to receive(:write_uploader).with(:monkey, "test.jpg")
+        expect(@instance).to receive(:write_uploader).with(:monkey, "test.jpg", anything)
         @instance.image = stub_file('test.jpg')
         @instance.write_image_identifier
       end
@@ -802,7 +802,7 @@ describe CarrierWave::Mount do
         @instance.image = stub_file('test.jpg')
         @instance.store_image!
         @instance.remove_image = true
-        expect(@instance).to receive(:write_uploader).with(:monkey, nil)
+        expect(@instance).to receive(:write_uploader).with(:monkey, nil, anything)
         @instance.write_image_identifier
       end
     end


### PR DESCRIPTION
This PR enables mounting within JSON columns for ORM's that support it by introducing a new option, `mount_path`. Basic usage:

```ruby
class Person < ActiveRecord::Base
  mount_uploader :avatar, AvatarUploader, mount_on: :settings, mount_path: '/images/avatar'
end
```

`mount_path` takes a string in [JSON Pointer](https://tools.ietf.org/html/rfc6901) format that specifies which property within the JSON column you want to mount on. Given the example above, the JSON column `Person.settings` may look like this:

```ruby
person.settings # {images: {avatar: nil}}
person.avatar = File.new("avatar.jpg")
person.save.settings # {images: {avatar: "70f91839-e560-4639-9e4f-2cd0eb61c22b.png"}}
```

Mount paths that don't exist will be generated upon save:

```ruby
person.settings # {}
person.avatar = File.new("avatar.jpg")
person.save.settings # {images: {avatar: "70f91839-e560-4639-9e4f-2cd0eb61c22b.png"}}
```

Mount paths that have non-hash segments (except for the last segment, which can be an array when using `mount_uploaders`, see below) are considered invalid and will cause an error to be raised upon save:

```ruby
person.settings # {images: []}
person.avatar = File.new("avatar.jpg")
person.save # CarrierWave::InvalidParameter error raised
```

Finally, `mount_uploaders` can be used as normal:

```ruby
class Person < ActiveRecord::Base
  mount_uploaders :avatar, AvatarUploader, mount_on: :settings, mount_path: '/images/avatar'
end

person.settings # {images: {avatar: nil}}
person.avatar = File.new("avatar.jpg")
person.save.settings # {images: {avatar: ["70f91839-e560-4639-9e4f-2cd0eb61c22b.png"]}}
```