### PR TITLE
Added Proc Support for Width and Height

### DIFF
--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -127,6 +127,8 @@ module CarrierWave
     # [MiniMagick::Image] additional manipulations to perform
     #
     def resize_to_limit(width, height, combine_options: {})
+      width = width.call if width.instance_of?(Proc)
+      height = height.call if height.instance_of?(Proc)
       manipulate! do |img|
         img.combine_options do |cmd|
           cmd.resize "#{width}x#{height}>"
@@ -152,6 +154,8 @@ module CarrierWave
     # [MiniMagick::Image] additional manipulations to perform
     #
     def resize_to_fit(width, height, combine_options: {})
+      width = width.call if width.instance_of?(Proc)
+      height = height.call if height.instance_of?(Proc)
       manipulate! do |img|
         img.combine_options do |cmd|
           cmd.resize "#{width}x#{height}"
@@ -178,6 +182,8 @@ module CarrierWave
     # [MiniMagick::Image] additional manipulations to perform
     #
     def resize_to_fill(width, height, gravity = 'Center', combine_options: {})
+      width = width.call if width.instance_of?(Proc)
+      height = height.call if height.instance_of?(Proc)
       manipulate! do |img|
         cols, rows = img[:dimensions]
         img.combine_options do |cmd|
@@ -225,6 +231,8 @@ module CarrierWave
     # [MiniMagick::Image] additional manipulations to perform
     #
     def resize_and_pad(width, height, background=:transparent, gravity='Center', combine_options: {})
+      width = width.call if width.instance_of?(Proc)
+      height = height.call if height.instance_of?(Proc)
       manipulate! do |img|
         img.combine_options do |cmd|
           cmd.thumbnail "#{width}x#{height}>"

--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -127,8 +127,8 @@ module CarrierWave
     # [MiniMagick::Image] additional manipulations to perform
     #
     def resize_to_limit(width, height, combine_options: {})
-      width = width.call if width.instance_of?(Proc)
-      height = height.call if height.instance_of?(Proc)
+      width = dimension_from width
+      height = dimension_from height
       manipulate! do |img|
         img.combine_options do |cmd|
           cmd.resize "#{width}x#{height}>"
@@ -154,8 +154,8 @@ module CarrierWave
     # [MiniMagick::Image] additional manipulations to perform
     #
     def resize_to_fit(width, height, combine_options: {})
-      width = width.call if width.instance_of?(Proc)
-      height = height.call if height.instance_of?(Proc)
+      width = dimension_from width
+      height = dimension_from height
       manipulate! do |img|
         img.combine_options do |cmd|
           cmd.resize "#{width}x#{height}"
@@ -182,8 +182,8 @@ module CarrierWave
     # [MiniMagick::Image] additional manipulations to perform
     #
     def resize_to_fill(width, height, gravity = 'Center', combine_options: {})
-      width = width.call if width.instance_of?(Proc)
-      height = height.call if height.instance_of?(Proc)
+      width = dimension_from width
+      height = dimension_from height
       manipulate! do |img|
         cols, rows = img[:dimensions]
         img.combine_options do |cmd|
@@ -231,8 +231,8 @@ module CarrierWave
     # [MiniMagick::Image] additional manipulations to perform
     #
     def resize_and_pad(width, height, background=:transparent, gravity='Center', combine_options: {})
-      width = width.call if width.instance_of?(Proc)
-      height = height.call if height.instance_of?(Proc)
+      width = dimension_from width
+      height = dimension_from height
       manipulate! do |img|
         img.combine_options do |cmd|
           cmd.thumbnail "#{width}x#{height}>"
@@ -325,6 +325,11 @@ module CarrierWave
             cmd.send(method, options)
           end
         end
+      end
+
+      def dimension_from(value)
+        return value unless value.instance_of?(Proc)
+        value.arity >= 1 ? value.call(self) : value.call
       end
 
       def mini_magick_image

--- a/lib/carrierwave/processing/rmagick.rb
+++ b/lib/carrierwave/processing/rmagick.rb
@@ -133,8 +133,8 @@ module CarrierWave
     # [Magick::Image] additional manipulations to perform
     #
     def resize_to_limit(width, height)
-      width = width.call if width.instance_of?(Proc)
-      height = height.call if height.instance_of?(Proc)
+      width = dimension_from width
+      height = dimension_from height
       manipulate! do |img|
         geometry = Magick::Geometry.new(width, height, 0, 0, Magick::GreaterGeometry)
         new_img = img.change_geometry(geometry) do |new_width, new_height|
