### PR TITLE
Add "public" messages to errors

### DIFF
--- a/lib/carrierwave/error.rb
+++ b/lib/carrierwave/error.rb
@@ -1,8 +1,76 @@
 module CarrierWave
   class UploadError < StandardError; end
-  class IntegrityError < UploadError; end
+
+  class IntegrityError < UploadError
+    # @return [String] Returns the error message which can safely be exposed to
+    # the user.
+    attr_reader :public_message
+
+    # Construct a new IntegrityError object, optionally passing in messages.
+    #
+    # @param error_message [String] Optional message.
+    #
+    # @param public_error_message [String] Error message which can safely be
+    # exposed to the user. If it is not specified, it fallbacks to
+    # error_message. If error_message is not specified, it fallbacks to
+    # a default message translated for the current locale.
+    def initialize(error_message = nil, public_error_message = error_message)
+      super error_message
+      @public_message = if public_error_message.nil?
+                          I18n.t(:"errors.messages.carrierwave_integrity_error")
+                        else
+                          public_error_message
+                        end
+    end
+  end
+
   class InvalidParameter < UploadError; end
-  class ProcessingError < UploadError; end
-  class DownloadError < UploadError; end
+
+  class ProcessingError < UploadError
+    # @return [String] Returns the error message which can safely be exposed to
+    # the user.
+    attr_reader :public_message
+
+    # Construct a new IntegrityError object, optionally passing in messages.
+    #
+    # @param error_message [String] Optional message.
+    #
+    # @param public_error_message [String] Error message which can safely be
+    # exposed to the user. If it is not specified, it fallbacks to
+    # error_message. If error_message is not specified, it fallbacks to
+    # a default message translated for the current locale.
+    def initialize(error_message = nil, public_error_message = error_message)
+      super error_message
+      @public_message = if public_error_message.nil?
+                          I18n.t(:"errors.messages.carrierwave_processing_error")
+                        else
+                          public_error_message
+                        end
+    end
+  end
+
+  class DownloadError < UploadError
+    # @return [String] Returns the error message which can safely be exposed to
+    # the user.
+    attr_reader :public_message
+
+    # Construct a new IntegrityError object, optionally passing in messages.
+    #
+    # @param error_message [String] Optional message.
+    #
+    # @param public_error_message [String] Error message which can safely be
+    # exposed to the user. If it is not specified, it fallbacks to
+    # error_message. If error_message is not specified, it fallbacks to
+    # a default message translated for the current locale.
+    def initialize(error_message = nil, public_error_message = error_message)
+      super error_message
+      @public_message = if public_error_message.nil?
+                          I18n.t(:"errors.messages.carrierwave_download_error")
+                        else
+                          public_error_message
+                        end
+    end
+  end
+
   class UnknownStorageError < StandardError; end
 end

--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -265,7 +265,8 @@ module CarrierWave
       image.run_command("identify", current_path)
     rescue ::MiniMagick::Error, ::MiniMagick::Invalid => e
       message = I18n.translate(:"errors.messages.mini_magick_processing_error", :e => e)
-      raise CarrierWave::ProcessingError, message
+      public_message = I18n.translate(:"errors.messages.public_processing_error")
+      raise CarrierWave::ProcessingError.new(message, public_message)
     ensure
       image.destroy! if image
     end
@@ -311,7 +312,8 @@ module CarrierWave
       end
     rescue ::MiniMagick::Error, ::MiniMagick::Invalid => e
       message = I18n.translate(:"errors.messages.mini_magick_processing_error", :e => e)
-      raise CarrierWave::ProcessingError, message
+      public_message = I18n.translate(:"errors.messages.carrierwave_processing_error")
+      raise CarrierWave::ProcessingError.new(message, public_message)
     end
 
     private

--- a/lib/carrierwave/processing/rmagick.rb
+++ b/lib/carrierwave/processing/rmagick.rb
@@ -371,7 +371,9 @@ module CarrierWave
 
       destroy_image(frames)
     rescue ::Magick::ImageMagickError => e
-      raise CarrierWave::ProcessingError, I18n.translate(:"errors.messages.rmagick_processing_error", :e => e)
+      message = I18n.translate(:"errors.messages.rmagick_processing_error", :e => e)
+      public_message = I18n.translate(:"errors.messages.carrierwave_processing_error")
+      raise CarrierWave::ProcessingError.new(message, public_message)
     end
 
   private

