### PR TITLE
Check if before is either nil or empty, not just nil in lib/carrierwave/mounter.rb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ gemfile:
 sudo: false
 
 before_install:
-  - gem install bundler
+  - gem install bundler -v 1.16.2
 
 before_script:
   - psql -c 'create database carrierwave_test;' -U postgres

--- a/lib/carrierwave/mounter.rb
+++ b/lib/carrierwave/mounter.rb
@@ -124,10 +124,11 @@ module CarrierWave
 
     def remove_previous(before=nil, after=nil)
       after ||= []
-      return unless before
+      before.reject!(&:blank?) if before
+      return if before.blank?
 
       # both 'before' and 'after' can be string when 'mount_on' option is set
-      before = before.reject(&:blank?).map do |value|
+      before = before.map do |value|
         if value.is_a?(String)
           uploader = blank_uploader
           uploader.retrieve_from_store!(value)


### PR DESCRIPTION
It doesn't make sense to me to check here if `before` is only nil, the check should be if it is nil or empty, since before being an empty array defeats the purpose of the rest of this method.

This is causing a problem with https://github.com/diogob/carrierwave-postgresql/issues/33 for me, where the second part of this method breaks hard when before is empty.