### PR TITLE
Provide public interface alternatives to whitelist/blacklist terminology

### DIFF
--- a/lib/carrierwave/uploader/content_type_blacklist.rb
+++ b/lib/carrierwave/uploader/content_type_blacklist.rb
@@ -28,7 +28,11 @@ module CarrierWave
       #       [/(text|application)\/json/]
       #     end
       #
-      def content_type_blacklist; end
+      def content_type_blacklist
+        content_type_blocklist
+      end
+
+      def content_type_blocklist; end
 
     private
 

--- a/lib/carrierwave/uploader/content_type_whitelist.rb
+++ b/lib/carrierwave/uploader/content_type_whitelist.rb
@@ -7,6 +7,8 @@ module CarrierWave
         before :cache, :check_content_type_whitelist!
       end
 
+      def content_type_allowlist; end
+
       ##
       # Override this method in your uploader to provide a whitelist of files content types
       # which are allowed to be uploaded.
@@ -28,7 +30,9 @@ module CarrierWave
       #       [/(text|application)\/json/]
       #     end
       #
-      def content_type_whitelist; end
+      def content_type_whitelist
+        content_type_allowlist
+      end
 
     private
 

--- a/lib/carrierwave/uploader/extension_blacklist.rb
+++ b/lib/carrierwave/uploader/extension_blacklist.rb
@@ -32,7 +32,11 @@ module CarrierWave
       #     end
       #
 
-      def extension_blacklist; end
+      def extension_blacklist
+        extension_blocklist
+      end
+
+      def extension_blocklist; end
 
     private
 

--- a/lib/carrierwave/uploader/extension_whitelist.rb
+++ b/lib/carrierwave/uploader/extension_whitelist.rb
@@ -7,6 +7,8 @@ module CarrierWave
         before :cache, :check_extension_whitelist!
       end
 
+      def extension_allowlist; end
+
       ##
       # Override this method in your uploader to provide a white list of extensions which
       # are allowed to be uploaded. Compares the file's extension case insensitive.
@@ -31,7 +33,9 @@ module CarrierWave
       #       [/jpe?g/, 'gif', 'png']
       #     end
       #
-      def extension_whitelist; end
+      def extension_whitelist
+        extension_allowlist
+      end
 
     private
 

--- a/spec/uploader/content_type_blacklist_spec.rb
+++ b/spec/uploader/content_type_blacklist_spec.rb
@@ -36,6 +36,12 @@ describe CarrierWave::Uploader do
           expect { uploader.cache!(ruby_file) }.to raise_error(CarrierWave::IntegrityError)
         end
 
+        it "raises an integrity error if the file has a blocklisted content type" do
+          allow(uploader).to receive(:content_type_blocklist).and_return(['image/png'])
+
+          expect { uploader.cache!(ruby_file) }.to raise_error(CarrierWave::IntegrityError)
+        end
+
         it "accepts content types as regular expressions" do
           allow(uploader).to receive(:content_type_blacklist).and_return([/image\//])
 

--- a/spec/uploader/content_type_whitelist_spec.rb
+++ b/spec/uploader/content_type_whitelist_spec.rb
@@ -36,6 +36,12 @@ describe CarrierWave::Uploader do
           expect { uploader.cache!(bork_file) }.to raise_error(CarrierWave::IntegrityError)
         end
 
+        it "raises an integrity error the file has not an allowlisted content type" do
+          allow(uploader).to receive(:content_type_allowlist).and_return(['image/gif'])
+
+          expect { uploader.cache!(bork_file) }.to raise_error(CarrierWave::IntegrityError)
+        end
+
         it "accepts content types as regular expressions" do
           allow(uploader).to receive(:content_type_whitelist).and_return([/image\//])
 

--- a/spec/uploader/extension_blacklist_spec.rb
+++ b/spec/uploader/extension_blacklist_spec.rb
@@ -14,7 +14,7 @@ describe CarrierWave::Uploader do
   before { allow(CarrierWave).to receive(:generate_cache_id).and_return(cache_id) }
 
   describe '#cache!' do
-    before { allow(uploader).to receive(:extension_blacklist).and_return(extension_blacklist) }
+    before { allow(uploader).to receive(:extension_blocklist).and_return(extension_blacklist) }
 
     context "when there are no blacklisted extensions" do
       let(:extension_blacklist) { nil }

--- a/spec/uploader/extension_whitelist_spec.rb
+++ b/spec/uploader/extension_whitelist_spec.rb
@@ -43,6 +43,14 @@ describe CarrierWave::Uploader do
           }).to raise_error(CarrierWave::IntegrityError)
         end
 
+        it "raises an integrity error if the file has not an allowlisted extension" do
+          allow(@uploader).to receive(:extension_allowlist).and_return(%w(txt doc xls))
+
+          expect(running {
+            @uploader.cache!(File.open(file_path('test.jpg')))
+          }).to raise_error(CarrierWave::IntegrityError)
+        end
+
         it "raises an integrity error if the file has not a whitelisted extension, using start of string matcher" do
           allow(@uploader).to receive(:extension_whitelist).and_return(%w(txt))
 


### PR DESCRIPTION
The goal of this pull request is to give developers the option to use something like allowlist/blocklist terminology with this gem instead of whitelist/blacklist. https://github.com/rubocop-hq/rubocop/pull/6464 has links to the original motivation and many changes to other gems that have been replacing those words.

Since managing allowed content types and extensions is a significant part of the gem's purpose and impacts the code users write, as a starting point the changes in this PR are intended to be minimally intrusive. Overriding the existing methods still works so it is backwards compatible. If there is buy-in from the maintainers, I will gladly contribute deeper changes to the internals and deprecation of the old methods could be considered as well.

Allowlist and blocklist are only starting points here and I'm open to different names that could be more descriptive. The wording in some places could probably be improved if there is consensus on the alternative. For example, I used "allowlisted" for consistency but you may feel as I do that it sounds awkward and it could be clearer as "allowed" or "permitted" in those instances.

In this case, I would consider naming the methods like `allowed_extensions` and `prohibited_content_types` if you want to match the wording in the [translation file](https://github.com/grantbdev/carrierwave/blob/6545b6bb7e01a53dba465931020ffeb1a46bc885/lib/carrierwave/locale/en.yml#L7-L9) and use language closer to what application users might see.