### PR TITLE
Revert "Manage transaction rollback"

### DIFF
--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -56,12 +56,13 @@ module CarrierWave
       validates_processing_of column if uploader_option(column.to_sym, :validate_processing)
       validates_download_of column if uploader_option(column.to_sym, :validate_download)
 
+      after_save :"store_#{column}!"
       before_save :"write_#{column}_identifier"
-      after_save :"store_previous_changes_for_#{column}"
       after_commit :"remove_#{column}!", :on => :destroy
       after_commit :"mark_remove_#{column}_false", :on => :update
+
+      after_save :"store_previous_changes_for_#{column}"
       after_commit :"remove_previously_stored_#{column}", :on => :update
-      after_commit :"store_#{column}!", :on => [:create, :update]
 
       mod = Module.new
       prepend mod

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -672,7 +672,7 @@ describe CarrierWave::ActiveRecord do
     end
 
     after do
-      FileUtils.rm_rf(public_path("uploads"))
+      FileUtils.rm_rf(file_path("uploads"))
     end
 
     describe 'normally' do
@@ -757,7 +757,7 @@ describe CarrierWave::ActiveRecord do
     end
 
     after do
-      FileUtils.rm_rf(public_path("uploads"))
+      FileUtils.rm_rf(file_path("uploads"))
     end
 
     it "should remove old file if old file had a different path" do
@@ -780,48 +780,10 @@ describe CarrierWave::ActiveRecord do
       Event.transaction do
         @event.image = stub_file('new.jpeg')
         @event.save
+        expect(File.exist?(public_path('uploads/new.jpeg'))).to be_truthy
         expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
         raise ActiveRecord::Rollback
       end
-      expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
-    end
-  end
-
-  describe "#mount_uploader into transaction" do
-    before do
-      @uploader.version :thumb
-      reset_class("Event")
-      Event.mount_uploader(:image, @uploader)
-      @event = Event.new
-    end
-
-    after do
-      FileUtils.rm_rf(public_path("uploads"))
-    end
-
-    it "should not store file during rollback" do
-      Event.transaction do
-        @event.image = stub_file('new.jpeg')
-        @event.save
-
-        raise ActiveRecord::Rollback
-      end
-
-      expect(File.exist?(public_path('uploads/new.jpeg'))).to be_falsey
-    end
-
-    it "should not change file during rollback" do
-      @event.image = stub_file('old.jpeg')
-      @event.save
-
-      Event.transaction do
-        @event.image = stub_file('new.jpeg')
-        @event.save
-
-        raise ActiveRecord::Rollback
-      end
-
-      expect(File.exist?(public_path('uploads/new.jpeg'))).to be_falsey
       expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
     end
   end
@@ -843,7 +805,7 @@ describe CarrierWave::ActiveRecord do
     end
 
     after do
-      FileUtils.rm_rf(public_path("uploads"))
+      FileUtils.rm_rf(file_path("uploads"))
     end
 
     it "should remove old file1 and file2 if old file1 and file2 had a different paths" do
@@ -886,7 +848,7 @@ describe CarrierWave::ActiveRecord do
     end
 
     after do
-      FileUtils.rm_rf(public_path("uploads"))
+      FileUtils.rm_rf(file_path("uploads"))
     end
 
     it "should remove old file if old file had a different path" do
@@ -1434,7 +1396,7 @@ describe CarrierWave::ActiveRecord do
     end
 
     after do
-      FileUtils.rm_rf(public_path("uploads"))
+      FileUtils.rm_rf(file_path("uploads"))
     end
 
     describe 'normally' do
@@ -1511,7 +1473,7 @@ describe CarrierWave::ActiveRecord do
     end
 
     after do
-      FileUtils.rm_rf(public_path("uploads"))
+      FileUtils.rm_rf(file_path("uploads"))
     end
 
     it "should remove old file if old file had a different path" do
@@ -1548,7 +1510,7 @@ describe CarrierWave::ActiveRecord do
     end
 
     after do
-      FileUtils.rm_rf(public_path("uploads"))
+      FileUtils.rm_rf(file_path("uploads"))
     end
 
     it "should remove old file1 and file2 if old file1 and file2 had a different paths" do
@@ -1590,7 +1552,7 @@ describe CarrierWave::ActiveRecord do
     end
 
     after do
-      FileUtils.rm_rf(public_path("uploads"))
+      FileUtils.rm_rf(file_path("uploads"))
     end
 
     it "should remove old file if old file had a different path" do


### PR DESCRIPTION
This commit attempts to fix leftover files in failed transactions, but
in the process introduces three problems:

- Uploader state is inconsistent between `save` and `commit`. For example, reading `my_object.file_url.url` will return a bogus url if read before commit.
- A file might not be uploaded after a successful commit. For example, if there is a network failure. This causes the transaction to not be rolled back and invalid records (pointing to a non-existent-file) being recorded.
- Even if the upload eventually completes, it can take an arbitrary amount of time, during which the record is invalid.

This reverts commit 665f2254a2c70385b67942b13a4710dc6826c42d from https://github.com/carrierwaveuploader/carrierwave/pull/2209.

Fixes: #2544
