### PR TITLE
Only include `x-amz-acl` header for AWS

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -467,7 +467,7 @@ module CarrierWave
 
         def acl_header
           if fog_provider == 'AWS'
-            {'x-amz-acl' => @uploader.fog_public ? 'public-read' : 'private'}
+            { 'x-amz-acl' => @uploader.fog_public ? 'public-read' : 'private' }
           else
             {}
           end

--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -352,7 +352,7 @@ module CarrierWave
             end
           else
             # AWS/Google optimized for speed over correctness
-            case @uploader.fog_credentials[:provider].to_s
+            case fog_provider
             when 'AWS'
               # check if some endpoint is set in fog_credentials
               if @uploader.fog_credentials.has_key?(:endpoint)
@@ -466,7 +466,15 @@ module CarrierWave
         end
 
         def acl_header
-          {'x-amz-acl' => @uploader.fog_public ? 'public-read' : 'private'}
+          if fog_provider == 'AWS'
+            {'x-amz-acl' => @uploader.fog_public ? 'public-read' : 'private'}
+          else
+            {}
+          end
+        end
+
+        def fog_provider
+          @uploader.fog_credentials[:provider].to_s
         end
 
         def read_source_file(file_body)

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -44,6 +44,28 @@ end
         end
       end
 
+      context '#acl_header' do
+        let(:store_path) { 'uploads/test+.jpg' }
+
+        before do
+          allow(@uploader).to receive(:store_path).and_return(store_path)
+        end
+
+        it 'includes acl_header when necessary' do
+          if file.is_a?(CarrierWave::Storage::Fog::File)
+            if @provider == 'AWS'
+              expect(@storage.connection).to receive(:copy_object)
+                                              .with(anything, anything, anything, anything, { "x-amz-acl"=>"public-read" }).and_call_original
+            else
+              expect(@storage.connection).to receive(:copy_object)
+                                              .with(anything, anything, anything, anything, {}).and_call_original
+            end
+          end
+
+          @storage.store!(file)
+        end
+      end
+
       describe '#store!' do
         let(:store_path) { 'uploads/test+.jpg' }
 


### PR DESCRIPTION
Even in AWS S3 compatibility mode, Google now appears to reject requests
that includes this header with this error:

```
Requests cannot specify both x-amz and x-goog headers
```