### PR TITLE
Fix `remote_x_url=` raise undefined method `[]' for nil:NilClass (NoMethodError)

### DIFF
--- a/lib/carrierwave/downloader/remote_file.rb
+++ b/lib/carrierwave/downloader/remote_file.rb
@@ -23,10 +23,12 @@ module CarrierWave
       private
 
       def filename_from_header
-        if file.meta.include? 'content-disposition'
-          match = file.meta['content-disposition'].match(/filename=(?:"([^"]+)"|([^";]+))/)
-          match[1].presence || match[2].presence
-        end
+        return nil unless file.meta.include? 'content-disposition'
+
+        match = file.meta['content-disposition'].match(/filename=(?:"([^"]+)"|([^";]+))/)
+        return nil unless match
+
+        match[1].presence || match[2].presence
       end
 
       def filename_from_uri

--- a/spec/downloader/remote_file_spec.rb
+++ b/spec/downloader/remote_file_spec.rb
@@ -6,9 +6,12 @@ describe CarrierWave::Downloader::RemoteFile do
   end
   subject { CarrierWave::Downloader::RemoteFile.new(file) }
 
-  it 'sets file extension based on content-type if missing' do
+  before do
     subject.base_uri = URI.parse 'http://example.com/test'
     subject.meta_add_field 'content-type', 'image/jpeg'
+  end
+
+  it 'sets file extension based on content-type if missing' do
     expect(subject.original_filename).to eq "test.jpeg"
   end
 
@@ -22,6 +25,22 @@ describe CarrierWave::Downloader::RemoteFile do
 
       it "reads filename correctly" do
         expect(subject.original_filename).to eq 'another_test.jpg'
+      end
+    end
+
+    context 'when filename is quoted and empty' do
+      let(:content_disposition){ 'filename=""' }
+
+      it "sets file extension based on content-type if missing" do
+        expect(subject.original_filename).to eq 'test.jpeg'
+      end
+    end
+
+    context 'when filename is not quoted and empty' do
+      let(:content_disposition){ 'filename=' }
+
+      it "reads filename correctly" do
+        expect(subject.original_filename).to eq 'test.jpeg'
       end
     end
 


### PR DESCRIPTION
Fix `remote_x_url=` when the response header includes `content-disposition: inline;filename=""`

Please see https://github.com/carrierwaveuploader/carrierwave/issues/2411#issuecomment-529735994 for detail.

Maybe related to #2415 also.