### PR TITLE
Replace mimemagic gem with ruby-magic

### DIFF
--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activemodel", ">= 5.0.0"
   s.add_dependency "mini_mime", ">= 0.1.3"
   s.add_dependency "image_processing", "~> 1.1"
-  s.add_dependency "mimemagic", ">= 0.3.0"
+  s.add_dependency "ruby-magic", "~> 0.3.1"
   s.add_dependency "addressable", "~> 2.6"
   s.add_dependency "ssrf_filter", "~> 1.0"
   if RUBY_ENGINE == 'jruby'

--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -1,8 +1,7 @@
 require 'pathname'
 require 'active_support/core_ext/string/multibyte'
 require 'mini_mime'
-require 'mimemagic'
-require 'mimemagic/overlay'
+require 'magic'
 
 module CarrierWave
 
@@ -15,7 +14,6 @@ module CarrierWave
   # It's probably needlessly comprehensive and complex. Help is appreciated.
   #
   class SanitizedFile
-
     attr_reader :file
 
     class << self
@@ -262,7 +260,7 @@ module CarrierWave
     def content_type
       @content_type ||=
         existing_content_type ||
-        mime_magic_content_type ||
+        file_magic_content_type ||
         mini_mime_content_type
     end
 
@@ -329,13 +327,13 @@ module CarrierWave
       end
     end
 
-    def mime_magic_content_type
+    def file_magic_content_type
       if path
         type = File.open(path) do |file|
-          MimeMagic.by_magic(file).try(:type)
+          FileMagic.file(file, FileMagic::MIME_TYPE)
         end
 
-        if type.nil?
+        if type == "application/x-empty"
           type = ::MiniMime.lookup_by_filename(path).try(:content_type)
           type = 'invalid/invalid' unless type.nil? || type.start_with?('text/')
         end

--- a/spec/sanitized_file_spec.rb
+++ b/spec/sanitized_file_spec.rb
@@ -378,7 +378,7 @@ describe CarrierWave::SanitizedFile do
         expect(sanitized_file.content_type).to eq("application/octet-stream")
       end
 
-      it "should detect content type correctly using MagicMime when content_type is not set" do
+      it "should detect content type correctly using FileMagic when content_type is not set" do
         sanitized_file.content_type = nil
         sanitized_file.move_to(file_path("new_dir","gurr.png"))
 


### PR DESCRIPTION
- Replace `mimemagic` gem with `ruby-magic`
- Some tests are failing, in example:
  - CarrierWave::SanitizedFile#content_type does not allow spoofing of the mime type if the mime type is not detectable
    ```
     expected: "invalid/invalid"
     got: "image/x-mvg"
    ```
    But since the file is a ImageMagick Vector Graphic it seems it should be correct to return `image/x-mvg` instead of `invalid/invalid`
  - CarrierWave::SanitizedFile#content_type does not allow spoofing of the mime type
    ```
     expected: "application/zip"
     got: "application/octet-stream"
    ```
  - CarrierWave::SanitizedFile with a valid File object it should behave like all valid sanitized files #move_to should detect content type correctly using FileMagic when content_type is not set
      ```
     expected:  "invalid/invalid"
     got: "text/plain"
    ```
    But since the file contains the text `this is stuff` it seems it should be correct to return `text/plain` instead of `invalid/invalid`