### PR TITLE
Fix activerecord spec errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ rvm:
  - jruby-9.1.5.0
 
 gemfile:
-  - gemfiles/rails-4-0.gemfile
-  - gemfiles/rails-4-1.gemfile
   - gemfiles/rails-4-2.gemfile
   - gemfiles/rails-5-0.gemfile
   - gemfiles/rails-5-1.gemfile
@@ -27,15 +25,7 @@ before_script:
 matrix:
   include:
     - rvm: 2.0
-      gemfile: gemfiles/rails-4-0.gemfile
-    - rvm: 2.0
-      gemfile: gemfiles/rails-4-1.gemfile
-    - rvm: 2.0
       gemfile: gemfiles/rails-4-2.gemfile
-    - rvm: 2.1
-      gemfile: gemfiles/rails-4-0.gemfile
-    - rvm: 2.1
-      gemfile: gemfiles/rails-4-1.gemfile
     - rvm: 2.1
       gemfile: gemfiles/rails-4-2.gemfile
     - rvm: ruby-head
@@ -47,10 +37,6 @@ matrix:
     - rvm: jruby-head
       gemfile: gemfiles/rails-master.gemfile
   exclude:
-    - rvm: 2.4.1
-      gemfile: gemfiles/rails-4-0.gemfile
-    - rvm: 2.4.1
-      gemfile: gemfiles/rails-4-1.gemfile
     - rvm: 2.4.1
       gemfile: gemfiles/rails-4-2.gemfile
   allow_failures:

--- a/gemfiles/rails-4-0.gemfile
+++ b/gemfiles/rails-4-0.gemfile
@@ -1,6 +1,0 @@
-source "https://rubygems.org"
-
-gem "rails", "~> 4.0.0"
-gem "railties", "~> 4.0.0"
-
-gemspec :path => "../"

--- a/gemfiles/rails-4-1.gemfile
+++ b/gemfiles/rails-4-1.gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gem "rails", "~> 4.1.0"
-
-gemspec :path => "../"

--- a/gemfiles/rails-4-2.gemfile
+++ b/gemfiles/rails-4-2.gemfile
@@ -2,4 +2,5 @@ source "https://rubygems.org"
 
 gem "rails", "~> 4.2.0"
 
+gem "activerecord-jdbc-adapter", "1.3.24" if RUBY_ENGINE == 'jruby'
 gemspec :path => "../"

--- a/gemfiles/rails-5-0.gemfile
+++ b/gemfiles/rails-5-0.gemfile
@@ -2,6 +2,6 @@ source "https://rubygems.org"
 
 gem "rails", "~> 5.0.0"
 gem "activemodel-serializers-xml"
-gem "activerecord-jdbcpostgresql-adapter", github: "jruby/activerecord-jdbc-adapter", branch: "rails-5", platforms: :jruby
+gem "activerecord-jdbcpostgresql-adapter", github: "jruby/activerecord-jdbc-adapter", branch: "50-stable", platforms: :jruby
 
 gemspec :path => "../"

--- a/gemfiles/rails-5-1.gemfile
+++ b/gemfiles/rails-5-1.gemfile
@@ -2,6 +2,6 @@ source "https://rubygems.org"
 
 gem "rails", "~> 5.1.0"
 gem "activemodel-serializers-xml"
-gem "activerecord-jdbcpostgresql-adapter", github: "jruby/activerecord-jdbc-adapter", branch: "rails-5", platforms: :jruby
+gem "activerecord-jdbcpostgresql-adapter", github: "jruby/activerecord-jdbc-adapter", branch: "master", platforms: :jruby
 
 gemspec :path => "../"

--- a/gemfiles/rails-master.gemfile
+++ b/gemfiles/rails-master.gemfile
@@ -7,6 +7,6 @@ gem "sprockets", github: "rails/sprockets", branch: "master"
 gem "sprockets-rails", github: "rails/sprockets-rails", branch: "master"
 gem "sass-rails", github: "rails/sass-rails"
 gem "activemodel-serializers-xml"
-gem "activerecord-jdbcpostgresql-adapter", github: "jruby/activerecord-jdbc-adapter", branch: "rails-5", platforms: :jruby
+gem "activerecord-jdbcpostgresql-adapter", github: "jruby/activerecord-jdbc-adapter", branch: "master", platforms: :jruby
 
 gemspec :path => "../"


### PR DESCRIPTION
Fix spec errors like [Build \#1195 \- carrierwaveuploader/carrierwave \- Travis CI](https://travis-ci.org/carrierwaveuploader/carrierwave/builds/302365612).

According to [jruby/activerecord-jdbc-adapter](https://github.com/jruby/activerecord-jdbc-adapter)'s README, 

> Version 50.x supports Rails version 5.0.x and it lives on branch 50-stable. Version 51.x supports Rails version 5.1.x and is currently on master until its first release. 

And Rails 4.0 and 4.1 are no longer unsupported by Rails official community. I think it should not be suppported anymore.