### PR TITLE
Fix S3 path-style URL for host with dots for buckets that are placed in other regions than us-east-1

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -161,6 +161,8 @@ module CarrierWave
       end
 
       class File
+        DEFAULT_S3_REGION = 'us-east-1'
+
         include CarrierWave::Utilities::Uri
 
         ##
@@ -384,9 +386,15 @@ module CarrierWave
                 if valid_subdomain
                   s3_subdomain = @uploader.fog_aws_accelerate ? "s3-accelerate" : "s3"
                   "#{protocol}://#{@uploader.fog_directory}.#{s3_subdomain}.amazonaws.com/#{encoded_path}"
-                else
-                  # directory is not a valid subdomain, so use path style for access
-                  "#{protocol}://s3.amazonaws.com/#{@uploader.fog_directory}/#{encoded_path}"
+                else # directory is not a valid subdomain, so use path style for access
+                  region = @uploader.fog_credentials[:region].to_s
+                  host   = case region
+                           when DEFAULT_S3_REGION, ''
+                             's3.amazonaws.com'
+                           else
+                             "s3.#{region}.amazonaws.com"
+                           end
+                  "#{protocol}://#{host}/#{@uploader.fog_directory}/#{encoded_path}"
                 end
               end
             when 'Google'

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -163,6 +163,24 @@ end
               end
             end
 
+            {
+              nil            => 's3.amazonaws.com',
+              'us-east-1'    => 's3.amazonaws.com',
+              'us-east-2'    => 's3.us-east-2.amazonaws.com',
+              'eu-central-1' => 's3.eu-central-1.amazonaws.com'
+            }.each do |region, expected_host|
+              it "should use a #{expected_host} hostname when using path style for access #{region} region" do
+                if @provider == 'AWS'
+                  allow(@uploader).to receive(:fog_use_ssl_for_aws).and_return(true)
+                  allow(@uploader).to receive(:fog_directory).and_return('foo.bar')
+
+                  allow(@uploader).to receive(:fog_credentials).and_return(@uploader.fog_credentials.merge(region: region))
+
+                  expect(@fog_file.public_url).to include("https://#{expected_host}/foo.bar")
+                end
+              end
+            end
+
             it "should use https as a default protocol" do
               if @provider == 'AWS'
                 expect(@fog_file.public_url).to start_with 'https://'


### PR DESCRIPTION
https://github.com/carrierwaveuploader/carrierwave/pull/2359 added support for bucket names with period, but this only works for `us-east-1` region. For other regions `s3.{aws-region}.amazonaws.com` needs to be used (see https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro).

This PR adds support for bucket names with period that are placed in regions other than `us-east-1`.

---

Also, I'm wondering about one other thing regarding virtual-hosted–style URL. https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro says:

> Buckets created in Regions launched after March 20, 2019 are not reachable via the https://bucket.s3.amazonaws.com naming scheme. 

Should carrierwave be updated to use `http://{bucket}.s3.{aws-region}.amazonaws.com`? If so should it:

  - use `http://{bucket}.s3.{aws-region}.amazonaws.com` for all regions (this is what both `aws-sdk-s3`, `carrierwave-aws` do and kind of what `fog-aws` does; `fog-aws` uses `http://{bucket}.s3-{aws-region}.amazonaws.com`),
  - use `http://{bucket}.s3.{aws-region}.amazonaws.com` only for regions created after `March 20, 2019`? (in that case carrierwave would require to have a list of regions created before `March 20, 2019`)

?