--- a/lib/carrierwave/processing/vips.rb
+++ b/lib/carrierwave/processing/vips.rb
@@ -264,7 +264,8 @@ module CarrierWave
       end
     rescue ::Vips::Error => e
       message = I18n.translate(:"errors.messages.vips_processing_error", :e => e)
-      raise CarrierWave::ProcessingError, message
+      public_message = I18n.translate(:"errors.messages.carrierwave_processing_error")
+      raise CarrierWave::ProcessingError.new(message, public_message)
     end
 
     private

--- a/lib/carrierwave/validations/active_model.rb
+++ b/lib/carrierwave/validations/active_model.rb
@@ -12,8 +12,7 @@ module CarrierWave
 
         def validate_each(record, attribute, value)
           record.__send__("#{attribute}_processing_errors").each do |e|
-            message = (e.message == e.class.to_s) ? :carrierwave_processing_error : e.message
-            record.errors.add(attribute, message)
+            record.errors.add(attribute, e.public_message)
           end
         end
       end
@@ -22,8 +21,7 @@ module CarrierWave
 
         def validate_each(record, attribute, value)
           record.__send__("#{attribute}_integrity_errors").each do |e|
-            message = (e.message == e.class.to_s) ? :carrierwave_integrity_error : e.message
-            record.errors.add(attribute, message)
+            record.errors.add(attribute, e.public_message)
           end
         end
       end
@@ -32,8 +30,7 @@ module CarrierWave
 
         def validate_each(record, attribute, value)
           record.__send__("#{attribute}_download_errors").each do |e|
-            message = (e.message == e.class.to_s) ? :carrierwave_download_error : e.message
-            record.errors.add(attribute, message)
+            record.errors.add(attribute, e.public_message)
           end
         end
       end

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+describe CarrierWave::IntegrityError do
+  it "should use I18n to fill the default public message" do
+    expect(CarrierWave::IntegrityError.new).to have_attributes(public_message: 'is not of an allowed file type')
+
+    change_locale_and_store_translations(:pt, :errors => {
+      :messages => {
+        :carrierwave_integrity_error => 'não é um tipo de ficheiro permitido'
+      }
+    }) do
+      expect(CarrierWave::IntegrityError.new).to have_attributes(public_message: 'não é um tipo de ficheiro permitido')
+    end
+  end
+
+  it "should use the given public messages" do
+    expect(CarrierWave::IntegrityError.new('Ohh noez!')).to have_attributes(public_message: 'Ohh noez!')
+
+    change_locale_and_store_translations(:pt, :activerecord => {
+      :errors => {
+        :messages => {
+          :carrierwave_integrity_error => 'não é um tipo de ficheiro permitido'
+        }
+      }
+    }) do
+      expect(CarrierWave::IntegrityError.new('Ohh noez!')).to have_attributes(public_message: 'Ohh noez!')
+    end
+  end
+end
+
+describe CarrierWave::ProcessingError do
+  it "should use I18n to fill the default public message" do
+    expect(CarrierWave::ProcessingError.new).to have_attributes(public_message: 'failed to be processed')
+
+    change_locale_and_store_translations(:pt, :errors => {
+      :messages => {
+        :carrierwave_processing_error => 'falha ao processar imagem.'
+      }
+    }) do
+      expect(CarrierWave::ProcessingError.new).to have_attributes(public_message: 'falha ao processar imagem.')
+    end
+  end
+
+  it "should use the given public messages" do
+    expect(CarrierWave::ProcessingError.new('Ohh noez!')).to have_attributes(public_message: 'Ohh noez!')
+
+    change_locale_and_store_translations(:pt, :errors => {
+      :messages => {
+        :carrierwave_processing_error => 'falha ao processar imagem.'
+      }
+    }) do
+      expect(CarrierWave::ProcessingError.new('Ohh noez!')).to have_attributes(public_message: 'Ohh noez!')
+    end
+  end
+end
+
+describe CarrierWave::DownloadError do
+  it "should use I18n to fill the default public message" do
+    expect(CarrierWave::DownloadError.new).to have_attributes(public_message: 'could not be downloaded')
+
+    change_locale_and_store_translations(:pt, :errors => {
+      :messages => {
+        :carrierwave_download_error => 'não pôde ser transferido'
+      }
+    }) do
+      expect(CarrierWave::DownloadError.new).to have_attributes(public_message: 'não pôde ser transferido')
+    end
+  end
+
+  it "should use the given public messages" do
+    expect(CarrierWave::DownloadError.new('Ohh noez!')).to have_attributes(public_message: 'Ohh noez!')
+
+    change_locale_and_store_translations(:pt, :errors => {
+      :messages => {
+        :carrierwave_download_error => 'não pôde ser transferido'
+      }
+    }) do
+      expect(CarrierWave::DownloadError.new('Ohh noez!')).to have_attributes(public_message: 'Ohh noez!')
+    end
+  end
+end

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -302,7 +302,7 @@ describe CarrierWave::ActiveRecord do
           @uploader.class_eval do
             process :monkey
             def monkey
