### PR TITLE
Encode query params with colons properly

### DIFF
--- a/lib/carrierwave/downloader/base.rb
+++ b/lib/carrierwave/downloader/base.rb
@@ -40,7 +40,8 @@ module CarrierWave
       def process_uri(uri)
         uri_parts = uri.split('?')
         encoded_uri = Addressable::URI.parse(uri_parts.shift).normalize.to_s
-        encoded_uri << '?' << Addressable::URI.encode(uri_parts.join('?')).gsub('%5B', '[').gsub('%5D', ']') if uri_parts.any?
+        query = uri_parts.join('?').split(':').map { |part| Addressable::URI.encode(part) }.join(':') if uri_parts.any?
+        encoded_uri << '?' << query.gsub('%5B', '[').gsub('%5D', ']') if query
         URI.parse(encoded_uri)
       rescue URI::InvalidURIError, Addressable::URI::InvalidURIError
         raise CarrierWave::DownloadError, "couldn't parse URL: #{uri}"

--- a/spec/downloader/base_spec.rb
+++ b/spec/downloader/base_spec.rb
@@ -41,6 +41,22 @@ describe CarrierWave::Downloader::Base do
     end
   end
 
+  context "with equal and colons in the query path" do
+    let(:query) { 'test=query&with=equal&before=colon:param' }
+    let(:uri) { "https://example.com/#{filename}?#{query}" }
+    before do
+      stub_request(:get, uri).to_return(body: file)
+    end
+
+    it "leaves colon in resulting URI" do
+      expect(subject.process_uri(uri).query).to eq query
+    end
+
+    it "downloads a file" do
+      expect(subject.download(uri).file.read).to eq file
+    end
+  end
+
   context 'with request headers' do
     let(:authentication_headers) do
       {


### PR DESCRIPTION
This PR fixes bug #2472