### PR TITLE
Avoid extra HEAD request when making request for auth URL

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -495,7 +495,7 @@ module CarrierWave
         end
 
         def url_options_supported?(local_file)
-          parameters = file.method(:url).parameters
+          parameters = local_file.method(:url).parameters
           parameters.count == 2 && parameters[1].include?(:options)
         end
       end


### PR DESCRIPTION
1.3.0 has a performance regression in that `file` would call `directories.files.head` to check whether the given `File` had the right signature. We can avoid that by just using `local_file`.