### PR TITLE
Fix failing master builds

### DIFF
--- a/spec/sanitized_file_spec.rb
+++ b/spec/sanitized_file_spec.rb
@@ -9,8 +9,11 @@ end
 
 describe CarrierWave::SanitizedFile do
   before do
-    FileUtils.rm_rf(file_path("new_dir"))
     FileUtils.cp(file_path('test.jpg'), file_path('llama.jpg'))
+  end
+
+  after do
+    FileUtils.rm_rf(file_path("new_dir"))
   end
 
   after(:all) do

--- a/spec/sanitized_file_spec.rb
+++ b/spec/sanitized_file_spec.rb
@@ -9,6 +9,7 @@ end
 
 describe CarrierWave::SanitizedFile do
   before do
+    FileUtils.rm_rf(file_path("new_dir"))
     FileUtils.cp(file_path('test.jpg'), file_path('llama.jpg'))
   end
 
@@ -301,7 +302,6 @@ describe CarrierWave::SanitizedFile do
         sanitized_file.move_to(file_path("new_dir","gurr.png"), nil, 0775)
 
         expect(sanitized_file).to have_directory_permissions(0775)
-        FileUtils.rm_rf(file_path("new_dir"))
       end
 
       it "should return itself" do
@@ -395,7 +395,6 @@ describe CarrierWave::SanitizedFile do
         new_file = sanitized_file.copy_to(file_path("new_dir", "gurr.png"), nil, 0755)
 
         expect(new_file).to have_directory_permissions(0755)
-        FileUtils.rm_rf(file_path("new_dir"))
       end
 
       it "should preserve the file's content type" do


### PR DESCRIPTION
Leftover `new_dir` directories with the wrong permissions were causing
false positives when multiple examples were running.