### PR TITLE
Do not return unexpected false for content type when file is deleted

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -218,7 +218,7 @@ module CarrierWave
         # [String] value of content-type
         #
         def content_type
-          @content_type || !file.nil? && file.content_type
+          @content_type || file&.content_type
         end
 
         ##

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -251,8 +251,8 @@ end
               expect { @fog_file.size }.not_to raise_error
             end
 
-            it "should not error getting the content type" do
-              expect { @fog_file.content_type }.not_to raise_error
+            it "should return a string or nil for content type" do
+              expect { @fog_file.content_type&.size }.not_to raise_error
             end
           end
         end


### PR DESCRIPTION
Background:
- it is weird when calling file.content_type return `false` if file is deleted
- I would expecting a string (or maybe nil) for file.content_type