### PR TITLE
Changing Imagemagick to rmagick

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Some documentation refers to RMagick instead of MiniMagick but MiniMagick is rec
 To install Imagemagick on OSX with homebrew type the following:
 
 ```
-$ brew install imagemagick
+$ brew install rmagick
 ```
 
 ```ruby


### PR DESCRIPTION
Imagemagick is not on ruby gems.