### PR TITLE
Add fog_serve_public as an override

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -12,7 +12,8 @@ module CarrierWave
     # [:fog_directory]    specifies name of directory to store data in, assumed to already exist
     #
     # [:fog_attributes]                   (optional) additional attributes to set on files
-    # [:fog_public]                       (optional) public readability, defaults to true
+    # [:fog_public]                       (optional) set public ACL and public URLs, defaults to true
+    # [:fog_serve_public]                 (optional) override for public URLs, no default
     # [:fog_authenticated_url_expiration] (optional) time (in seconds) that authenticated urls
     #   will be valid, when fog_public is false and provider is AWS or Google, defaults to 600
     # [:fog_use_ssl_for_aws]              (optional) #public_url will use https for the AWS generated URL]
@@ -378,10 +379,10 @@ module CarrierWave
         # [NilClass] no url available
         #
         def url(options = {})
-          if !@uploader.fog_public
-            authenticated_url(options)
-          else
+          if @uploader.fog_public || @uploader.fog_serve_public
             public_url
+          else
+            authenticated_url(options)
           end
         end
 

--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -28,6 +28,7 @@ module CarrierWave
         add_config :fog_credentials
         add_config :fog_directory
         add_config :fog_public
+        add_config :fog_serve_public
         add_config :fog_authenticated_url_expiration
         add_config :fog_use_ssl_for_aws
         add_config :fog_aws_accelerate

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -379,6 +379,15 @@ end
             end
           end
 
+          it "should have a public_url if fog_serve_public override is present" do
+            allow(@uploader).to receive(:fog_serve_public).and_return(true)
+            if ['AWS', 'Rackspace', 'Google', 'OpenStack'].include?(@provider)
+              unless Fog.mocking? || fog_credentials[:provider] == 'Local'
+                expect(open(@fog_file.public_url).read).to eq('this is stuff')
+              end
+            end
+          end
+
           it 'should generate correct filename' do
             expect(@fog_file.filename).to eq('private.txt')
           end


### PR DESCRIPTION
## What
For security purposes, having in a bucket a mix of files that are meant to be public and others that are meant to be PII data is a security breach waiting to happen.

This PR allows to decouple fog_public from fog_serve_public. Which means you can upload files as private but still serve them as public files through Cloudfront or through your provider.

We want to do this so that we can remove the permission for the user to set ACL on a per file basis but still allows for public access to these files.