### PR TITLE
Skip content type filters where possible.

### DIFF
--- a/lib/carrierwave/uploader/content_type_blacklist.rb
+++ b/lib/carrierwave/uploader/content_type_blacklist.rb
@@ -33,8 +33,10 @@ module CarrierWave
     private
 
       def check_content_type_blacklist!(new_file)
+        return unless content_type_blacklist
+
         content_type = new_file.content_type
-        if content_type_blacklist && blacklisted_content_type?(content_type)
+        if blacklisted_content_type?(content_type)
           raise CarrierWave::IntegrityError, I18n.translate(:"errors.messages.content_type_blacklist_error", content_type: content_type)
         end
       end

--- a/lib/carrierwave/uploader/content_type_whitelist.rb
+++ b/lib/carrierwave/uploader/content_type_whitelist.rb
@@ -33,8 +33,10 @@ module CarrierWave
     private
 
       def check_content_type_whitelist!(new_file)
+        return unless content_type_whitelist
+
         content_type = new_file.content_type
-        if content_type_whitelist && !whitelisted_content_type?(content_type)
+        if !whitelisted_content_type?(content_type)
           raise CarrierWave::IntegrityError, I18n.translate(:"errors.messages.content_type_whitelist_error", content_type: content_type, allowed_types: Array(content_type_whitelist).join(", "))
         end
       end

--- a/lib/carrierwave/uploader/extension_blacklist.rb
+++ b/lib/carrierwave/uploader/extension_blacklist.rb
@@ -37,8 +37,10 @@ module CarrierWave
     private
 
       def check_extension_blacklist!(new_file)
+        return unless extension_blacklist
+
         extension = new_file.extension.to_s
-        if extension_blacklist && blacklisted_extension?(extension)
+        if blacklisted_extension?(extension)
           raise CarrierWave::IntegrityError, I18n.translate(:"errors.messages.extension_blacklist_error", extension: new_file.extension.inspect, prohibited_types: Array(extension_blacklist).join(", "))
         end
       end

--- a/lib/carrierwave/uploader/extension_whitelist.rb
+++ b/lib/carrierwave/uploader/extension_whitelist.rb
@@ -36,8 +36,10 @@ module CarrierWave
     private
 
       def check_extension_whitelist!(new_file)
+        return unless extension_whitelist
+
         extension = new_file.extension.to_s
-        if extension_whitelist && !whitelisted_extension?(extension)
+        if !whitelisted_extension?(extension)
           raise CarrierWave::IntegrityError, I18n.translate(:"errors.messages.extension_whitelist_error", extension: new_file.extension.inspect, allowed_types: Array(extension_whitelist).join(", "))
         end
       end


### PR DESCRIPTION
Prior to this patch every content_type_* filter would parse magic headers via `SanitizedFile#content_type`,
even when the filter was not defined.

I have split the primary conditional check in to a guard clause that
simply returns unless the blacklist or whitelist returns truthy.

I've made the same changes to the extension filters for consistency.

I wanted to remove any unnecessary parse of magic headers completely on upload. This is a half measure to getting there.