### PR TITLE
Add Jets Turbine Support

### DIFF
--- a/lib/carrierwave.rb
+++ b/lib/carrierwave.rb
@@ -34,6 +34,26 @@ if defined?(Merb)
     Dir.glob(File.join(Merb.load_paths[:uploaders])).each {|f| require f }
   end
 
+elsif defined?(Jets)
+
+  module CarrierWave
+    class Turbine < Jets::Turbine
+      initializer "carrierwave.setup_paths" do |app|
+        CarrierWave.root = Jets.root.to_s
+        CarrierWave.tmp_path = "/tmp/carrierwave"
+        CarrierWave.configure do |config|
+          config.cache_dir = "/tmp/carrierwave/uploads/tmp"
+        end
+      end
+
+      initializer "carrierwave.active_record" do
+        ActiveSupport.on_load :active_record do
+          require 'carrierwave/orm/activerecord'
+        end
+      end
+    end
+  end
+
 elsif defined?(Rails)
 
   module CarrierWave


### PR DESCRIPTION
This pull request adds [Jets](http://rubyonjets.com/) support to Carrierwave as a [Turbine](http://rubyonjets.com/docs/jets-turbines/). Jets is a Ruby Serverless Framework. This allows us to upload files to s3 via Carrierwave with API Gateway and AWS Lambda. Here are some relevant links:

* [Live Demo of Jets Support Working](https://upload.demo.rubyonjets.com/)
* Blog Post covering it: [Jets Image Upload Carrierwave Tutorial: Binary Support](https://blog.boltops.com/2018/12/13/jets-image-upload-carrierwave-tutorial-binary-support)
