### PR TITLE
If no space left then remove old cache

### DIFF
--- a/lib/carrierwave/storage/file.rb
+++ b/lib/carrierwave/storage/file.rb
@@ -66,7 +66,7 @@ module CarrierWave
       #
       def cache!(new_file)
         new_file.move_to(::File.expand_path(uploader.cache_path, uploader.root), uploader.permissions, uploader.directory_permissions, true)
-      rescue Errno::EMLINK => e
+      rescue Errno::EMLINK, Errno::ENOSPC => e
         raise(e) if @cache_called
         @cache_called = true
 

--- a/spec/storage/file_spec.rb
+++ b/spec/storage/file_spec.rb
@@ -40,7 +40,14 @@ describe CarrierWave::Storage::File do
 
   describe '#cache!' do
     context "when FileUtils.mkdir_p raises Errno::EMLINK" do
-      before { fake_failed_mkdir_p }
+      before { fake_failed_mkdir_p(Errno::EMLINK) }
+      after { storage.cache!(sanitized_temp_file) }
+
+      it { is_expected.to receive(:clean_cache!).with(600) }
+    end
+
+    context "when FileUtils.mkdir_p raises Errno::ENOSPC" do
+      before { fake_failed_mkdir_p(Errno::ENOSPC) }
       after { storage.cache!(sanitized_temp_file) }
 
       it { is_expected.to receive(:clean_cache!).with(600) }

--- a/spec/support/file_utils_helper.rb
+++ b/spec/support/file_utils_helper.rb
@@ -1,6 +1,6 @@
 module FileUtilsHelper
-  # NOTE: Make FileUtils.mkdir_p to raise `Errno::EMLINK` only once
-  def fake_failed_mkdir_p
+  # NOTE: Make FileUtils.mkdir_p to raise error only once
+  def fake_failed_mkdir_p(error)
     original_mkdir_p = FileUtils.method(:mkdir_p)
     mkdir_p_called = false
     allow(FileUtils).to receive(:mkdir_p) do |args|
@@ -8,7 +8,7 @@ module FileUtilsHelper
         original_mkdir_p.call(*args)
       else
         mkdir_p_called = true
-        raise Errno::EMLINK
+        raise error
       end
     end
   end


### PR DESCRIPTION
Hi from GitLab

Currently, we're experiencing that Carrierwave raises `Errno::ENOSPC` when caching files. This is because inodes are full in the cache directory regardless of that its capacity has still some room. (See more  https://gitlab.com/gitlab-com/gl-infra/infrastructure/issues/5217) We manually removed old cache files/directories and the situation was mitigated, but this could happen in the future again, and ideally this recovery process should be automated.

/cc @stanhu