### PR TITLE
Update nokogiri to 1.7.1

### DIFF
--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.licenses = ["MIT"]
 
-  s.required_ruby_version = ">= 2.0.0"
+  s.required_ruby_version = ">= 2.1.0"
 
   s.add_dependency "activesupport", ">= 4.0.0"
   s.add_dependency "activemodel", ">= 4.0.0"

--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   if RUBY_ENGINE != 'jruby'
     s.add_development_dependency "rmagick"
   end
-  s.add_development_dependency "nokogiri", "~> 1.6.3"
+  s.add_development_dependency "nokogiri", "~> 1.7.1"
   s.add_development_dependency "timecop", "0.7.1"
   s.add_development_dependency "generator_spec", ">= 0.9.1"
   s.add_development_dependency "pry"


### PR DESCRIPTION
This PR will modify the dependency in the Gemspec to indicate that Nokogiri 1.7.1+ should be used.

Caveat: Nokogiri requires a Ruby version greater than 2.1.0. There should be a separate PR bumping the Ruby version before this is merged.

Closes #2153 