### PR TITLE
Send fog_attributes in Storage::Fog#copy_to

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -450,7 +450,7 @@ module CarrierWave
         # @return [CarrierWave::Storage::Fog::File] the location where the file will be stored.
         #
         def copy_to(new_path)
-          connection.copy_object(@uploader.fog_directory, file.key, @uploader.fog_directory, new_path, uploader_options)
+          connection.copy_object(@uploader.fog_directory, file.key, @uploader.fog_directory, new_path, copy_to_options)
           CarrierWave::Storage::Fog::File.new(@uploader, @base, new_path)
         end
 
@@ -491,10 +491,14 @@ module CarrierWave
         # [Fog::#{provider}::File] file data from remote service
         #
         def file
-          @file ||= directory.files.head(path)
+          @file ||= directory.files.head(path, head_options)
         end
 
-        def uploader_options
+        def head_options
+          @uploader.fog_attributes
+        end
+
+        def copy_to_options
           acl_header.merge(@uploader.fog_attributes)
         end
 

--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -450,7 +450,7 @@ module CarrierWave
         # @return [CarrierWave::Storage::Fog::File] the location where the file will be stored.
         #
         def copy_to(new_path)
-          connection.copy_object(@uploader.fog_directory, file.key, @uploader.fog_directory, new_path, acl_header)
+          connection.copy_object(@uploader.fog_directory, file.key, @uploader.fog_directory, new_path, uploader_options)
           CarrierWave::Storage::Fog::File.new(@uploader, @base, new_path)
         end
 
@@ -492,6 +492,10 @@ module CarrierWave
         #
         def file
           @file ||= directory.files.head(path)
+        end
+
+        def uploader_options
+          acl_header.merge(@uploader.fog_attributes)
         end
 
         def acl_header

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -57,6 +57,34 @@ end
         end
       end
 
+      context '#uploader_options' do
+        let(:store_path) { 'uploads/test+.jpg' }
+        let(:fog_attributes) { { 'x-amz-server-side-encryption' => true } }
+
+        before do
+          allow(@uploader).to receive(:store_path).and_return(store_path)
+
+          if @provider == 'AWS'
+            allow(@uploader).to receive(:fog_attributes).and_return(fog_attributes)
+          end
+        end
+
+        it 'includes custom attributes' do
+          if file.is_a?(CarrierWave::Storage::Fog::File)
+            if @provider == 'AWS'
+              expect(@storage.connection).to receive(:copy_object)
+                                               .with(anything, anything, anything, anything,
+                                                     { "x-amz-acl"=>"public-read", 'x-amz-server-side-encryption' => true }).and_call_original
+            else
+              expect(@storage.connection).to receive(:copy_object)
+                                               .with(anything, anything, anything, anything, {}).and_call_original
+            end
+
+            @storage.store!(file)
+          end
+        end
+      end
+
       context '#acl_header' do
         let(:store_path) { 'uploads/test+.jpg' }
 


### PR DESCRIPTION
This allows an uploader to specify special headers, such as
`x-amz-server-side-encryption`.