-              raise CarrierWave::ProcessingError
+              raise CarrierWave::ProcessingError.new(nil, 'public message')
             end
           end
           @event.image = stub_file('test.jpg')
@@ -312,52 +312,9 @@ describe CarrierWave::ActiveRecord do
           expect(@event).to_not be_valid
         end
 
-        it "should use I18n for processing errors without messages" do
+        it "should use the error's public message" do
           @event.valid?
-          expect(@event.errors[:image]).to eq(['failed to be processed'])
-
-          change_locale_and_store_translations(:pt, :activerecord => {
-            :errors => {
-              :messages => {
-                :carrierwave_processing_error => 'falha ao processar imagem.'
-              }
-            }
-          }) do
-            expect(@event).to_not be_valid
-            expect(@event.errors[:image]).to eq(['falha ao processar imagem.'])
-          end
-        end
-      end
-
-      context 'when validating processing' do
-        before do
-          @uploader.class_eval do
-            process :monkey
-            def monkey
-              raise CarrierWave::ProcessingError, "Ohh noez!"
-            end
-          end
-          @event.image = stub_file('test.jpg')
-        end
-
-        it "should make the record invalid when a processing error occurs" do
-          expect(@event).to_not be_valid
-        end
-
-        it "should use the error's messages for processing errors with messages" do
-          @event.valid?
-          expect(@event.errors[:image]).to eq(['Ohh noez!'])
-
-          change_locale_and_store_translations(:pt, :activerecord => {
-            :errors => {
-              :messages => {
-                :carrierwave_processing_error => 'falha ao processar imagem.'
-              }
-            }
-          }) do
-            expect(@event).to_not be_valid
-            expect(@event.errors[:image]).to eq(['Ohh noez!'])
-          end
+          expect(@event.errors[:image]).to eq(['public message'])
         end
       end
     end
@@ -513,7 +470,7 @@ describe CarrierWave::ActiveRecord do
         before do
           @uploader.class_eval do
             def download! file, headers = {}
-              raise CarrierWave::DownloadError
+              raise CarrierWave::DownloadError.new(nil, 'public message')
             end
           end
           @event.remote_image_url = 'http://www.example.com/missing.jpg'
@@ -523,20 +480,9 @@ describe CarrierWave::ActiveRecord do
           expect(@event).to_not be_valid
         end
 
-        it "should use I18n for download errors without messages" do
+        it "should use the error's public message" do
           @event.valid?
-          expect(@event.errors[:image]).to eq(['could not be downloaded'])
-
-          change_locale_and_store_translations(:pt, :activerecord => {
-            :errors => {
-              :messages => {
-                :carrierwave_download_error => 'não pode ser descarregado'
-              }
-            }
-          }) do
-            expect(@event).to_not be_valid
-            expect(@event.errors[:image]).to eq(['não pode ser descarregado'])
-          end
+          expect(@event.errors[:image]).to eq(['public message'])
         end
       end
 
@@ -1097,7 +1043,7 @@ describe CarrierWave::ActiveRecord do
           @uploader.class_eval do
             process :monkey
             def monkey
-              raise CarrierWave::ProcessingError
+              raise CarrierWave::ProcessingError.new(nil, 'public message')
             end
           end
           @event.images = [stub_file('test.jpg')]
