### PR TITLE
Remove unwanted space from uploader template

### DIFF
--- a/lib/generators/templates/uploader.rb
+++ b/lib/generators/templates/uploader.rb
@@ -1,5 +1,4 @@
 class <%= class_name %>Uploader < CarrierWave::Uploader::Base
-
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
   # include CarrierWave::MiniMagick
@@ -45,5 +44,4 @@ class <%= class_name %>Uploader < CarrierWave::Uploader::Base
   # def filename
   #   "something.jpg" if original_filename
   # end
-
 end


### PR DESCRIPTION
Removed unwanted space from uploader template which was causing overcommit error.
![carrierwave_overcommit](https://user-images.githubusercontent.com/13102912/32174759-be3de83a-bda8-11e7-9151-5c6dae2c08fa.png)
