### PR TITLE
Replace mini_mime with marcel

### DIFF
--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", ">= 5.0.0"
   s.add_dependency "activemodel", ">= 5.0.0"
-  s.add_dependency "mini_mime", ">= 0.1.3"
   s.add_dependency "image_processing", "~> 1.1"
   s.add_dependency "marcel", "~> 1.0.0"
   s.add_dependency "addressable", "~> 2.6"

--- a/lib/carrierwave/downloader/remote_file.rb
+++ b/lib/carrierwave/downloader/remote_file.rb
@@ -30,9 +30,10 @@ module CarrierWave
 
       def original_filename
         filename = filename_from_header || filename_from_uri
-        mime_type = MiniMime.lookup_by_content_type(content_type)
+        mime_type = Marcel::TYPES[content_type]
         unless File.extname(filename).present? || mime_type.blank?
-          filename = "#{filename}.#{mime_type.extension}"
+          extension = mime_type[0].first
+          filename = "#{filename}.#{extension}"
         end
         filename
       end

--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -306,7 +306,7 @@ module CarrierWave
 
       if File.extname(result.path) != File.extname(current_path)
         move_to = current_path.chomp(File.extname(current_path)) + File.extname(result.path)
-        file.content_type = ::MiniMime.lookup_by_filename(move_to).content_type
+        file.content_type = Marcel::Magic.by_path(move_to).try(:type)
         file.move_to(move_to, permissions, directory_permissions)
       end
     rescue ::MiniMagick::Error, ::MiniMagick::Invalid => e

--- a/lib/carrierwave/processing/rmagick.rb
+++ b/lib/carrierwave/processing/rmagick.rb
@@ -363,7 +363,7 @@ module CarrierWave
       if options[:format] || @format
         frames.write("#{options[:format] || @format}:#{current_path}", &write_block)
         move_to = current_path.chomp(File.extname(current_path)) + ".#{options[:format] || @format}"
-        file.content_type = ::MiniMime.lookup_by_filename(move_to).content_type
+        file.content_type = Marcel::Magic.by_path(move_to).try(:type)
         file.move_to(move_to, permissions, directory_permissions)
       else
         frames.write(current_path, &write_block)

--- a/lib/carrierwave/processing/vips.rb
+++ b/lib/carrierwave/processing/vips.rb
@@ -259,7 +259,7 @@ module CarrierWave
 
       if File.extname(result.path) != File.extname(current_path)
         move_to = current_path.chomp(File.extname(current_path)) + File.extname(result.path)
-        file.content_type = ::MiniMime.lookup_by_filename(move_to).content_type
+        file.content_type = Marcel::Magic.by_path(move_to).try(:type)
         file.move_to(move_to, permissions, directory_permissions)
       end
     rescue ::Vips::Error => e

--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -1,6 +1,5 @@
 require 'pathname'
 require 'active_support/core_ext/string/multibyte'
-require 'mini_mime'
 require 'marcel'
 
 module CarrierWave
@@ -261,8 +260,8 @@ module CarrierWave
     def content_type
       @content_type ||=
         existing_content_type ||
-        marcel_magic_content_type ||
-        mini_mime_content_type
+        marcel_magic_by_mime_type ||
+        marcel_magic_by_path
     end
 
     ##
@@ -328,27 +327,27 @@ module CarrierWave
       end
     end
 
-    def marcel_magic_content_type
-      if path
-        type = File.open(path) do |file|
-          Marcel::Magic.by_magic(file).try(:type)
-        end
+    def marcel_magic_by_mime_type
+      return unless path
 
-        if type.nil?
-          type = Marcel::Magic.by_path(file).try(:type)
-          type = 'invalid/invalid' unless type.nil? || type.start_with?('text/')
-        end
-
-        type
+      type = File.open(path) do |file|
+        Marcel::Magic.by_magic(file).try(:type)
       end
+
+      if type.nil?
+        type = Marcel::Magic.by_path(file).try(:type)
+        type = 'invalid/invalid' unless type.nil? || type.start_with?('text/')
+      end
+
+      type
     rescue Errno::ENOENT
       nil
     end
 
