### PR TITLE
Manage transaction rollback

### DIFF
--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -52,13 +52,12 @@ module CarrierWave
       validates_processing_of column if uploader_option(column.to_sym, :validate_processing)
       validates_download_of column if uploader_option(column.to_sym, :validate_download)
 
-      after_save :"store_#{column}!"
       before_save :"write_#{column}_identifier"
+      after_save :"store_previous_changes_for_#{column}"
       after_commit :"remove_#{column}!", :on => :destroy
       after_commit :"mark_remove_#{column}_false", :on => :update
-
-      after_save :"store_previous_changes_for_#{column}"
       after_commit :"remove_previously_stored_#{column}", :on => :update
+      after_commit :"store_#{column}!", :on => [:create, :update]
 
       class_eval <<-RUBY, __FILE__, __LINE__+1
         def #{column}=(new_file)

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -648,7 +648,7 @@ describe CarrierWave::ActiveRecord do
     end
 
     after do
-      FileUtils.rm_rf(file_path("uploads"))
+      FileUtils.rm_rf(public_path("uploads"))
     end
 
     describe 'normally' do
@@ -735,7 +735,7 @@ describe CarrierWave::ActiveRecord do
     end
 
     after do
-      FileUtils.rm_rf(file_path("uploads"))
+      FileUtils.rm_rf(public_path("uploads"))
     end
 
     it "should remove old file if old file had a different path" do
@@ -758,10 +758,48 @@ describe CarrierWave::ActiveRecord do
       Event.transaction do
         @event.image = stub_file('new.jpeg')
         @event.save
-        expect(File.exist?(public_path('uploads/new.jpeg'))).to be_truthy
         expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
         raise ActiveRecord::Rollback
       end
+      expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
+    end
+  end
+
+  describe "#mount_uploader into transaction" do
+    before do
+      @uploader.version :thumb
+      reset_class("Event")
+      Event.mount_uploader(:image, @uploader)
+      @event = Event.new
+    end
+
+    after do
+      FileUtils.rm_rf(public_path("uploads"))
+    end
+
+    it "should not store file during rollback" do
+      Event.transaction do
+        @event.image = stub_file('new.jpeg')
+        @event.save
+
+        raise ActiveRecord::Rollback
+      end
+
+      expect(File.exist?(public_path('uploads/new.jpeg'))).to be_falsey
+    end
+
+    it "should not change file during rollback" do
+      @event.image = stub_file('old.jpeg')
+      @event.save
+
+      Event.transaction do
+        @event.image = stub_file('new.jpeg')
+        @event.save
+
+        raise ActiveRecord::Rollback
+      end
+
+      expect(File.exist?(public_path('uploads/new.jpeg'))).to be_falsey
       expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
     end
   end
@@ -783,7 +821,7 @@ describe CarrierWave::ActiveRecord do
     end
 
     after do
-      FileUtils.rm_rf(file_path("uploads"))
+      FileUtils.rm_rf(public_path("uploads"))
     end
 
     it "should remove old file1 and file2 if old file1 and file2 had a different paths" do
@@ -826,7 +864,7 @@ describe CarrierWave::ActiveRecord do
     end
 
     after do
-      FileUtils.rm_rf(file_path("uploads"))
+      FileUtils.rm_rf(public_path("uploads"))
     end
 
     it "should remove old file if old file had a different path" do
@@ -1367,7 +1405,7 @@ describe CarrierWave::ActiveRecord do
     end
 
     after do
-      FileUtils.rm_rf(file_path("uploads"))
+      FileUtils.rm_rf(public_path("uploads"))
     end
 
     describe 'normally' do
@@ -1444,7 +1482,7 @@ describe CarrierWave::ActiveRecord do
     end
 
     after do
-      FileUtils.rm_rf(file_path("uploads"))
+      FileUtils.rm_rf(public_path("uploads"))
     end
 
     it "should remove old file if old file had a different path" do
@@ -1481,7 +1519,7 @@ describe CarrierWave::ActiveRecord do
     end
 
     after do
-      FileUtils.rm_rf(file_path("uploads"))
+      FileUtils.rm_rf(public_path("uploads"))
     end
 
     it "should remove old file1 and file2 if old file1 and file2 had a different paths" do
@@ -1523,7 +1561,7 @@ describe CarrierWave::ActiveRecord do
     end
 
     after do
-      FileUtils.rm_rf(file_path("uploads"))
+      FileUtils.rm_rf(public_path("uploads"))
     end
 
     it "should remove old file if old file had a different path" do


### PR DESCRIPTION
  When we try to create new active record object into transaction and meet rollback:
    database row will not be created but uploader has created file in folder and doesn't remove it.

  I changed behavior: now we store file only after commit action. This true and for update action in transaction.

  Changes in spec/orm/activerecord_spec.rb:
    - Add tests which covers this flows
    - replace cleaning folder from 'file_path' to 'public_path'. Cause file_path is 'spec/fixtures'
      and we don't create any 'uploads' folders there. We works with 'spec/public/uploads' folder.