@@ -164,8 +164,8 @@ module CarrierWave
     # [Magick::Image] additional manipulations to perform
     #
     def resize_to_fit(width, height)
-      width = width.call if width.instance_of?(Proc)
-      height = height.call if height.instance_of?(Proc)
+      width = dimension_from width
+      height = dimension_from height
       manipulate! do |img|
         img.resize_to_fit!(width, height)
         img = yield(img) if block_given?
@@ -190,8 +190,8 @@ module CarrierWave
     # [Magick::Image] additional manipulations to perform
     #
     def resize_to_fill(width, height, gravity=::Magick::CenterGravity)
-      width = width.call if width.instance_of?(Proc)
-      height = height.call if height.instance_of?(Proc)
+      width = dimension_from width
+      height = dimension_from height
       manipulate! do |img|
         img.crop_resized!(width, height, gravity)
         img = yield(img) if block_given?
@@ -217,8 +217,8 @@ module CarrierWave
     # [Magick::Image] additional manipulations to perform
     #
     def resize_and_pad(width, height, background=:transparent, gravity=::Magick::CenterGravity)
-      width = width.call if width.instance_of?(Proc)
-      height = height.call if height.instance_of?(Proc)
+      width = dimension_from width
+      height = dimension_from height
       manipulate! do |img|
         img.resize_to_fit!(width, height)
         new_img = ::Magick::Image.new(width, height) { self.background_color = background == :transparent ? 'rgba(255,255,255,0)' : background.to_s }
@@ -377,6 +377,11 @@ module CarrierWave
 
     def destroy_image(image)
       image.try(:destroy!)
+    end
+
+    def dimension_from(value)
+      return value unless value.instance_of?(Proc)
+      value.arity >= 1 ? value.call(self) : value.call
     end
 
     def rmagick_image

--- a/lib/carrierwave/processing/rmagick.rb
+++ b/lib/carrierwave/processing/rmagick.rb
@@ -133,6 +133,8 @@ module CarrierWave
     # [Magick::Image] additional manipulations to perform
     #
     def resize_to_limit(width, height)
+      width = width.call if width.instance_of?(Proc)
+      height = height.call if height.instance_of?(Proc)
       manipulate! do |img|
         geometry = Magick::Geometry.new(width, height, 0, 0, Magick::GreaterGeometry)
         new_img = img.change_geometry(geometry) do |new_width, new_height|
@@ -162,6 +164,8 @@ module CarrierWave
     # [Magick::Image] additional manipulations to perform
     #
     def resize_to_fit(width, height)
+      width = width.call if width.instance_of?(Proc)
+      height = height.call if height.instance_of?(Proc)
       manipulate! do |img|
         img.resize_to_fit!(width, height)
         img = yield(img) if block_given?
@@ -186,6 +190,8 @@ module CarrierWave
     # [Magick::Image] additional manipulations to perform
     #
     def resize_to_fill(width, height, gravity=::Magick::CenterGravity)
+      width = width.call if width.instance_of?(Proc)
+      height = height.call if height.instance_of?(Proc)
       manipulate! do |img|
         img.crop_resized!(width, height, gravity)
         img = yield(img) if block_given?
@@ -211,6 +217,8 @@ module CarrierWave
     # [Magick::Image] additional manipulations to perform
     #
     def resize_and_pad(width, height, background=:transparent, gravity=::Magick::CenterGravity)
+      width = width.call if width.instance_of?(Proc)
+      height = height.call if height.instance_of?(Proc)
       manipulate! do |img|
         img.resize_to_fit!(width, height)
         new_img = ::Magick::Image.new(width, height) { self.background_color = background == :transparent ? 'rgba(255,255,255,0)' : background.to_s }

--- a/spec/processing/mini_magick_spec.rb
+++ b/spec/processing/mini_magick_spec.rb
@@ -42,13 +42,6 @@ describe CarrierWave::MiniMagick do
       expect(::MiniMagick::Image.open(instance.current_path)['format']).to match(/JPEG/)
     end
 
-    it "resizes the image to exactly the evaluated dimensions and maintain file type" do
-      instance.resize_to_fill(Proc.new { 200 }, Proc.new { 200 })
-
-      expect(instance).to have_dimensions(200, 200)
-      expect(::MiniMagick::Image.open(instance.current_path)['format']).to match(/JPEG/)
-    end
-
     it "resizes the image to exactly the given dimensions and maintain updated file type" do
       instance.convert('png')
       instance.resize_to_fill(200, 200)
