### PR TITLE
Replace send with __send__

### DIFF
--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -15,7 +15,7 @@ module CarrierWave
       class_eval <<-RUBY, __FILE__, __LINE__+1
         def remote_#{column}_url=(url)
           column = _mounter(:#{column}).serialization_column
-          send(:"\#{column}_will_change!")
+          __send__(:"\#{column}_will_change!")
           super
         end
       RUBY
@@ -30,7 +30,7 @@ module CarrierWave
       class_eval <<-RUBY, __FILE__, __LINE__+1
         def remote_#{column}_urls=(url)
           column = _mounter(:#{column}).serialization_column
-          send(:"\#{column}_will_change!")
+          __send__(:"\#{column}_will_change!")
           super
         end
       RUBY
@@ -63,8 +63,8 @@ module CarrierWave
       class_eval <<-RUBY, __FILE__, __LINE__+1
         def #{column}=(new_file)
           column = _mounter(:#{column}).serialization_column
-          if !(new_file.blank? && send(:#{column}).blank?)
-            send(:"\#{column}_will_change!")
+          if !(new_file.blank? && __send__(:#{column}).blank?)
+            __send__(:"\#{column}_will_change!")
           end
 
           super
@@ -72,7 +72,7 @@ module CarrierWave
 
         def remove_#{column}=(value)
           column = _mounter(:#{column}).serialization_column
-          send(:"\#{column}_will_change!")
+          __send__(:"\#{column}_will_change!")
           super
         end
 

--- a/lib/carrierwave/validations/active_model.rb
+++ b/lib/carrierwave/validations/active_model.rb
@@ -11,7 +11,7 @@ module CarrierWave
       class ProcessingValidator < ::ActiveModel::EachValidator
 
         def validate_each(record, attribute, value)
-          if e = record.send("#{attribute}_processing_error")
+          if e = record.__send__("#{attribute}_processing_error")
             message = (e.message == e.class.to_s) ? :carrierwave_processing_error : e.message
             record.errors.add(attribute, message)
           end
@@ -21,7 +21,7 @@ module CarrierWave
       class IntegrityValidator < ::ActiveModel::EachValidator
 
         def validate_each(record, attribute, value)
-          if e = record.send("#{attribute}_integrity_error")
+          if e = record.__send__("#{attribute}_integrity_error")
             message = (e.message == e.class.to_s) ? :carrierwave_integrity_error : e.message
             record.errors.add(attribute, message)
           end
@@ -31,7 +31,7 @@ module CarrierWave
       class DownloadValidator < ::ActiveModel::EachValidator
 
         def validate_each(record, attribute, value)
-          if e = record.send("#{attribute}_download_error")
+          if e = record.__send__("#{attribute}_download_error")
             message = (e.message == e.class.to_s) ? :carrierwave_download_error : e.message
             record.errors.add(attribute, message)
           end


### PR DESCRIPTION
Right now if a user overrides the `send` method in their model it breaks the mount_upload helper and carrierwave validations. By using `__send__` instead it avoids possible name clashes for when the user does override `send` in their model.