-    def mini_mime_content_type
+    def marcel_magic_by_path
       return unless path
-      mime_type = ::MiniMime.lookup_by_filename(path)
-      @content_type = (mime_type && mime_type.content_type).to_s
+
+      Marcel::Magic.by_path(path).to_s
     end
 
     def split_extension(filename)

--- a/spec/downloader/remote_file_spec.rb
+++ b/spec/downloader/remote_file_spec.rb
@@ -55,7 +55,7 @@ describe CarrierWave::Downloader::RemoteFile do
     end
 
     it 'sets file extension based on content-type if missing' do
-      expect(subject.original_filename).to eq "test.jpeg"
+      expect(subject.original_filename).to eq "test.jpg"
     end
 
     context 'when filename is quoted' do
@@ -70,7 +70,7 @@ describe CarrierWave::Downloader::RemoteFile do
       let(:content_disposition){ 'filename=""' }
 
       it "sets file extension based on content-type if missing" do
-        expect(subject.original_filename).to eq 'test.jpeg'
+        expect(subject.original_filename).to eq 'test.jpg'
       end
     end
 
@@ -78,7 +78,7 @@ describe CarrierWave::Downloader::RemoteFile do
       let(:content_disposition){ 'filename=' }
 
       it "reads filename correctly" do
-        expect(subject.original_filename).to eq 'test.jpeg'
+        expect(subject.original_filename).to eq 'test.jpg'
       end
     end
 


### PR DESCRIPTION
- Replaces `mini_mime` with `marcel` since `marcel` has the same functionality 
- Pros:
  - The number of dependencies is reduced (less complexity, less bugs)
  - More consistency since mime types and extensions would be handled by a single gem
  - `marcel` is maintained by Rails core team, which is a warranty of long-term support and development
  - `marcel` identifies 1243 extensions while `mini_mime` identifies 1210
    ```
    irb(main)> Marcel::EXTENSIONS.count
    => 1243

    irb(main)> File.readlines(MiniMime::Configuration.ext_db_path).each do |line|
    irb(main)*     s << line.strip
    irb(main)> end
    irb(main)> File.readlines(MiniMime::Configuration.content_type_db_path).each do |line|
    irb(main)*     s << line.strip
    irb(main)> end
    irb(main)> s.length
    => 1210
    ```
 
- Cons:
  - Introduces the following [breaking change](https://github.com/carrierwaveuploader/carrierwave/blob/70f098c3945c7f82bac8ac1f02b16c5fa314fbae/lib/carrierwave/downloader/remote_file.rb#L35), since some mime types like `image/jpeg` have more than one possible extension (`jpg`, `jpeg`, etc.):

    ```ruby
    Failures:

    1) CarrierWave::Downloader::RemoteFile#original_filename sets file extension based on content-type if missing
       Failure/Error: expect(subject.original_filename).to eq "test.jpeg"
     
         expected: "test.jpeg"
              got: "test.jpg"
     
         (compared using ==)
       # ./spec/downloader/remote_file_spec.rb:58:in `block (3 levels) in <top (required)>'

    2) CarrierWave::Downloader::RemoteFile#original_filename when filename is quoted and empty sets file extension based on content-type if missing
       Failure/Error: expect(subject.original_filename).to eq 'test.jpeg'
     
         expected: "test.jpeg"
              got: "test.jpg"
     
         (compared using ==)
       # ./spec/downloader/remote_file_spec.rb:73:in `block (4 levels) in <top (required)>'

    3) CarrierWave::Downloader::RemoteFile#original_filename when filename is not quoted and empty reads filename correctly
       Failure/Error: expect(subject.original_filename).to eq 'test.jpeg'
     
         expected: "test.jpeg"
              got: "test.jpg"
     
         (compared using ==)
       # ./spec/downloader/remote_file_spec.rb:81:in `block (4 levels) in <top (required)>'
    ```
    - Regarding memory consumption and performance, `mime_magic` has a hash cache of 200 rows and misses are binary-searched from a file (which seems less performant apparently) while `marcel` loads all records in a hash in memory. I don't think there is a noticeable improvement in performance respect what `mime_magic` does, benchmarks should be performed to compare both solutions.