### PR TITLE
Add rmagick's original error to I18n message

### DIFF
--- a/README.md
+++ b/README.md
@@ -968,7 +968,7 @@ errors:
     extension_blacklist_error: "You are not allowed to upload %{extension} files, prohibited types: %{prohibited_types}"
     content_type_whitelist_error: "You are not allowed to upload %{content_type} files, allowed types: %{allowed_types}"
     content_type_blacklist_error: "You are not allowed to upload %{content_type} files"
-    rmagick_processing_error: "Failed to manipulate with rmagick, maybe it is not an image?"
+    rmagick_processing_error: "Failed to manipulate with rmagick, maybe it is not an image? Original Error: %{e}"
     mini_magick_processing_error: "Failed to manipulate with MiniMagick, maybe it is not an image? Original Error: %{e}"
     min_size_error: "File size should be greater than %{min_size}"
     max_size_error: "File size should be less than %{max_size}"

--- a/lib/carrierwave/locale/en.yml
+++ b/lib/carrierwave/locale/en.yml
@@ -8,7 +8,7 @@ en:
       extension_blacklist_error: "You are not allowed to upload %{extension} files, prohibited types: %{prohibited_types}"
       content_type_whitelist_error: "You are not allowed to upload %{content_type} files, allowed types: %{allowed_types}"
       content_type_blacklist_error: "You are not allowed to upload %{content_type} files"
-      rmagick_processing_error: "Failed to manipulate with rmagick, maybe it is not an image?"
+      rmagick_processing_error: "Failed to manipulate with rmagick, maybe it is not an image? Original Error: %{e}"
       mini_magick_processing_error: "Failed to manipulate with MiniMagick, maybe it is not an image? Original Error: %{e}"
       min_size_error: "File size should be greater than %{min_size}"
       max_size_error: "File size should be less than %{max_size}"


### PR DESCRIPTION
The file [lib/carrierwave/processing/rmagick.rb](lib/carrierwave/processing/rmagick.rb) adds the RMagick's original error to the I18n message. It is very useful for understanding low-level issues on processing images with image magick, such as [policy errors](https://stackoverflow.com/questions/52998331/imagemagick-security-policy-pdf-blocking-conversion)