### PR TITLE
GCS: pass acl_header for public read if fog is public

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -497,6 +497,8 @@ module CarrierWave
         def acl_header
           if fog_provider == 'AWS'
             { 'x-amz-acl' => @uploader.fog_public ? 'public-read' : 'private' }
+          elsif fog_provider == "Google"
+            @uploader.fog_public ? { destination_predefined_acl: "publicRead" } : {}
           else
             {}
           end

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -69,6 +69,9 @@ end
             if @provider == 'AWS'
               expect(@storage.connection).to receive(:copy_object)
                                               .with(anything, anything, anything, anything, { "x-amz-acl"=>"public-read" }).and_call_original
+            elsif @provider == 'Google'
+              expect(@storage.connection).to receive(:copy_object)
+                                              .with(anything, anything, anything, anything, { destination_predefined_acl: "publicRead" }).and_call_original
             else
               expect(@storage.connection).to receive(:copy_object)
                                               .with(anything, anything, anything, anything, {}).and_call_original


### PR DESCRIPTION
When upgrading from carrierwave 1.3 to 2 we noticed that when we upload to GCS the URL we get is not public, even though we have `fog_public = true` in our initializer.

After some investigation it looks like the copy_object is not maintaining the ACL, this change is passing the correct ACL if `fog_public` is true.

Tested locally and it fixed the issue.

Closes https://github.com/carrierwaveuploader/carrierwave/issues/2426
fog-google pr: https://github.com/fog/fog-google/pull/513