### PR TITLE
Performance improvement, fixes twice #url method call

### DIFF
--- a/lib/carrierwave/uploader/url.rb
+++ b/lib/carrierwave/uploader/url.rb
@@ -15,9 +15,12 @@ module CarrierWave
       # [String] the location where this file is accessible via a url
       #
       def url(options = {})
-        if file.respond_to?(:url) && !(tmp_url = file.url).blank?
-          file.method(:url).arity.zero? ? tmp_url : file.url(options)
-        elsif file.respond_to?(:path)
+        if file.respond_to?(:url)
+          tmp_url = file.method(:url).arity.zero? ? file.url : file.url(options)
+          return tmp_url if tmp_url.present?
+        end
+
+        if file.respond_to?(:path)
           path = encode_path(file.path.sub(File.expand_path(root), ''))
 
           if host = asset_host

--- a/spec/uploader/url_spec.rb
+++ b/spec/uploader/url_spec.rb
@@ -60,21 +60,23 @@ describe CarrierWave::Uploader do
       end
     end
 
-    context "when File#url method doesn't get params" do
-      before do
-        module StorageX
-          class File
-            def url
-              true
-            end
-          end
-        end
+    context "File#url" do
+      let(:file_class) { FileX = Class.new }
+      let(:file) { file_class.new }
 
-        allow(uploader).to receive(:file).and_return(StorageX::File.new)
+      before do
+        allow(uploader).to receive(:file).and_return(file)
       end
 
-      it "raises ArgumentError" do
-        expect { uploader.url }.not_to raise_error
+      it "does not accept arguments" do
+        file.define_singleton_method(:url) { true }
+        uploader.url
+      end
+
+      it "does accept arguments" do
+        file.define_singleton_method(:url) { |x = true| x }
+        expect(file).to receive(:url).once.and_call_original
+        uploader.url
       end
     end
 


### PR DESCRIPTION
Hi there,

Currently, the method #url is being called twice (with and without options) in a case of arity != 0 (very common case).
It is very inefficient for signed URLs specifically.

This PR fixes that.

Thanks!