### PR TITLE
Add CarrierWave::Vips and related specs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,8 @@ jobs:
       run: sudo sh -c 'echo '\''<policymap><policy domain="coder" rights="read|write" pattern="PDF" /></policymap>'\'' > /etc/ImageMagick-6/policy.xml'
     - name: Install ghostscript to process PDF
       run: sudo apt-get -y install ghostscript
+    - name: Install libvips-dev for Carrierwave::Vips
+      run: sudo apt-get install libvips-dev
     - name: Install dependencies
       run: bundle install --jobs=3 --retry=3 --path=vendor/bundle || [ "$EXPERIMENTAL" == "true" ] && true
     - name: Run RSpec

--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -48,4 +48,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "timecop"
   s.add_development_dependency "generator_spec", ">= 0.9.1"
   s.add_development_dependency "pry"
+  s.add_development_dependency "pry-byebug"
 end

--- a/lib/carrierwave/locale/en.yml
+++ b/lib/carrierwave/locale/en.yml
@@ -10,5 +10,6 @@ en:
       content_type_denylist_error: "You are not allowed to upload %{content_type} files"
       rmagick_processing_error: "Failed to manipulate with rmagick, maybe it is not an image?"
       mini_magick_processing_error: "Failed to manipulate with MiniMagick, maybe it is not an image? Original Error: %{e}"
+      vips_processing_error: "Failed to manipulate with vips, maybe it is not an image? Original Error: %{e}"
       min_size_error: "File size should be greater than %{min_size}"
       max_size_error: "File size should be less than %{max_size}"

--- a/lib/carrierwave/processing.rb
+++ b/lib/carrierwave/processing.rb
@@ -1,2 +1,3 @@
 require "carrierwave/processing/rmagick"
 require "carrierwave/processing/mini_magick"
+require "carrierwave/processing/vips"

