### PR TITLE
Prioritize the FileSize check before the extensions/content type

### DIFF
--- a/lib/carrierwave/uploader.rb
+++ b/lib/carrierwave/uploader.rb
@@ -7,11 +7,11 @@ require "carrierwave/uploader/cache"
 require "carrierwave/uploader/store"
 require "carrierwave/uploader/download"
 require "carrierwave/uploader/remove"
+require "carrierwave/uploader/file_size"
 require "carrierwave/uploader/extension_whitelist"
 require "carrierwave/uploader/extension_blacklist"
 require "carrierwave/uploader/content_type_whitelist"
 require "carrierwave/uploader/content_type_blacklist"
-require "carrierwave/uploader/file_size"
 require "carrierwave/uploader/processing"
 require "carrierwave/uploader/versions"
 require "carrierwave/uploader/default_url"
@@ -52,11 +52,11 @@ module CarrierWave
       include CarrierWave::Uploader::Store
       include CarrierWave::Uploader::Download
       include CarrierWave::Uploader::Remove
+      include CarrierWave::Uploader::FileSize
       include CarrierWave::Uploader::ExtensionWhitelist
       include CarrierWave::Uploader::ExtensionBlacklist
       include CarrierWave::Uploader::ContentTypeWhitelist
       include CarrierWave::Uploader::ContentTypeBlacklist
-      include CarrierWave::Uploader::FileSize
       include CarrierWave::Uploader::Processing
       include CarrierWave::Uploader::Versions
       include CarrierWave::Uploader::DefaultUrl


### PR DESCRIPTION
I think we should check the file size before we try to check the extension and the content-type