### PR TITLE
[1.x-stable] - Fix deprecation warning ruby 2.7

### DIFF
--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -312,7 +312,7 @@ module CarrierWave
     def mkdir!(path, directory_permissions)
       options = {}
       options[:mode] = directory_permissions if directory_permissions
-      FileUtils.mkdir_p(File.dirname(path), options) unless File.exist?(File.dirname(path))
+      FileUtils.mkdir_p(File.dirname(path), **options) unless File.exist?(File.dirname(path))
     end
 
     def chmod!(path, permissions)

--- a/lib/carrierwave/uploader/download.rb
+++ b/lib/carrierwave/uploader/download.rb
@@ -40,7 +40,7 @@ module CarrierWave
             headers = @remote_headers.
               reverse_merge('User-Agent' => "CarrierWave/#{CarrierWave::VERSION}")
 
-            @file = Kernel.open(@uri.to_s, headers)
+            @file = URI.open(@uri.to_s, headers)
             @file = @file.is_a?(String) ? StringIO.new(@file) : @file
           end
           @file

--- a/lib/carrierwave/uploader/download.rb
+++ b/lib/carrierwave/uploader/download.rb
@@ -57,7 +57,7 @@ module CarrierWave
         end
 
         def filename_from_uri
-          URI.decode(File.basename(file.base_uri.path))
+          URI::DEFAULT_PARSER.unescape(File.basename(file.base_uri.path))
         end
 
         def method_missing(*args, &block)
@@ -92,8 +92,8 @@ module CarrierWave
       rescue URI::InvalidURIError
         uri_parts = uri.split('?')
         # regexp from Ruby's URI::Parser#regexp[:UNSAFE], with [] specifically removed
-        encoded_uri = URI.encode(uri_parts.shift, /[^\-_.!~*'()a-zA-Z\d;\/?:@&=+$,]/)
-        encoded_uri << '?' << URI.encode(uri_parts.join('?')) if uri_parts.any?
+        encoded_uri = URI::DEFAULT_PARSER.unescape(uri_parts.shift, /[^\-_.!~*'()a-zA-Z\d;\/?:@&=+$,]/)
+        encoded_uri << '?' << URI::DEFAULT_PARSER.unescape(uri_parts.join('?')) if uri_parts.any?
         URI.parse(encoded_uri) rescue raise CarrierWave::DownloadError, "couldn't parse URL"
       end
 


### PR DESCRIPTION
This PR fix some deprecation warnings introduced with Ruby 2.7.

- Separation of positional and keyword arguments in Ruby 3.0 [source](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)
- Deprecation of URI.decode [link](https://docs.knapsackpro.com/2020/uri-escape-is-obsolete-percent-encoding-your-query-string)

```
warning: URI.escape is obsolete
warning: URI.encode is obsolete
```

- Deprecation of Kernel.open

```
calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open