### PR TITLE
When the file pointed to by a CarrierWave::Storage::Fog::File ...

### DIFF
--- a/lib/carrierwave/locale/en.yml
+++ b/lib/carrierwave/locale/en.yml
@@ -6,6 +6,7 @@ en:
       carrierwave_download_error: could not be downloaded
       extension_whitelist_error: "You are not allowed to upload %{extension} files, allowed types: %{allowed_types}"
       extension_blacklist_error: "You are not allowed to upload %{extension} files, prohibited types: %{prohibited_types}"
+      fog_file_not_found_error: "File not found in remote directory: %{path}"
       content_type_whitelist_error: "You are not allowed to upload %{content_type} files"
       content_type_blacklist_error: "You are not allowed to upload %{content_type} files"
       rmagick_processing_error: "Failed to manipulate with rmagick, maybe it is not an image?"

--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -451,8 +451,16 @@ module CarrierWave
         #
         # [Fog::#{provider}::File] file data from remote service
         #
+        # === Raises
+        #
+        # [CarrierWave::IntegrityError] if the file is not found.
+        #
         def file
-          @file ||= directory.files.head(path)
+          @file ||= directory.files.head(path) || begin
+                                                    raise CarrierWave::IntegrityError,
+                                                          I18n.translate(:"errors.messages.fog_file_not_found_error",
+                                                                         :path => path)
+                                                  end
         end
 
         def acl_header

--- a/spec/storage/fog_spec.rb
+++ b/spec/storage/fog_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'spec_helper'
 require 'fog'
 require 'carrierwave/storage/fog'
@@ -42,6 +43,14 @@ describe CarrierWave::Storage::Fog::File do
 
       it "decodes multi-byte characters" do
         is_expected.to eq('日本語.txt')
+      end
+    end
+
+    context "when the remote file does not exist" do
+      before { allow(file).to receive_message_chain("directory.files.head") { nil } }
+      let(:url) { 'http://example.com/path/to/nothing.txt' }
+      it "raises a CarrierWave::IntegrityError" do
+        expect(file.read).to raise_error(CarrierWave::IntegrityError)
       end
     end
   end


### PR DESCRIPTION
When the file pointed to by a `CarrierWave::Storage::Fog::File` does not exist, throw a `CarrierWave::IntegrityError` when the private `file` method is called.

Otherwise, if you call `read` on the object, a `NoMethodError` is thrown because `file` ends up returning `nil`, and then `read` attempts to call `nil.body`.

```
Error: undefined method `body' for nil:NilClass (Error of type NoMethodError) /var/app/20180403T073104Z/vendor/bundle/ruby/2.3.0/gems/carrierwave-0.11.2/lib/carrierwave/storage/fog.rb:226:in `read' /var/app/20180403T073104Z/vendor/bundle/ruby/2.3.0/gems/carrierwave-0.11.2/lib/carrierwave/uploader/cache.rb:89:in `sanitized_file' /var/app/20180403T073104Z/vendor/bundle/ruby/2.3.0/gems/carrierwave-0.11.2/lib/carrierwave/uploader/cache.rb:128:in `cache!' /var/app/20180403T073104Z/vendor/bundle/ruby/2.3.0/gems/carrierwave-0.11.2/lib/carrierwave/uploader/cache.rb:85:in `cache_stored_file!' 
```
