### PR TITLE
MiniMagick: use read method to get file data

### DIFF
--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -341,11 +341,7 @@ module CarrierWave
       end
 
       def mini_magick_image
-        if url
-          ::MiniMagick::Image.open(url)
-        else
-          ::MiniMagick::Image.open(current_path)
-        end
+        ::MiniMagick::Image.read(self.read)
       end
 
   end # MiniMagick

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -164,6 +164,30 @@ describe CarrierWave::ActiveRecord do
 
         expect(@event.reload.image).to be_blank
       end
+
+      context "with CarrierWave::MiniMagick" do
+        before(:each) do
+          @uploader.send(:include, CarrierWave::MiniMagick)
+        end
+
+        it "has width and height" do
+          @event.image = stub_file('landscape.jpg')
+          expect(@event.image.width).to eq 640
+          expect(@event.image.height).to eq 480
+        end
+      end
+
+      context "with CarrierWave::MiniMagick", :rmagick => true do
+        before(:each) do
+          @uploader.send(:include, CarrierWave::RMagick)
+        end
+
+        it "has width and height" do
+          @event.image = stub_file('landscape.jpg')
+          expect(@event.image.width).to eq 640
+          expect(@event.image.height).to eq 480
+        end
+      end
     end
 
     describe '#image=' do

--- a/spec/processing/mini_magick_spec.rb
+++ b/spec/processing/mini_magick_spec.rb
@@ -10,7 +10,6 @@ describe CarrierWave::MiniMagick do
   before do
     FileUtils.cp(landscape_file_path, landscape_copy_file_path)
     allow(instance).to receive(:cached?).and_return true
-    allow(instance).to receive(:url).and_return nil
     allow(instance).to receive(:file).and_return(CarrierWave::SanitizedFile.new(landscape_copy_file_path))
   end
 


### PR DESCRIPTION
Fixes #1947 and the issue described in #2299 

> When a file is uploaded and it is still not saved yet, getting its width or height fails with an error message something like in #1947. So this fix uses the cached file first if it is available or use previous strategy to continue.

