### PR TITLE
Add SemVer stability badge to README, and fix code climate badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ It works well with Rack based web applications, such as Ruby on Rails.
 
 [![Build Status](https://travis-ci.org/carrierwaveuploader/carrierwave.svg?branch=master)](http://travis-ci.org/carrierwaveuploader/carrierwave)
 [![Code Climate](https://codeclimate.com/github/carrierwaveuploader/carrierwave.svg)](https://codeclimate.com/github/carrierwaveuploader/carrierwave)
-[![git.legal](https://git.legal/projects/1363/badge.svg "Number of libraries approved")](https://git.legal/projects/1363)
 [![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=carrierwave&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=carrierwave&package-manager=bundler&version-scheme=semver)
 
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ This gem provides a simple and extremely flexible way to upload files from Ruby 
 It works well with Rack based web applications, such as Ruby on Rails.
 
 [![Build Status](https://travis-ci.org/carrierwaveuploader/carrierwave.svg?branch=master)](http://travis-ci.org/carrierwaveuploader/carrierwave)
-[![Code Climate](http://img.shields.io/codeclimate/github/carrierwaveuploader/carrierwave.svg)](https://codeclimate.com/github/carrierwaveuploader/carrierwave)
+[![Code Climate](https://codeclimate.com/github/carrierwaveuploader/carrierwave.svg)](https://codeclimate.com/github/carrierwaveuploader/carrierwave)
 [![git.legal](https://git.legal/projects/1363/badge.svg "Number of libraries approved")](https://git.legal/projects/1363)
+[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=carrierwave&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=carrierwave&package-manager=bundler&version-scheme=semver)
 
 
 ## Information
@@ -307,7 +308,7 @@ to exactly 200 by 200 pixels.
 
 If you would like to crop images to a specific height and width you
 can use the alternative option of '''resize_to_fill'''. It will make sure
-that the width and height specified are filled, only cropping 
+that the width and height specified are filled, only cropping
 if the aspect ratio requires it.
 
 The uploader could be used like this:


### PR DESCRIPTION
@plribeiro3000 - saw your comment on https://github.com/fog/fog/pull/4001 and that you're a maintainer here, so thought I'd put together a badge for carrierware, too 🙂.

I've also fixed the codeclimate badge. ~~I left the git.legal badge, which was broken when I was putting this together, incase they were just suffering downtime. I'll delete it if they're not back up tomorrow...~~ I've now deleted the git.legal badge, too.

Updated badges:

[![Build Status](https://travis-ci.org/carrierwaveuploader/carrierwave.svg?branch=master)](http://travis-ci.org/carrierwaveuploader/carrierwave) [![Code Climate](https://codeclimate.com/github/carrierwaveuploader/carrierwave.svg)](https://codeclimate.com/github/carrierwaveuploader/carrierwave) [![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=carrierwave&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=carrierwave&package-manager=bundler&version-scheme=semver)