### PR TITLE
Correct syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,7 +659,7 @@ CarrierWave.configure do |config|
   }
   config.fog_directory  = 'name_of_directory'                          # required
   config.fog_public     = false                                        # optional, defaults to true
-  config.fog_attributes = { 'Cache-Control' => "max-age=#{365.day.to_i}" } # optional, defaults to {}
+  config.fog_attributes = { cache_control: "public, max-age=#{365.day.to_i}" } # optional, defaults to {}
 end
 ```
 


### PR DESCRIPTION
After a lot of attempts, only this example works for me.
Syntax is taken from fog: https://github.com/fog/fog-google/blob/db446d1d8fbf0b75e13b4c39af3eb6b1ecb3101c/lib/fog/storage/google_json/models/file.rb
and tested for fog-google, and fog-aws.