### PR TITLE
Modify README.md to add iam_profile credentials configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,6 +671,16 @@ CarrierWave.configure do |config|
 end
 ```
 
+You can also use iam_profile credentials:
+
+```ruby
+config.fog_credentials = {
+  ...
+  use_iam_profile: true
+  ...
+}
+```
+
 In your uploader, set the storage to :fog
 
 ```ruby


### PR DESCRIPTION
Instead of using AWS secret and access key, we can also use IAM Profile credentials.