### PR TITLE
fix: remove uploaded files if transaction is rolled back

### DIFF
--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -62,7 +62,9 @@ module CarrierWave
       after_commit :"mark_remove_#{column}_false", :on => :update
 
       after_save :"store_previous_changes_for_#{column}"
+      after_commit :"reset_previous_changes_for_#{column}"
       after_commit :"remove_previously_stored_#{column}", :on => :update
+      after_rollback :"remove_rolled_back_#{column}"
 
       mod = Module.new
       prepend mod

--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -56,12 +56,13 @@ module CarrierWave
       validates_processing_of column if uploader_option(column.to_sym, :validate_processing)
       validates_download_of column if uploader_option(column.to_sym, :validate_download)
 
+      after_save :"store_#{column}!"
       before_save :"write_#{column}_identifier"
-      after_save :"store_previous_changes_for_#{column}"
       after_commit :"remove_#{column}!", :on => :destroy
       after_commit :"mark_remove_#{column}_false", :on => :update
+
+      after_save :"store_previous_changes_for_#{column}"
       after_commit :"remove_previously_stored_#{column}", :on => :update
-      after_commit :"store_#{column}!", :on => [:create, :update]
 
       mod = Module.new
       prepend mod

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -780,48 +780,10 @@ describe CarrierWave::ActiveRecord do
       Event.transaction do
         @event.image = stub_file('new.jpeg')
         @event.save
+        expect(File.exist?(public_path('uploads/new.jpeg'))).to be_truthy
         expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
         raise ActiveRecord::Rollback
       end
-      expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
-    end
-  end
-
-  describe "#mount_uploader into transaction" do
-    before do
-      @uploader.version :thumb
-      reset_class("Event")
-      Event.mount_uploader(:image, @uploader)
-      @event = Event.new
-    end
-
-    after do
-      FileUtils.rm_rf(public_path("uploads"))
-    end
-
-    it "should not store file during rollback" do
-      Event.transaction do
-        @event.image = stub_file('new.jpeg')
-        @event.save
-
-        raise ActiveRecord::Rollback
-      end
-
-      expect(File.exist?(public_path('uploads/new.jpeg'))).to be_falsey
-    end
-
-    it "should not change file during rollback" do
-      @event.image = stub_file('old.jpeg')
-      @event.save
-
-      Event.transaction do
-        @event.image = stub_file('new.jpeg')
-        @event.save
-
-        raise ActiveRecord::Rollback
-      end
-
-      expect(File.exist?(public_path('uploads/new.jpeg'))).to be_falsey
       expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
     end
   end

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -780,11 +780,48 @@ describe CarrierWave::ActiveRecord do
       Event.transaction do
         @event.image = stub_file('new.jpeg')
         @event.save
-        expect(File.exist?(public_path('uploads/new.jpeg'))).to be_truthy
         expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
         raise ActiveRecord::Rollback
       end
       expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
+    end
+
+    it 'should remove new file if transaction is rollback' do
+      Event.transaction do
+        @event.image = stub_file('new.jpeg')
+        @event.save
+        expect(File.exist?(public_path('uploads/new.jpeg'))).to be_truthy
+        raise ActiveRecord::Rollback
+      end
+      expect(File.exist?(public_path('uploads/new.jpeg'))).to be_falsey
+    end
+
+    it 'should give correct url during transaction' do
+      Event.transaction do
+        @event.image = stub_file('new.jpeg')
+        @event.save
+        expect(@event.image_url).to eq '/uploads/new.jpeg'
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    it 'should raise error at save if storage cannot be done, preserving old' do
+      allow(@event).to receive(:store_image!).and_raise(CarrierWave::UploadError)
+      Event.transaction do
+        @event.image = stub_file('new.jpeg')
+        expect{ @event.save }.to raise_error(CarrierWave::UploadError)
+        raise ActiveRecord::Rollback
+      end
+      expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
+    end
+
+    it 'should remove new file if transaction is rollback' do
+      Event.transaction do
+        @event.image = stub_file('new.jpeg')
+        @event.save
+        expect(File.exist?(public_path('uploads/new.jpeg'))).to be_truthy
+        raise ActiveRecord::Rollback
+      end
       expect(File.exist?(public_path('uploads/new.jpeg'))).to be_falsey
     end
   end

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -785,6 +785,46 @@ describe CarrierWave::ActiveRecord do
         raise ActiveRecord::Rollback
       end
       expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
+      expect(File.exist?(public_path('uploads/new.jpeg'))).to be_falsey
+    end
+  end
+
+  describe "#mount_uploader into transaction" do
+    before do
+      @uploader.version :thumb
+      reset_class("Event")
+      Event.mount_uploader(:image, @uploader)
+      @event = Event.new
+    end
+
+    after do
+      FileUtils.rm_rf(public_path("uploads"))
+    end
+
+    it "should not store file during rollback" do
+      Event.transaction do
+        @event.image = stub_file('new.jpeg')
+        @event.save
+
+        raise ActiveRecord::Rollback
+      end
+
+      expect(File.exist?(public_path('uploads/new.jpeg'))).to be_falsey
+    end
+
+    it "should not change file during rollback" do
+      @event.image = stub_file('old.jpeg')
+      @event.save
+
+      Event.transaction do
+        @event.image = stub_file('new.jpeg')
+        @event.save
+
+        raise ActiveRecord::Rollback
+      end
+
+      expect(File.exist?(public_path('uploads/new.jpeg'))).to be_falsey
+      expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
     end
   end
 


### PR DESCRIPTION
This prevents accumulating stale files when transaction is aborted.

Depends on #2545 , restores functionality added by #2209 