### PR TITLE
base64 encoding

### DIFF
--- a/lib/carrierwave/uploader/serialization.rb
+++ b/lib/carrierwave/uploader/serialization.rb
@@ -23,6 +23,17 @@ module CarrierWave
         serializable_hash.to_xml(merged_options)
       end
 
+      def to_base64
+        {"data" => as_base64(url)}.merge Hash[versions.map { |name, version| [name.to_s, { "data" => as_base64(version.url) }] }]
+      end
+
+      private
+
+      def as_base64(url)
+        bytes = open(url) {|f| f.read }
+        "data:image/png;base64," + Base64.strict_encode64(bytes)
+      end
+
     end
   end
 end


### PR DESCRIPTION
problem
---------
- run into CORS issues when attempting to modify an image whose src is from another domain
    - ex: cropping a profile pic for a user while storing images with S3
    - ex error: '...Tainted canvases may not be exported.'

solution
--------
- in my project, I overwrote the to_json module to serialize into base64 in the appropriate image src format
- but in this pr, I created a separate method

notes
------
- the current implementation could certainly use some refactoring (for example it would probably blow up if url was nil) but IMO the general feature is useful
- perhaps an additional key could be added to the JSON hash
