### PR TITLE
Update `gem install carrierwave` instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ It works well with Rack based web applications, such as Ruby on Rails.
 Install the latest release:
 
 ```
-$ gem install carrierwave -v "1.0.0"
+$ gem install carrierwave
 ```
 
 In Rails, add it to your Gemfile:


### PR DESCRIPTION
Hi there! 

Right now Carrierwave's latest version is 1.2.2. 

The `gem install` instruction seems to be out of date. 

Please check it out.

Thanks! 