### PR TITLE
Preserve connection cache when setting fog_credentials

### DIFF
--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -123,7 +123,9 @@ module CarrierWave
               # see #1198. This will hopefully no longer be necessary after fog 2.0
               require self.fog_provider
               require 'carrierwave/storage/fog'
-              Fog::Storage.new(fog_credentials) if fog_credentials.present?
+              if fog_credentials.present?
+                CarrierWave::Storage::Fog.connection_cache[fog_credentials] ||= Fog::Storage.new(fog_credentials)
+              end
             end unless defined? eager_load_fog
 
             def self.#{name}(value=nil)


### PR DESCRIPTION
Create a setup using this wiki https://github.com/carrierwaveuploader/carrierwave/wiki/How-to:-Define-different-storage-configuration-for-each-Uploader leads to initializing CarrierWave on every uploader initialization instead of using cached connections.
This PR adds connection cache utilization for the case described in wiki above.