### PR TITLE
Use Fog::Storage::GoogleJSON::Files#each_file_this_page

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -145,7 +145,7 @@ module CarrierWave
         connection.directories.new(
           :key    => uploader.fog_directory,
           :public => uploader.fog_public
-        ).files.all(:prefix => uploader.cache_dir).each do |file|
+        ).files.all(:prefix => uploader.cache_dir).each_file_this_page do |file|
           # generate_cache_id returns key formated TIMEINT-PID(-COUNTER)-RND
           time = file.key.scan(/(\d+)-\d+-\d+(?:-\d+)?/).first.map { |t| t.to_i }
           time = Time.at(*time)


### PR DESCRIPTION
I tried to clean my cache files on Google Cloud Storage, but I got this error.
I think I can solve this error by using `each_file_this_page` instead of `each`.
(Fog::Storage::GoogleJSON::Files#each may ignore `:prefix` specification) 

・storage :fog

```
irb(main):002:0> MyUploader.storage.new(MyUploader.new).clean_cache! 0
Sending HTTP get https://storage.googleapis.com/storage/v1/b/...
200
...
Traceback (most recent call last):
        2: from (irb):2
        1: from (irb):2:in `rescue in irb_binding'
NoMethodError (undefined method `map' for nil:NilClass)
```

Thanks.