### PR TITLE
Add note on S3 permissions on the 'Using Amazon S3' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,6 +711,14 @@ end
 
 That's it! You can still use the `CarrierWave::Uploader#url` method to return the url to the file on Amazon S3.
 
+**Note**: for Carrierwave to work properly it needs credentials with the following permissions:
+
+* `s3:ListBucket`
+* `s3:PutObject`
+* `s3:GetObject`
+* `s3:DeleteObject`
+* `s3:PutObjectAcl`
+
 ## Using Rackspace Cloud Files
 
 [Fog](http://github.com/fog/fog) is used to support Rackspace Cloud Files. Ensure you have it in your Gemfile:


### PR DESCRIPTION
We struggled to make carrierwave work with S3 (with iam profile) only to found out that we needed to add the `s3:PutObjectAcl` permission to the role used. This note in the documentation may save a lot of time for future developers setting up S3 with carrierwave. 

The listed permissions are the ones we are currently using. If Carrierwave actually needs more permissions (or doesn't need one of the listed in the changes) let me know and I can change the PR. English is not my native language, so feel free to make any corrections needed.