### PR TITLE
[debug] Update ImageMagick to v6.9.10 on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: ruby
 
 cache: bundler
 
+env:
+  - IM_VERSION=6.9.10
+
 rvm:
   - 2.5.5
   - 2.6.2
@@ -19,6 +22,7 @@ before_install:
 before_script:
   - psql -c 'create database carrierwave_test;' -U postgres
   - sudo sh -c 'echo '\''<policymap><policy domain="coder" rights="read|write" pattern="PDF" /></policymap>'\'' > /etc/ImageMagick-6/policy.xml'
+  - bash install/imagemagick.sh
 
 matrix:
   include:

--- a/install/imagemagick.sh
+++ b/install/imagemagick.sh
@@ -1,0 +1,8 @@
+set -ex
+
+im_download_path=$(curl -sf http://www.imagemagick.org/download/releases/ | grep -o "ImageMagick-$IM_VERSION-.*.tar.gz" -m 1)
+curl -f "http://www.imagemagick.org/download/releases/$im_download_path" > ImageMagick.tar.gz
+tar xzf ImageMagick.tar.gz
+cd ImageMagick-*
+./configure --prefix=/usr
+sudo make install


### PR DESCRIPTION
Current default ImageMagick version on Travis CI is v6.8.9-9 (https://travis-ci.org/carrierwaveuploader/carrierwave/builds/583012458)

Trying to update it to fix CI for JRuby.

`install/imagemagick.sh` and `v6.9.10` comes from https://github.com/minimagick/minimagick

- https://github.com/minimagick/minimagick/blob/916b89589a4486ba6d1d417b495a2affe0d08a7a/install/imagemagick.sh
- https://github.com/minimagick/minimagick/blob/916b89589a4486ba6d1d417b495a2affe0d08a7a/.travis.yml 
