### PR TITLE
downcase the filename to fix issue with versions

### DIFF
--- a/lib/carrierwave/uploader/store.rb
+++ b/lib/carrierwave/uploader/store.rb
@@ -38,7 +38,7 @@ module CarrierWave
       # [String] the store path
       #
       def store_path(for_file=filename)
-        File.join([store_dir, full_filename(for_file)].compact)
+        File.join([store_dir, full_filename(for_file)].compact).downcase
       end
 
       ##


### PR DESCRIPTION
When for instance the original filename is `my_file.JPG` and I
upload the file using Fog, the original file is stored as `my_file.JPG`
but the thumb version is stored as `thumb_my_file.jpg`, in concecuence,
when I try to retrieve the thumb version using `model.photo_url(:thumb)`
I get `thumb_my_file.JPG` which does not exist. This commit changes the
default store path to always use lowercase names.