### PR TITLE
change more explicit comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,7 +673,7 @@ CarrierWave.configure do |config|
     host:                  's3.example.com',             # optional, defaults to nil
     endpoint:              'https://s3.example.com:8080' # optional, defaults to nil
   }
-  config.fog_directory  = 'name_of_directory'                                   # required
+  config.fog_directory  = 'name_of_bucket'                                      # required
   config.fog_public     = false                                                 # optional, defaults to true
   config.fog_attributes = { cache_control: "public, max-age=#{365.days.to_i}" } # optional, defaults to {}
 end


### PR DESCRIPTION
'name_of_directory' to 'name_of_bucket' about fog AWS S3 configuration

I think that it is a explicit expression
because aws is using the bucket not the directory