### PR TITLE
Update README to indicate when to use :file as the cache storage for AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,6 +717,9 @@ CarrierWave.configure do |config|
   config.fog_directory  = 'name_of_bucket'                                      # required
   config.fog_public     = false                                                 # optional, defaults to true
   config.fog_attributes = { cache_control: "public, max-age=#{365.days.to_i}" } # optional, defaults to {}
+  # For an application which utilizes multiple servers but does not need caches persisted across requests,
+  # uncomment the line :file instead of the default :storage.  Otherwise, it will use AWS as the temp cache store.
+  # config.cache_storage = :file
 end
 ```
 


### PR DESCRIPTION
See 
https://github.com/carrierwaveuploader/carrierwave/pull/1879/files#r506082731
https://github.com/carrierwaveuploader/carrierwave/commit/629afecbaeccd2300e4660b78ee36bd95dd845c5#commitcomment-43337716
