### PR TITLE
Update callbacks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1015,12 +1015,12 @@ end
 Will add these callbacks:
 
 ```ruby
-after_save :store_avatar!
 before_save :write_avatar_identifier
+after_save :store_previous_changes_for_avatar
 after_commit :remove_avatar!, on: :destroy
 after_commit :mark_remove_avatar_false, on: :update
-after_save :store_previous_changes_for_avatar
 after_commit :remove_previously_stored_avatar, on: :update
+after_commit :store_avatar!, on: [:create, :update]
 ```
 
 If you want to skip any of these callbacks (eg. you want to keep the existing


### PR DESCRIPTION
The callbacks listed in the README were in a different order to the application code [1].  There was also an after_save which has been changed to an after_commit [2] (albeit only on create or update), which should therefore have the same behaviour but will execute at a different time to an after_save.

[1]: https://github.com/carrierwaveuploader/carrierwave/blob/d12a289d9cdd68d26d3900cf7f1e4e879678d16b/lib/carrierwave/orm/activerecord.rb#L59-L64
[2]: https://github.com/carrierwaveuploader/carrierwave/commit/665f2254a2c70385b67942b13a4710dc6826c42d