--- a/lib/carrierwave/processing/vips.rb
+++ b/lib/carrierwave/processing/vips.rb
@@ -1,0 +1,330 @@
+module CarrierWave
+
+  ##
+  # This module simplifies manipulation with vips by providing a set
+  # of convenient helper methods. If you want to use them, you'll need to
+  # require this file:
+  #
+  #     require 'carrierwave/processing/vips'
+  #
+  # And then include it in your uploader:
+  #
+  #     class MyUploader < CarrierWave::Uploader::Base
+  #       include CarrierWave::Vips
+  #     end
+  #
+  # You can now use the provided helpers:
+  #
+  #     class MyUploader < CarrierWave::Uploader::Base
+  #       include CarrierWave::Vips
+  #
+  #       process :resize_to_fit => [200, 200]
+  #     end
+  #
+  # Or create your own helpers with the powerful vips! method, which
+  # yields an ImageProcessing::Builder object. Check out the ImageProcessing
+  # docs at http://github.com/janko-m/image_processing and the list of all
+  # available Vips options at
+  # https://libvips.github.io/libvips/API/current/using-cli.html for more info.
+  #
+  #     class MyUploader < CarrierWave::Uploader::Base
+  #       include CarrierWave::Vips
+  #
+  #       process :radial_blur => 10
+  #
+  #       def radial_blur(amount)
+  #         vips! do |builder|
+  #           builder.radial_blur(amount)
+  #           builder = yield(builder) if block_given?
+  #           builder
+  #         end
+  #       end
+  #     end
+  #
+  # === Note
+  #
+  # The ImageProcessing gem uses ruby-vips, a binding for the vips image
+  # library, to build a "convert" command that
+  # performs the processing.
+  #
+  # You can find more information here:
+  #
+  # https://github.com/libvips/ruby-vips
+  #
+  #
+  module Vips
+    extend ActiveSupport::Concern
+
+    included do
+      require "image_processing/vips"
+    end
+
+    module ClassMethods
+      def convert(format)
+        process :convert => format
+      end
+
+      def resize_to_limit(width, height)
+        process :resize_to_limit => [width, height]
+      end
+
+      def resize_to_fit(width, height)
+        process :resize_to_fit => [width, height]
+      end
+
+      def resize_to_fill(width, height, gravity='centre')
+        process :resize_to_fill => [width, height, gravity]
+      end
+
+      def resize_and_pad(width, height, background=nil, gravity='centre', alpha=nil)
+        process :resize_and_pad => [width, height, background, gravity, alpha]
+      end
+    end
+
+    ##
+    # Changes the image encoding format to the given format
+    #
+    # See https://libvips.github.io/libvips/API/current/using-cli.html#using-command-line-conversion
+    #
+    # === Parameters
+    #
+    # [format (#to_s)] an abbreviation of the format
+    #
+    # === Yields
+    #
+    # [Vips::Image] additional manipulations to perform
+    #
+    # === Examples
+    #
+    #     image.convert(:png)
+    #
+    def convert(format, page=nil, &block)
+      vips!(block) do |builder|
+        builder = builder.convert(format)
+        builder = builder.loader(page: page) if page
+        builder
+      end
+    end
+
+    ##
+    # Resize the image to fit within the specified dimensions while retaining
+    # the original aspect ratio. Will only resize the image if it is larger than the
+    # specified dimensions. The resulting image may be shorter or narrower than specified
+    # in the smaller dimension but will not be larger than the specified values.
+    #
+    # === Parameters
+    #
+    # [width (Integer)] the width to scale the image to
+    # [height (Integer)] the height to scale the image to
+    # [combine_options (Hash)] additional Vips options to apply before resizing
+    #
+    # === Yields
+    #
+    # [Vips::Image] additional manipulations to perform
+    #
+    def resize_to_limit(width, height, combine_options: {}, &block)
+      width, height = resolve_dimensions(width, height)
+
+      vips!(block) do |builder|
+        builder.resize_to_limit(width, height)
+          .apply(combine_options)
+      end
+    end
+
+    ##
+    # Resize the image to fit within the specified dimensions while retaining
+    # the original aspect ratio. The image may be shorter or narrower than
+    # specified in the smaller dimension but will not be larger than the specified values.
+    #
+    # === Parameters
+    #
+    # [width (Integer)] the width to scale the image to
+    # [height (Integer)] the height to scale the image to
+    # [combine_options (Hash)] additional Vips options to apply before resizing
+    #
+    # === Yields
+    #
+    # [Vips::Image] additional manipulations to perform
+    #
+    def resize_to_fit(width, height, combine_options: {}, &block)
+      width, height = resolve_dimensions(width, height)
+
+      vips!(block) do |builder|
+        builder.resize_to_fit(width, height)
+          .apply(combine_options)
+      end
+    end
+
+    ##
+    # Resize the image to fit within the specified dimensions while retaining
+    # the aspect ratio of the original image. If necessary, crop the image in the
+    # larger dimension.
+    #
+    # === Parameters
+    #
+    # [width (Integer)] the width to scale the image to
+    # [height (Integer)] the height to scale the image to
+    # [combine_options (Hash)] additional vips options to apply before resizing
+    #
+    # === Yields
+    #
+    # [Vips::Image] additional manipulations to perform
+    #
+    def resize_to_fill(width, height, _gravity = nil, combine_options: {}, &block)
+      width, height = resolve_dimensions(width, height)
+
+      vips!(block) do |builder|
+        builder.resize_to_fill(width, height).apply(combine_options)
+      end
+    end
+
+    ##
+    # Resize the image to fit within the specified dimensions while retaining
+    # the original aspect ratio. If necessary, will pad the remaining area
+    # with the given color, which defaults to transparent (for gif and png,
+    # white for jpeg).
+    #
+    # See https://libvips.github.io/libvips/API/current/libvips-conversion.html#VipsCompassDirection
+    # for gravity options.
+    #
+    # === Parameters
+    #
+    # [width (Integer)] the width to scale the image to
+    # [height (Integer)] the height to scale the image to
+    # [background (List, nil)] the color of the background as a RGB, like [0, 255, 255], nil indicates transparent
+    # [gravity (String)] how to position the image
+    # [alpha (Boolean, nil)] pad the image with the alpha channel if supported
+    # [combine_options (Hash)] additional vips options to apply before resizing
+    #
+    # === Yields
+    #
+    # [Vips::Image] additional manipulations to perform
+    #
+    def resize_and_pad(width, height, background=nil, gravity='centre', alpha=nil, combine_options: {}, &block)
+      width, height = resolve_dimensions(width, height)
+
+      vips!(block) do |builder|
+        builder.resize_and_pad(width, height, background: background, gravity: gravity, alpha: alpha)
+          .apply(combine_options)
+      end
+    end
+
+    ##
+    # Returns the width of the image in pixels.
+    #
+    # === Returns
+    #
+    # [Integer] the image's width in pixels
+    #
+    def width
+      vips_image.width
+    end
+
+    ##
+    # Returns the height of the image in pixels.
+    #
+    # === Returns
+    #
+    # [Integer] the image's height in pixels
+    #
+    def height
+      vips_image.height
+    end
+
+    ##
+    # Manipulate the image with vips. This method will load up an image
+    # and then pass each of its frames to the supplied block. It will then
+    # save the image to disk.
+    #
+    # NOTE: This method exists mostly for backwards compatibility, you should
+    # probably use #vips!.
+    #
+    # === Gotcha
+    #
+    # This method assumes that the object responds to +current_path+.
+    # Any class that this module is mixed into must have a +current_path+ method.
+    # CarrierWave::Uploader does, so you won't need to worry about this in
+    # most cases.
+    #
+    # === Yields
+    #
+    # [Vips::Image] manipulations to perform
+    #
+    # === Raises
+    #
+    # [CarrierWave::ProcessingError] if manipulation failed.
+    #
+    def manipulate!
+      cache_stored_file! if !cached?
+      image = ::Vips::Image.open(current_path)
+
+      image = yield(image)
+      FileUtils.mv image.path, current_path
+
+      image.run_command("identify", current_path)
+    rescue ::Vips::Error, ::Vips::Invalid => e
+      message = I18n.translate(:"errors.messages.vips_processing_error", :e => e)
+      raise CarrierWave::ProcessingError, message
+    ensure
+      image.destroy! if image
+    end
+
+    # Process the image with vip, using the ImageProcessing gem. This
+    # method will build a "convert" vips command and execute it on the
+    # current image.
+    #
+    # === Gotcha
+    #
+    # This method assumes that the object responds to +current_path+.
+    # Any class that this module is mixed into must have a +current_path+ method.
+    # CarrierWave::Uploader does, so you won't need to worry about this in
+    # most cases.
+    #
+    # === Yields
+    #
+    # [ImageProcessing::Builder] use it to define processing to be performed
+    #
+    # === Raises
+    #
+    # [CarrierWave::ProcessingError] if processing failed.
+    def vips!(block = nil)
+      builder = ImageProcessing::Vips.source(current_path)
+      builder = yield(builder)
+
+      result = builder.call
+      result.close
+
+      # backwards compatibility (we want to eventually move away from Vips::Image)
+      if block
+        image  = ::Vips::Image.new(result.path, result)
+        image  = block.call(image)
+        result = image.instance_variable_get(:@tempfile)
+      end
+
+      FileUtils.mv result.path, current_path
+
+      if File.extname(result.path) != File.extname(current_path)
+        move_to = current_path.chomp(File.extname(current_path)) + File.extname(result.path)
+        file.content_type = ::MiniMime.lookup_by_filename(move_to).content_type
+        file.move_to(move_to, permissions, directory_permissions)
+      end
+    rescue ::Vips::Error => e
+      message = I18n.translate(:"errors.messages.vips_processing_error", :e => e)
+      raise CarrierWave::ProcessingError, message
+    end
+
+    private
+
+      def resolve_dimensions(*dimensions)
+        dimensions.map do |value|
+          next value unless value.instance_of?(Proc)
+          value.arity >= 1 ? value.call(self) : value.call
+        end
+      end
+
+      def vips_image
+        ::Vips::Image.new_from_buffer(read, "")
+      end
+
+  end # Vips
+end # CarrierWave

