### PR TITLE
use cached file first to open image with MiniMagic

### DIFF
--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -341,11 +341,8 @@ module CarrierWave
       end
 
       def mini_magick_image
-        if url
-          ::MiniMagick::Image.open(url)
-        else
-          ::MiniMagick::Image.open(current_path)
-        end
+        img = cached? ? full_cached_path : url || current_path
+        ::MiniMagick::Image.open(img)
       end
 
   end # MiniMagick

--- a/lib/carrierwave/uploader/cache.rb
+++ b/lib/carrierwave/uploader/cache.rb
@@ -176,6 +176,17 @@ module CarrierWave
         File.join(*[cache_dir, @cache_id, for_file].compact)
       end
 
+      ##
+      # Gets the full path where the cached file is stored
+      #
+      # === Returns
+      #
+      # [String] the full cached path
+      #
+      def full_cached_path
+        File.join(root, cache_path)
+      end
+
     private
 
       def workfile_path(for_file=original_filename)


### PR DESCRIPTION
When a file is uploaded and it is still not saved yet, getting its width or height fails with an error message something like in #1947. So this fix uses the cached file first if it is available or use previous strategy to continue.

This pull request fixed #1947.