### PR TITLE
Clear remote urls on assigning nil to remote_[:column]_url

### DIFF
--- a/lib/carrierwave/mounter.rb
+++ b/lib/carrierwave/mounter.rb
@@ -70,7 +70,7 @@ module CarrierWave
     end
 
     def remote_urls=(urls)
-      return if not urls or urls == "" or urls.all?(&:blank?)
+      return @remote_urls = nil if not urls or urls == "" or urls.all?(&:blank?)
 
       @remote_urls = urls
       @download_error = nil


### PR DESCRIPTION
Add possibility to clear remote urls list on assigning nil to remote_[:column]_url
Issue: https://github.com/carrierwaveuploader/carrierwave/issues/2343

Usecase: If downloading or processing fails I want to be able to set remote url's value to nil to save my object totally without the image (using rescue).