### PR TITLE
Add support Aliyun provider to authenticated_url aliyun

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -177,7 +177,7 @@ module CarrierWave
 
         ##
         # Return a temporary authenticated url to a private file, if available
-        # Only supported for AWS, Rackspace, Google and AzureRM providers
+        # Only supported for AWS, Rackspace, Google, AzureRM and Aliyun providers
         #
         # === Returns
         #
@@ -186,7 +186,7 @@ module CarrierWave
         # [NilClass] no authenticated url available
         #
         def authenticated_url(options = {})
-          if ['AWS', 'Google', 'Rackspace', 'OpenStack', 'AzureRM'].include?(@uploader.fog_credentials[:provider])
+          if ['AWS', 'Google', 'Rackspace', 'OpenStack', 'AzureRM', 'Aliyun'].include?(@uploader.fog_credentials[:provider])
             # avoid a get by using local references
             local_directory = connection.directories.new(:key => @uploader.fog_directory)
             local_file = local_directory.files.new(:key => path)

--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -204,6 +204,9 @@ module CarrierWave
                 connection.get_object_https_url(@uploader.fog_directory, path, expire_at, options)
               when 'OpenStack'
                 connection.get_object_https_url(@uploader.fog_directory, path, expire_at)
+              when 'Aliyun'
+                expire_at = expire_at - Time.now
+                local_file.url(expire_at)
               else
                 local_file.url(expire_at)
             end

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -438,7 +438,7 @@ end
           end
 
           it "should have an authenticated_url" do
-            if ['AWS', 'Rackspace', 'Google', 'OpenStack', 'AzureRM'].include?(@provider)
+            if ['AWS', 'Rackspace', 'Google', 'OpenStack', 'AzureRM', 'Aliyun'].include?(@provider)
               expect(@fog_file.authenticated_url).not_to be_nil
             end
           end


### PR DESCRIPTION
Adds authenticated_url support when using [fog-aliyun](https://github.com/fog/fog-aliyun)