### PR TITLE
Add `use_iam_profile` aws config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,8 +667,9 @@ CarrierWave.configure do |config|
   config.fog_provider = 'fog/aws'                        # required
   config.fog_credentials = {
     provider:              'AWS',                        # required
-    aws_access_key_id:     'xxx',                        # required
-    aws_secret_access_key: 'yyy',                        # required
+    aws_access_key_id:     'xxx',                        # required unless using use_iam_profile
+    aws_secret_access_key: 'yyy',                        # required unless using use_iam_profile
+    use_iam_profile:       true,                         # optional, defaults to false
     region:                'eu-west-1',                  # optional, defaults to 'us-east-1'
     host:                  's3.example.com',             # optional, defaults to nil
     endpoint:              'https://s3.example.com:8080' # optional, defaults to nil


### PR DESCRIPTION
Good AWS practice dictates we should be using instance profiles where possible for AWS s3 permissions (provided we are all within AWS land).  I had to go digging to find this parameter, so upgraded the documentation to make it easier for anyone looking for this in future.