### PR TITLE
Fix #serializable_hash to returns string keys for versions

### DIFF
--- a/lib/carrierwave/uploader/serialization.rb
+++ b/lib/carrierwave/uploader/serialization.rb
@@ -7,7 +7,7 @@ module CarrierWave
       extend ActiveSupport::Concern
 
       def serializable_hash(options = nil)
-        {"url" => url}.merge Hash[versions.map { |name, version| [name, { "url" => version.url }] }]
+        {"url" => url}.merge Hash[versions.map { |name, version| [name.to_s, { "url" => version.url }] }]
       end
 
       def as_json(options=nil)


### PR DESCRIPTION
`> uploader.as_json`

Before: 
```
{
  "url" => "/uploads/81445456.jpg", 
  :thumb => {
    "url" => "/uploads/thumb_81445456.jpg"
  }
}
```

After: 

```
{
  "url" => "/uploads/81445456.jpg", 
  "thumb" => {
    "url" => "/uploads/thumb_81445456.jpg"
  }
}
```