@@ -71,13 +64,6 @@ describe CarrierWave::MiniMagick do
   describe '#resize_and_pad' do
     it "resizes the image to exactly the given dimensions and maintain file type" do
       instance.resize_and_pad(200, 200)
-
-      expect(instance).to have_dimensions(200, 200)
-      expect(::MiniMagick::Image.open(instance.current_path)['format']).to match(/JPEG/)
-    end
-
-    it "resizes the image to exactly the evaluated dimensions and maintain file type" do
-      instance.resize_and_pad(Proc.new { 200 }, Proc.new { 200 })
 
       expect(instance).to have_dimensions(200, 200)
       expect(::MiniMagick::Image.open(instance.current_path)['format']).to match(/JPEG/)
@@ -150,13 +136,6 @@ describe CarrierWave::MiniMagick do
       expect(::MiniMagick::Image.open(instance.current_path)['format']).to match(/JPEG/)
     end
 
-    it "resizes the image to fit within the evaluated dimensions and maintain file type" do
-      instance.resize_to_fit(Proc.new { 200 }, Proc.new { 200 })
-
-      expect(instance).to have_dimensions(200, 150)
-      expect(::MiniMagick::Image.open(instance.current_path)['format']).to match(/JPEG/)
-    end
-
     it "resizes the image to fit within the given dimensions and maintain updated file type" do
       instance.convert('png')
       instance.resize_to_fit(200, 200)
@@ -187,13 +166,6 @@ describe CarrierWave::MiniMagick do
       expect(::MiniMagick::Tool::Identify.new.verbose(instance.current_path).call).to include('Quality: 70')
     end
 
-    it "resizes the image to fit within the evaluated dimensions and maintain file type" do
-      instance.resize_to_limit(Proc.new { 200 }, Proc.new { 200 })
-
-      expect(instance).to have_dimensions(200, 150)
-      expect(::MiniMagick::Image.open(instance.current_path)['format']).to match(/JPEG/)
-    end
-
     it "resizes the image to fit within the given dimensions and maintain updated file type" do
       instance.convert('png')
       instance.resize_to_limit(200, 200)
@@ -216,6 +188,32 @@ describe CarrierWave::MiniMagick do
 
       expect(instance.width).to eq(200)
       expect(instance.height).to eq(300)
+    end
+  end
+
+  describe '#dimension_from' do
+    it 'evaluates procs' do
+      instance.resize_to_fill(Proc.new { 200 }, Proc.new { 200 })
+
+      expect(instance).to have_dimensions(200, 200)
+    end
+
+    it 'evaluates procs with uploader instance' do
+      width_argument = nil
+      width = Proc.new do |uploader|
+        width_argument = uploader
+        200
+      end
+      height_argument = nil
+      height = Proc.new do |uploader|
+        height_argument = uploader
+        200
+      end
+      instance.resize_to_fill(width, height)
+
+      expect(instance).to have_dimensions(200, 200)
+      expect(instance).to eq(width_argument)
+      expect(instance).to eq(height_argument)
     end
   end
 

--- a/spec/processing/mini_magick_spec.rb
+++ b/spec/processing/mini_magick_spec.rb
@@ -42,6 +42,13 @@ describe CarrierWave::MiniMagick do
       expect(::MiniMagick::Image.open(instance.current_path)['format']).to match(/JPEG/)
     end
 
+    it "resizes the image to exactly the evaluated dimensions and maintain file type" do
+      instance.resize_to_fill(Proc.new { 200 }, Proc.new { 200 })
+
+      expect(instance).to have_dimensions(200, 200)
+      expect(::MiniMagick::Image.open(instance.current_path)['format']).to match(/JPEG/)
+    end
+
     it "resizes the image to exactly the given dimensions and maintain updated file type" do
       instance.convert('png')
       instance.resize_to_fill(200, 200)
@@ -64,6 +71,13 @@ describe CarrierWave::MiniMagick do
   describe '#resize_and_pad' do
     it "resizes the image to exactly the given dimensions and maintain file type" do
       instance.resize_and_pad(200, 200)
+
+      expect(instance).to have_dimensions(200, 200)
+      expect(::MiniMagick::Image.open(instance.current_path)['format']).to match(/JPEG/)
+    end
+
+    it "resizes the image to exactly the evaluated dimensions and maintain file type" do
+      instance.resize_and_pad(Proc.new { 200 }, Proc.new { 200 })
 
       expect(instance).to have_dimensions(200, 200)
       expect(::MiniMagick::Image.open(instance.current_path)['format']).to match(/JPEG/)