@@ -1107,52 +1053,9 @@ describe CarrierWave::ActiveRecord do
           expect(@event).to_not be_valid
         end
 
-        it "should use I18n for processing errors without messages" do
+        it "should use the error's public message" do
           @event.valid?
-          expect(@event.errors[:images]).to eq(['failed to be processed'])
-
-          change_locale_and_store_translations(:pt, :activerecord => {
-            :errors => {
-              :messages => {
-                :carrierwave_processing_error => 'falha ao processar imagesm.'
-              }
-            }
-          }) do
-            expect(@event).to_not be_valid
-            expect(@event.errors[:images]).to eq(['falha ao processar imagesm.'])
-          end
-        end
-      end
-
-      context 'when validating processing' do
-        before do
-          @uploader.class_eval do
-            process :monkey
-            def monkey
-              raise CarrierWave::ProcessingError, "Ohh noez!"
-            end
-          end
-          @event.images = [stub_file('test.jpg')]
-        end
-
-        it "should make the record invalid when a processing error occurs" do
-          expect(@event).to_not be_valid
-        end
-
-        it "should use the error's messages for processing errors with messages" do
-          @event.valid?
-          expect(@event.errors[:images]).to eq(['Ohh noez!'])
-
-          change_locale_and_store_translations(:pt, :activerecord => {
-            :errors => {
-              :messages => {
-                :carrierwave_processing_error => 'falha ao processar imagesm.'
-              }
-            }
-          }) do
-            expect(@event).to_not be_valid
-            expect(@event.errors[:images]).to eq(['Ohh noez!'])
-          end
+          expect(@event.errors[:images]).to eq(['public message'])
         end
       end
     end
@@ -1277,7 +1180,7 @@ describe CarrierWave::ActiveRecord do
         before do
           @uploader.class_eval do
             def download! file, headers = {}
-              raise CarrierWave::DownloadError
+              raise CarrierWave::DownloadError.new(nil, 'public message')
             end
           end
           @event.remote_images_urls = ['http://www.example.com/missing.jpg']
@@ -1287,20 +1190,9 @@ describe CarrierWave::ActiveRecord do
           expect(@event).to_not be_valid
         end
 
-        it "should use I18n for download errors without messages" do
+        it "should use the error's public message" do
           @event.valid?
-          expect(@event.errors[:images]).to eq(['could not be downloaded'])
-
-          change_locale_and_store_translations(:pt, :activerecord => {
-            :errors => {
-              :messages => {
-                :carrierwave_download_error => 'não pode ser descarregado'
-              }
-            }
-          }) do
-            expect(@event).to_not be_valid
-            expect(@event.errors[:images]).to eq(['não pode ser descarregado'])
-          end
+          expect(@event.errors[:images]).to eq(['public message'])
         end
       end
 

--- a/spec/processing/mini_magick_spec.rb
+++ b/spec/processing/mini_magick_spec.rb
@@ -228,16 +228,25 @@ describe CarrierWave::MiniMagick do
       before { File.open(instance.current_path, 'w') { |f| f.puts "bogus" } }
 
       it "fails to process a non image file" do
-        expect { instance.resize_to_limit(200, 200) }.to raise_exception(CarrierWave::ProcessingError, /^Failed to manipulate with MiniMagick, maybe it is not an image\?/)
+        expect { instance.resize_to_limit(200, 200) }.to raise_exception(
+          an_instance_of(CarrierWave::ProcessingError)
+            .and(having_attributes(
+              message: a_string_starting_with('Failed to manipulate with MiniMagick, maybe it is not an image?'),
+              public_message: 'failed to be processed')))
       end
 
       it "uses I18n" do
         change_locale_and_store_translations(:nl, :errors => {
           :messages => {
+            :carrierwave_processing_error => "kon niet worden verwerkt",
             :mini_magick_processing_error => "Kon bestand niet met MiniMagick bewerken, misschien is het geen beeld bestand?"
           }
         }) do
-          expect {instance.resize_to_limit(200, 200)}.to raise_exception(CarrierWave::ProcessingError, /^Kon bestand niet met MiniMagick bewerken, misschien is het geen beeld bestand\?/)
+          expect { instance.resize_to_limit(200, 200) }.to raise_exception(
+            an_instance_of(CarrierWave::ProcessingError)
+              .and(having_attributes(
+                message: 'Kon bestand niet met MiniMagick bewerken, misschien is het geen beeld bestand?',
+                public_message: 'kon niet worden verwerkt')))
         end
       end
 

