### PR TITLE
add require statement

### DIFF
--- a/lib/carrierwave/utilities/uri.rb
+++ b/lib/carrierwave/utilities/uri.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 module CarrierWave
   module Utilities
     module Uri


### PR DESCRIPTION
otherwise raises: `uninitialized constant CarrierWave::Utilities::Uri::URI (NameError)` on a dependent project: https://github.com/metaware/carrierwave-google-storage