@@ -136,6 +150,13 @@ describe CarrierWave::MiniMagick do
       expect(::MiniMagick::Image.open(instance.current_path)['format']).to match(/JPEG/)
     end
 
+    it "resizes the image to fit within the evaluated dimensions and maintain file type" do
+      instance.resize_to_fit(Proc.new { 200 }, Proc.new { 200 })
+
+      expect(instance).to have_dimensions(200, 150)
+      expect(::MiniMagick::Image.open(instance.current_path)['format']).to match(/JPEG/)
+    end
+
     it "resizes the image to fit within the given dimensions and maintain updated file type" do
       instance.convert('png')
       instance.resize_to_fit(200, 200)
@@ -164,6 +185,13 @@ describe CarrierWave::MiniMagick do
       expect(instance).to have_dimensions(200, 150)
       expect(::MiniMagick::Image.open(instance.current_path)['format']).to match(/JPEG/)
       expect(::MiniMagick::Tool::Identify.new.verbose(instance.current_path).call).to include('Quality: 70')
+    end
+
+    it "resizes the image to fit within the evaluated dimensions and maintain file type" do
+      instance.resize_to_limit(Proc.new { 200 }, Proc.new { 200 })
+
+      expect(instance).to have_dimensions(200, 150)
+      expect(::MiniMagick::Image.open(instance.current_path)['format']).to match(/JPEG/)
     end
 
     it "resizes the image to fit within the given dimensions and maintain updated file type" do

--- a/spec/processing/rmagick_spec.rb
+++ b/spec/processing/rmagick_spec.rb
@@ -34,6 +34,13 @@ describe CarrierWave::RMagick, :rmagick => true do
       expect(::Magick::Image.read(instance.current_path).first.format).to eq('JPEG')
     end
 
+    it "resizes the image to exactly the evaluated dimensions and maintain file type" do
+      instance.resize_to_fill(Proc.new { 200 }, Proc.new { 200 })
+
+      expect(instance).to have_dimensions(200, 200)
+      expect(::Magick::Image.read(instance.current_path).first.format).to eq('JPEG')
+    end
+
     it "resizes the image to exactly the given dimensions and maintain updated file type" do
       instance.convert('png')
       instance.resize_to_fill(200, 200)
@@ -52,6 +59,13 @@ describe CarrierWave::RMagick, :rmagick => true do
   describe '#resize_and_pad' do
     it "resizes the image to exactly the given dimensions and maintain file type" do
       instance.resize_and_pad(200, 200)
+
+      expect(instance).to have_dimensions(200, 200)
+      expect(::Magick::Image.read(instance.current_path).first.format).to eq('JPEG')
+    end
+
+    it "resizes the image to exactly the evaluated dimensions and maintain file type" do
+      instance.resize_and_pad(Proc.new { 200 }, Proc.new { 200 })
 
       expect(instance).to have_dimensions(200, 200)
       expect(::Magick::Image.read(instance.current_path).first.format).to eq('JPEG')
@@ -113,6 +127,13 @@ describe CarrierWave::RMagick, :rmagick => true do
       expect(::Magick::Image.read(instance.current_path).first.format).to eq('JPEG')
     end
 
+    it "resizes the image to fit within evaluated dimensions and maintain file type" do
+      instance.resize_to_fit(Proc.new { 200 }, Proc.new { 200 })
+
+      expect(instance).to have_dimensions(200, 150)
+      expect(::Magick::Image.read(instance.current_path).first.format).to eq('JPEG')
+    end
+
     it "resize the image to fit within the given dimensions and maintain updated file type" do
       instance.convert('png')
       instance.resize_to_fit(200, 200)
@@ -131,6 +152,13 @@ describe CarrierWave::RMagick, :rmagick => true do
   describe '#resize_to_limit' do
     it "resizes the image to fit within the given dimensions and maintain file type" do
       instance.resize_to_limit(200, 200)
+
+      expect(instance).to have_dimensions(200, 150)
+      expect(::Magick::Image.read(instance.current_path).first.format).to eq('JPEG')
+    end
+
+    it "resizes the image to fit within the evaluated dimensions and maintain file type" do
+      instance.resize_to_limit(Proc.new { 200 }, Proc.new { 200 })
 
       expect(instance).to have_dimensions(200, 150)
       expect(::Magick::Image.read(instance.current_path).first.format).to eq('JPEG')