--- a/spec/processing/rmagick_spec.rb
+++ b/spec/processing/rmagick_spec.rb
@@ -318,16 +318,25 @@ describe CarrierWave::RMagick, :rmagick => true do
       end
 
       it "fails to process a non image file" do
-        expect {instance.resize_to_limit(200, 200)}.to raise_exception(CarrierWave::ProcessingError, /^Failed to manipulate with rmagick, maybe it is not an image\?/)
+        expect { instance.resize_to_limit(200, 200) }.to raise_exception(
+          an_instance_of(CarrierWave::ProcessingError)
+            .and(having_attributes(
+              message: a_string_starting_with('Failed to manipulate with rmagick, maybe it is not an image?'),
+              public_message: 'failed to be processed')))
       end
 
       it "uses I18n" do
         change_locale_and_store_translations(:nl, :errors => {
           :messages => {
+            :carrierwave_processing_error => "kon niet worden verwerkt",
             :rmagick_processing_error => "Kon bestand niet met rmagick bewerken, misschien is het geen beeld bestand?"
           }
         }) do
-          expect {instance.resize_to_limit(200, 200)}.to raise_exception(CarrierWave::ProcessingError, /^Kon bestand niet met rmagick bewerken, misschien is het geen beeld bestand\?/)
+          expect { instance.resize_to_limit(200, 200) }.to raise_exception(
+            an_instance_of(CarrierWave::ProcessingError)
+              .and(having_attributes(
+                message: 'Kon bestand niet met rmagick bewerken, misschien is het geen beeld bestand?',
+                public_message: 'kon niet worden verwerkt')))
         end
       end
 

--- a/spec/processing/vips_spec.rb
+++ b/spec/processing/vips_spec.rb
@@ -228,16 +228,25 @@ describe CarrierWave::Vips do
       before { File.open(instance.current_path, 'w') { |f| f.puts "bogus" } }
 
       it "fails to process a non image file" do
-        expect { instance.resize_to_limit(200, 200) }.to raise_exception(CarrierWave::ProcessingError, /^Failed to manipulate with vips, maybe it is not an image\?/)
+        expect { instance.resize_to_limit(200, 200) }.to raise_exception(
+          an_instance_of(CarrierWave::ProcessingError)
+            .and(having_attributes(
+              message: a_string_starting_with('Failed to manipulate with vips, maybe it is not an image?'),
+              public_message: 'failed to be processed')))
       end
 
       it "uses I18n" do
         change_locale_and_store_translations(:nl, :errors => {
           :messages => {
+            :carrierwave_processing_error => "kon niet worden verwerkt",
             :vips_processing_error => "Kon bestand niet met vips bewerken, misschien is het geen beeld bestand?"
           }
         }) do
-          expect {instance.resize_to_limit(200, 200)}.to raise_exception(CarrierWave::ProcessingError, /^Kon bestand niet met vips bewerken, misschien is het geen beeld bestand?\?/)
+          expect { instance.resize_to_limit(200, 200) }.to raise_exception(
+            an_instance_of(CarrierWave::ProcessingError)
+              .and(having_attributes(
+                message: 'Kon bestand niet met vips bewerken, misschien is het geen beeld bestand?',
+                public_message: 'kon niet worden verwerkt')))
         end
       end
 


### PR DESCRIPTION
This pull request supersedes #2499.

The message for `CarrierWave::ProcessingError` used to include
- the name of the underlying image processor (RMagick or MiniMagick) and
- the original error message produced by it.

The message is used for ActiveRecord validation, and it is often shown for an end-user. This behavior has some downsides:
- The message may look cryptic and is confusing for end-users. A typical end-user has no idea what is RMagick, for example.
- The information the message carries may be valuable for an adversary. Especially, the image processor may not be careful enough to mask sensitive information in an error message it produces. e.g. MiniMagick may include stderr of ImageMagick, which may contain file paths and reveal underlying ImageMagick configurations, in an error message.

This change solves the problems by adding `public_message` attributes, which does not contain such sensitive information, to error types and exposing them in ActiveRecord validation.