### PR TITLE
Add support AzureRM provider to authenticated_url

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -177,7 +177,7 @@ module CarrierWave
 
         ##
         # Return a temporary authenticated url to a private file, if available
-        # Only supported for AWS, Rackspace and Google providers
+        # Only supported for AWS, Rackspace, Google and AzureRM providers
         #
         # === Returns
         #
@@ -186,7 +186,7 @@ module CarrierWave
         # [NilClass] no authenticated url available
         #
         def authenticated_url(options = {})
-          if ['AWS', 'Google', 'Rackspace', 'OpenStack'].include?(@uploader.fog_credentials[:provider])
+          if ['AWS', 'Google', 'Rackspace', 'OpenStack', 'AzureRM'].include?(@uploader.fog_credentials[:provider])
             # avoid a get by using local references
             local_directory = connection.directories.new(:key => @uploader.fog_directory)
             local_file = local_directory.files.new(:key => path)

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -438,7 +438,7 @@ end
           end
 
           it "should have an authenticated_url" do
-            if ['AWS', 'Rackspace', 'Google', 'OpenStack'].include?(@provider)
+            if ['AWS', 'Rackspace', 'Google', 'OpenStack', 'AzureRM'].include?(@provider)
               expect(@fog_file.authenticated_url).not_to be_nil
             end
           end


### PR DESCRIPTION
Adds `authenticated_url` support when using [fog-azure-rm](https://github.com/fog/fog-azure-rm)