### PR TITLE
Reset Content-Type when converting a file format

### DIFF
--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -303,6 +303,7 @@ module CarrierWave
 
         if @format
           move_to = current_path.chomp(File.extname(current_path)) + ".#{@format}"
+          file.content_type = ::MIME::Types.type_for(move_to).first.to_s
           file.move_to(move_to, permissions, directory_permissions)
         end
 

--- a/lib/carrierwave/processing/rmagick.rb
+++ b/lib/carrierwave/processing/rmagick.rb
@@ -356,6 +356,7 @@ module CarrierWave
       if options[:format] || @format
         frames.write("#{options[:format] || @format}:#{current_path}", &write_block)
         move_to = current_path.chomp(File.extname(current_path)) + ".#{options[:format] || @format}"
+        file.content_type = ::MIME::Types.type_for(move_to).first.to_s
         file.move_to(move_to, permissions, directory_permissions)
       else
         frames.write(current_path, &write_block)

--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -185,6 +185,7 @@ module CarrierWave
       mkdir!(new_path, directory_permissions)
       move!(new_path)
       chmod!(new_path, permissions)
+      self.content_type = ::MIME::Types.type_for(new_path).first.to_s
       if keep_filename
         self.file = {:tempfile => new_path, :filename => original_filename, :content_type => content_type}
       else

--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -185,7 +185,6 @@ module CarrierWave
       mkdir!(new_path, directory_permissions)
       move!(new_path)
       chmod!(new_path, permissions)
-      self.content_type = ::MIME::Types.type_for(new_path).first.to_s
       if keep_filename
         self.file = {:tempfile => new_path, :filename => original_filename, :content_type => content_type}
       else

--- a/spec/processing/mini_magick_spec.rb
+++ b/spec/processing/mini_magick_spec.rb
@@ -21,6 +21,7 @@ describe CarrierWave::MiniMagick do
       instance.convert('png')
       expect(instance.file.extension).to eq('png')
       expect(instance).to be_format('png')
+      expect(instance.file.content_type).to eq('image/png')
     end
 
     it "converts all pages when no page number is specified" do

--- a/spec/processing/rmagick_spec.rb
+++ b/spec/processing/rmagick_spec.rb
@@ -23,6 +23,7 @@ describe CarrierWave::RMagick, :rmagick => true do
       instance.convert(:png)
       expect(instance.file.extension).to eq('png')
       expect(instance).to be_format('png')
+      expect(instance.file.content_type).to eq('image/png')
     end
   end
 

--- a/spec/sanitized_file_spec.rb
+++ b/spec/sanitized_file_spec.rb
@@ -309,10 +309,9 @@ describe CarrierWave::SanitizedFile do
       end
 
       it "should preserve the file's content type" do
-        content_type = sanitized_file.content_type
         sanitized_file.move_to(file_path("new_dir","gurr.png"))
 
-        expect(sanitized_file.content_type).to eq(content_type)
+        expect(sanitized_file.content_type).to eq("image/png")
       end
 
       context 'target path only differs by case' do

--- a/spec/sanitized_file_spec.rb
+++ b/spec/sanitized_file_spec.rb
@@ -308,10 +308,10 @@ describe CarrierWave::SanitizedFile do
         expect(sanitized_file.move_to(file_path("gurr.png"))).to eq(sanitized_file)
       end
 
-      it "should preserve the file's content type" do
+      it "should convert the file's content type" do
         sanitized_file.move_to(file_path("new_dir","gurr.png"))
 
-        expect(sanitized_file.content_type).to eq("image/png")
+        expect(sanitized_file.content_type).to eq("image/jpeg")
       end
 
       context 'target path only differs by case' do


### PR DESCRIPTION
Hi.

The original Content-Type is preserved, although the file format has been converted. 
It is a problem in my application, which returns the Content-Type by extracting from the stored file.

I would be happy if the Content-Type is set again with a converted new file.