### PR TITLE
Fix bug when reading content_type from a CSV object linked to a file

### DIFF
--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -335,7 +335,7 @@ module CarrierWave
         end
 
         if type.nil?
-          type = Marcel::Magic.by_path(file).try(:type)
+          type = Marcel::Magic.by_path(path).try(:type)
           type = 'invalid/invalid' unless type.nil? || type.start_with?('text/')
         end
 

--- a/spec/fixtures/addresses.csv
+++ b/spec/fixtures/addresses.csv
@@ -1,0 +1,6 @@
+John,Doe,120 jefferson st.,Riverside, NJ, 08075
+Jack,McGinnis,220 hobo Av.,Phila, PA,09119
+"John ""Da Man""",Repici,120 Jefferson St.,Riverside, NJ,08075
+Stephen,Tyler,"7452 Terrace ""At the Plaza"" road",SomeTown,SD, 91234
+,Blankman,,SomeTown, SD, 00298
+"Joan ""the bone"", Anne",Jet,"9th, at Terrace plc",Desert City,CO,00123

--- a/spec/sanitized_file_spec.rb
+++ b/spec/sanitized_file_spec.rb
@@ -221,6 +221,14 @@ describe CarrierWave::SanitizedFile do
       expect(sanitized_file.content_type).to eq("image/jpeg")
     end
 
+    it "reads content type of a CSV linked to a file" do
+      file = File.open(file_path('addresses.csv'))
+      csv_file = CSV.new(file)
+      sanitized_file = CarrierWave::SanitizedFile.new(csv_file)
+
+      expect(sanitized_file.content_type).to eq("text/csv")
+    end
+
     it "does not allow spoofing of the mime type" do
       file = File.open(file_path("zip.png"))
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ require 'pry'
 require 'tempfile'
 require 'time'
 require 'logger'
+require 'csv'
 
 require 'carrierwave'
 require 'timecop'


### PR DESCRIPTION
Resolves https://github.com/carrierwaveuploader/carrierwave/issues/2559

In my previous PR I mistakenly passed the `file` argument to `Marcel::Magic.by_path` instead of `path`. This was not an issue in the majority of cases (`File` objects work properly) but not for a CSV, which raises a `TypeError Exception: no implicit conversion of CSV into String`. Since all tests were passing, this bug passed inadvertently. I added a new test to ensure it does not happen again.