### PR TITLE
fix: default sharpen option in image_processing

### DIFF
--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -126,7 +126,7 @@ module CarrierWave
       width, height = resolve_dimensions(width, height)
 
       minimagick!(block) do |builder|
-        builder.resize_to_limit(width, height)
+        builder.resize_to_limit(width, height, sharpen: false)
           .apply(combine_options)
       end
     end
@@ -150,7 +150,7 @@ module CarrierWave
       width, height = resolve_dimensions(width, height)
 
       minimagick!(block) do |builder|
-        builder.resize_to_fit(width, height)
+        builder.resize_to_fit(width, height, sharpen: false)
           .apply(combine_options)
       end
     end
@@ -175,7 +175,7 @@ module CarrierWave
       width, height = resolve_dimensions(width, height)
 
       minimagick!(block) do |builder|
-        builder.resize_to_fill(width, height, gravity: gravity)
+        builder.resize_to_fill(width, height, gravity: gravity, sharpen: false)
           .apply(combine_options)
       end
     end
@@ -205,7 +205,7 @@ module CarrierWave
       width, height = resolve_dimensions(width, height)
 
       minimagick!(block) do |builder|
-        builder.resize_and_pad(width, height, background: background, gravity: gravity)
+        builder.resize_and_pad(width, height, background: background, gravity: gravity, sharpen: false)
           .apply(combine_options)
       end
     end


### PR DESCRIPTION
Prevent image_processing to automatically sharpen images https://github.com/janko/image_processing/pull/24.

To be able to keep control on imagemagick options and add sharpen in `combine_options`, force image_processing `sharpen` option to `false`.