--- a/spec/processing/vips_spec.rb
+++ b/spec/processing/vips_spec.rb
@@ -106,8 +106,6 @@ describe CarrierWave::Vips do
     end
 
     it "doesn't pad with transparent" do
-      binding.pry
-
       instance.resize_and_pad(200, 200)
       instance.convert('png')
 

--- a/spec/processing/vips_spec.rb
+++ b/spec/processing/vips_spec.rb
@@ -1,0 +1,261 @@
+require 'spec_helper'
+
+describe CarrierWave::Vips do
+  let(:klass) { Class.new(CarrierWave::Uploader::Base) { include CarrierWave::Vips } }
+
+  let(:instance) { klass.new }
+  let(:landscape_file_path) { file_path('landscape.jpg') }
+  let(:landscape_copy_file_path) { file_path('landscape_copy.jpg') }
+
+  before do
+    FileUtils.cp(landscape_file_path, landscape_copy_file_path)
+    allow(instance).to receive(:cached?).and_return true
+    allow(instance).to receive(:file).and_return(CarrierWave::SanitizedFile.new(landscape_copy_file_path))
+  end
+
+  after { FileUtils.rm(landscape_copy_file_path) if File.exist?(landscape_copy_file_path) }
+
+  describe "#convert" do
+    it "converts from one format to another" do
+      instance.convert('png')
+      expect(instance.file.extension).to eq('png')
+      expect(instance).to be_format('png')
+      expect(instance.file.content_type).to eq('image/png')
+    end
+
+    it "respects the page parameter" do
+      # create a multi-layer image
+      tiff = Tempfile.new(["file", ".tiff"])
+      MiniMagick::Tool::Convert.new do |convert|
+        convert.merge! [landscape_file_path, landscape_file_path, landscape_file_path]
+        convert << tiff.path
+      end
+
+      allow(instance).to receive(:file).and_return(CarrierWave::SanitizedFile.new(tiff.path))
+
+      instance.convert('png', 0)
+      expect(instance.file.extension).to eq('png')
+      expect(instance).to be_format('png')
+      expect(instance.file.size).not_to eq(0)
+    end
+  end
+
+  describe '#resize_to_fill' do
+    it "resizes the image to exactly the given dimensions and maintain file type" do
+      instance.resize_to_fill(200, 200)
+
+      expect(instance).to have_dimensions(200, 200)
+      expect(::Vips::Image.new_from_file(instance.current_path).get("vips-loader")).to match(/jpeg/)
+    end
+
+    it "resizes the image to exactly the given dimensions and maintain updated file type" do
+      instance.convert('png')
+      instance.resize_to_fill(200, 200)
+
+      expect(instance).to have_dimensions(200, 200)
+      expect(::Vips::Image.new_from_file(instance.current_path).get("vips-loader")).to match(/png/)
+      expect(instance.file.extension).to eq('png')
+    end
+
+    it "scales up the image if it smaller than the given dimensions" do
+      expect(::MiniMagick::Tool::Identify.new.verbose(instance.current_path).call).to_not include('Quality: 70')
+
+      instance.resize_to_fill(1000, 1000, combine_options: { saver: { quality: 70 } })
+
+      expect(instance).to have_dimensions(1000, 1000)
+      expect(::MiniMagick::Tool::Identify.new.verbose(instance.current_path).call).to include('Quality: 70')
+    end
+  end
+
+  describe '#resize_and_pad' do
+    it "resizes the image to exactly the given dimensions and maintain file type" do
+      instance.resize_and_pad(200, 200)
+
+      expect(instance).to have_dimensions(200, 200)
+      expect(::Vips::Image.new_from_file(instance.current_path).get("vips-loader")).to match(/jpeg/)
+    end
+
+    it "resizes the image to exactly the given dimensions and maintain updated file type" do
+      instance.convert('png')
+      instance.resize_and_pad(200, 200)
+
+      expect(instance).to have_dimensions(200, 200)
+      expect(::Vips::Image.new_from_file(instance.current_path).get("vips-loader")).to match(/png/)
+    end
+
+    it "scales up the image if it smaller than the given dimensions" do
+      instance.resize_and_pad(1000, 1000)
+
+      expect(instance).to have_dimensions(1000, 1000)
+    end
+
+    it "pads with black" do
+      instance.resize_and_pad(200, 200)
+
+      color_of_pixel(instance.current_path, 0, 0).tap do |color|
+        expect(color).to include('#000000')
+        expect(color).not_to include('none')
+      end
+    end
+
+    it "pads with transparent" do
+      instance.convert('png')
+      instance.resize_and_pad(200, 200, nil, 'centre', true)
+
+      expect(color_of_pixel(instance.current_path, 0, 0)).to include('none')
+    end
+
+    it "doesn't pad with transparent" do
+      binding.pry
+
+      instance.resize_and_pad(200, 200)
+      instance.convert('png')
+
+      color_of_pixel(instance.current_path, 0, 0).tap do |color|
+        expect(color).to include('#FFFFFF')
+        expect(color).not_to include('#FFFFFF00')
+      end
+    end
+
+    it 'accepts combine_options and set quality' do
+      expect(::MiniMagick::Tool::Identify.new.verbose(instance.current_path).call).to_not include('Quality: 70')
+
+      instance.resize_and_pad(1000, 1000, combine_options: { saver: { quality: 70 } })
+
+      expect(instance).to have_dimensions(1000, 1000)
+      expect(::MiniMagick::Tool::Identify.new.verbose(instance.current_path).call).to include('Quality: 70')
+    end
+
+    it 'accepts non-argument option as combine_options' do
+      expect(::MiniMagick::Tool::Identify.new.verbose(instance.current_path).call).to include('exif:ColorSpace: 1')
+
+      instance.resize_and_pad(1000, 1000, combine_options: { saver: { strip: true } })
+
+      expect(instance).to have_dimensions(1000, 1000)
+      expect(::MiniMagick::Tool::Identify.new.verbose(instance.current_path).call).to_not include('exif:ColorSpace: 1')
+    end
+  end
+
+  describe '#resize_to_fit' do
+    it "resizes the image to fit within the given dimensions and maintain file type" do
+      instance.resize_to_fit(200, 200)
+
+      expect(instance).to have_dimensions(200, 150)
+      expect(::Vips::Image.new_from_file(instance.current_path).get("vips-loader")).to match(/jpeg/)
+    end
+
+    it "resizes the image to fit within the given dimensions and maintain updated file type" do
+      instance.convert('png')
+      instance.resize_to_fit(200, 200)
+
+      expect(instance).to have_dimensions(200, 150)
+      expect(::Vips::Image.new_from_file(instance.current_path).get("vips-loader")).to match(/png/)
+      expect(instance.file.extension).to eq('png')
+    end
+
+    it 'scales up the image if it smaller than the given dimensions and set quality' do
+      expect(::MiniMagick::Tool::Identify.new.verbose(instance.current_path).call).to_not include('Quality: 70')
+
+      instance.resize_to_fit(1000, 1000, combine_options: { saver: { quality: 70} })
+
+      expect(instance).to have_dimensions(1000, 750)
+      expect(::MiniMagick::Tool::Identify.new.verbose(instance.current_path).call).to include('Quality: 70')
+    end
+  end
+
+  describe '#resize_to_limit' do
+    it 'resizes the image to fit within the given dimensions, maintain file type and set quality' do
+      expect(::MiniMagick::Tool::Identify.new.verbose(instance.current_path).call).to_not include('Quality: 70')
+
+      instance.resize_to_limit(200, 200, combine_options: { saver: { quality: 70} })
+
+      expect(instance).to have_dimensions(200, 150)
+      expect(::Vips::Image.new_from_file(instance.current_path).get("vips-loader")).to match(/jpeg/)
+      expect(::MiniMagick::Tool::Identify.new.verbose(instance.current_path).call).to include('Quality: 70')
+    end
+
+    it "resizes the image to fit within the given dimensions and maintain updated file type" do
+      instance.convert('png')
+      instance.resize_to_limit(200, 200)
+
+      expect(instance).to have_dimensions(200, 150)
+      expect(::Vips::Image.new_from_file(instance.current_path).get("vips-loader")).to match(/png/)
+      expect(instance.file.extension).to eq('png')
+    end
+
+    it "doesn't scale up the image if it smaller than the given dimensions" do
+      instance.resize_to_limit(1000, 1000)
+
+      expect(instance).to have_dimensions(640, 480)
+    end
+  end
+
+  describe "#width and #height" do
+    it "returns the width and height of the image" do
+      instance.resize_to_fill(200, 300)
+
+      expect(instance.width).to eq(200)
+      expect(instance.height).to eq(300)
+    end
+  end
+
+  describe '#dimension_from' do
+    it 'evaluates procs' do
+      instance.resize_to_fill(Proc.new { 200 }, Proc.new { 200 })
+
+      expect(instance).to have_dimensions(200, 200)
+    end
+
+    it 'evaluates procs with uploader instance' do
+      width_argument = nil
+      width = Proc.new do |uploader|
+        width_argument = uploader
+        200
+      end
+      height_argument = nil
+      height = Proc.new do |uploader|
+        height_argument = uploader
+        200
+      end
+      instance.resize_to_fill(width, height)
+
+      expect(instance).to have_dimensions(200, 200)
+      expect(instance).to eq(width_argument)
+      expect(instance).to eq(height_argument)
+    end
+  end
+
+  describe "test errors" do
+    context "invalid image file" do
+      before { File.open(instance.current_path, 'w') { |f| f.puts "bogus" } }
+
+      it "fails to process a non image file" do
+        expect { instance.resize_to_limit(200, 200) }.to raise_exception(CarrierWave::ProcessingError, /^Failed to manipulate with vips, maybe it is not an image\?/)
+      end
+
+      it "uses I18n" do
+        change_locale_and_store_translations(:nl, :errors => {
+          :messages => {
+            :vips_processing_error => "Kon bestand niet met vips bewerken, misschien is het geen beeld bestand?"
+          }
+        }) do
+          expect {instance.resize_to_limit(200, 200)}.to raise_exception(CarrierWave::ProcessingError, /^Kon bestand niet met vips bewerken, misschien is het geen beeld bestand?\?/)
+        end
+      end
+
+      it "doesn't suppress errors when translation is unavailable" do
+        change_locale_and_store_translations(:foo, {}) do
+          expect { instance.resize_to_limit(200, 200) }.to raise_exception( CarrierWave::ProcessingError )
+        end
+      end
+
+      context ":en locale is not available and enforce_available_locales is true" do
+        it "doesn't suppress errors" do
+          change_and_enforece_available_locales(:nl, [:nl, :foo]) do
+            expect { instance.resize_to_limit(200, 200) }.to raise_exception(CarrierWave::ProcessingError)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ require 'timecop'
 require 'open-uri'
 require "webmock/rspec"
 require 'mini_magick'
+require "vips"
 
 I18n.enforce_available_locales = false
 


### PR DESCRIPTION
This PR adds support for [libvips](https://github.com/libvips/libvips) through [ImageProcessing::Vips](https://github.com/janko/image_processing) and [ruby-vips](https://github.com/libvips/ruby-vips).

A few notes:

- I had to unlock `rmagick` as it's currently at version 4 and it wouldn't build version 2 on my machine
- I added [pry-byebug](https://github.com/deivid-rodriguez/pry-byebug) to development dependencies which makes stepping through the code infinitely easier via `binding.pry`
- libvips differs from ImageMagick in that [resize_and_pad](https://github.com/janko/image_processing/blob/master/doc/vips.md#resize_and_pad) adds a black background by default, not a white one. The background is transparent if the alpha channel is set and supported.
