### PR TITLE
Fix return value of `cached?` according to document

### DIFF
--- a/lib/carrierwave/uploader/cache.rb
+++ b/lib/carrierwave/uploader/cache.rb
@@ -76,7 +76,7 @@ module CarrierWave
       # [Bool] whether the current file is cached
       #
       def cached?
-        @cache_id
+        !!@cache_id
       end
 
       ##

--- a/spec/uploader/cache_spec.rb
+++ b/spec/uploader/cache_spec.rb
@@ -325,4 +325,20 @@ describe CarrierWave::Uploader do
       expect(CarrierWave.generate_cache_id.split('-')[2].length).to eq(4)
     end
   end
+
+  describe '#cached?' do
+    context 'when cache_id is present' do
+      before { uploader.cache!(test_file) }
+
+      it 'returns true' do
+        expect(uploader).to be_cached
+      end
+    end
+
+    context 'when cache_id is NOT present' do
+      it 'returns false' do
+        expect(uploader).not_to be_cached
+      end
+    end
+  end
 end


### PR DESCRIPTION
The document says `cached?` is expected to return `Bool` value. But actually, the method returns a `@cache_id`.
According to the document and ruby basic style, fixes return value to `Bool` value from `@cache_id`.

This change has breaking changes, so perhaps should not be changed this behavior.