--- a/spec/processing/rmagick_spec.rb
+++ b/spec/processing/rmagick_spec.rb
@@ -34,13 +34,6 @@ describe CarrierWave::RMagick, :rmagick => true do
       expect(::Magick::Image.read(instance.current_path).first.format).to eq('JPEG')
     end
 
-    it "resizes the image to exactly the evaluated dimensions and maintain file type" do
-      instance.resize_to_fill(Proc.new { 200 }, Proc.new { 200 })
-
-      expect(instance).to have_dimensions(200, 200)
-      expect(::Magick::Image.read(instance.current_path).first.format).to eq('JPEG')
-    end
-
     it "resizes the image to exactly the given dimensions and maintain updated file type" do
       instance.convert('png')
       instance.resize_to_fill(200, 200)
@@ -59,13 +52,6 @@ describe CarrierWave::RMagick, :rmagick => true do
   describe '#resize_and_pad' do
     it "resizes the image to exactly the given dimensions and maintain file type" do
       instance.resize_and_pad(200, 200)
-
-      expect(instance).to have_dimensions(200, 200)
-      expect(::Magick::Image.read(instance.current_path).first.format).to eq('JPEG')
-    end
-
-    it "resizes the image to exactly the evaluated dimensions and maintain file type" do
-      instance.resize_and_pad(Proc.new { 200 }, Proc.new { 200 })
 
       expect(instance).to have_dimensions(200, 200)
       expect(::Magick::Image.read(instance.current_path).first.format).to eq('JPEG')
@@ -127,13 +113,6 @@ describe CarrierWave::RMagick, :rmagick => true do
       expect(::Magick::Image.read(instance.current_path).first.format).to eq('JPEG')
     end
 
-    it "resizes the image to fit within evaluated dimensions and maintain file type" do
-      instance.resize_to_fit(Proc.new { 200 }, Proc.new { 200 })
-
-      expect(instance).to have_dimensions(200, 150)
-      expect(::Magick::Image.read(instance.current_path).first.format).to eq('JPEG')
-    end
-
     it "resize the image to fit within the given dimensions and maintain updated file type" do
       instance.convert('png')
       instance.resize_to_fit(200, 200)
@@ -152,13 +131,6 @@ describe CarrierWave::RMagick, :rmagick => true do
   describe '#resize_to_limit' do
     it "resizes the image to fit within the given dimensions and maintain file type" do
       instance.resize_to_limit(200, 200)
-
-      expect(instance).to have_dimensions(200, 150)
-      expect(::Magick::Image.read(instance.current_path).first.format).to eq('JPEG')
-    end
-
-    it "resizes the image to fit within the evaluated dimensions and maintain file type" do
-      instance.resize_to_limit(Proc.new { 200 }, Proc.new { 200 })
 
       expect(instance).to have_dimensions(200, 150)
       expect(::Magick::Image.read(instance.current_path).first.format).to eq('JPEG')
@@ -245,6 +217,32 @@ describe CarrierWave::RMagick, :rmagick => true do
       instance.resize_to_fill(200, 300)
       expect(instance.width).to eq(200)
       expect(instance.height).to eq(300)
+    end
+  end
+
+  describe '#dimension_from' do
+    it 'evaluates procs' do
+      instance.resize_to_fill(Proc.new { 200 }, Proc.new { 200 })
+
+      expect(instance).to have_dimensions(200, 200)
+    end
+
+    it 'evaluates procs with uploader instance' do
+      width_argument = nil
+      width = Proc.new do |uploader|
+        width_argument = uploader
+        200
+      end
+      height_argument = nil
+      height = Proc.new do |uploader|
+        height_argument = uploader
+        200
+      end
+      instance.resize_to_fill(width, height)
+
+      expect(instance).to have_dimensions(200, 200)
+      expect(instance).to eq(width_argument)
+      expect(instance).to eq(height_argument)
     end
   end
 


### PR DESCRIPTION
I opened this issue (https://github.com/carrierwaveuploader/carrierwave/issues/2167) earlier this week and found a couple hacky solutions, so I thought I'd offer a more direct solution.

I then found this issue (https://github.com/carrierwaveuploader/carrierwave/issues/464) today and I think my fix would solve that problem as well, but may need to be updated to include something like [this](https://github.com/carrierwaveuploader/carrierwave/blob/540a84c606353a878d6574740e44f7970b754463/lib/carrierwave/uploader/configuration.rb#L150) in case some context needs to be passed in.

Let me know what you think! Thanks,
Tom