### PR TITLE
Remove Postgresql and use sqlite3 for testing ActiveRecord

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,16 +34,6 @@ jobs:
             gemfile: gemfiles/rails-6-0.gemfile
             experimental: false
     runs-on: ubuntu-20.04
-    services:
-      postgres:
-        image: postgres:11
-        ports:
-          - 5432:5432
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: carrierwave_test
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
       EXPERIMENTAL: ${{ matrix.experimental }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,8 +30,3 @@ You should now be able to run the remote tests:
     REMOTE=true bundle exec rake
 
 Please test with the latest Ruby 2.2.x version using RVM if possible.
-
-## Running active record tests
-
-Make sure you have a local PostgreSQL database named `carrierwave_test` with the username
-`postgres`

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
 gem "activemodel-serializers-xml"
+gem 'sqlite3', platforms: :ruby
+gem "activerecord-jdbcsqlite3-adapter", platform: [:jruby, :truffleruby]
 
 gemspec

--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -28,11 +28,6 @@ Gem::Specification.new do |s|
   s.add_dependency "marcel", "~> 1.0.0"
   s.add_dependency "addressable", "~> 2.6"
   s.add_dependency "ssrf_filter", "~> 1.0"
-  if RUBY_ENGINE == 'jruby'
-    s.add_development_dependency 'activerecord-jdbcpostgresql-adapter'
-  else
-    s.add_development_dependency "pg"
-  end
   s.add_development_dependency "rails", ">= 5.0.0"
   s.add_development_dependency "cucumber", "~> 2.3"
   s.add_development_dependency "rspec", "~> 3.4"

--- a/gemfiles/rails-5-0.gemfile
+++ b/gemfiles/rails-5-0.gemfile
@@ -1,11 +1,11 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.0.0"
-gem 'pg', '~> 0.21.0', platforms: :ruby
 gem "activemodel-serializers-xml"
-gem "activerecord-jdbcpostgresql-adapter", "~> 50.0", platforms: :jruby
 if RUBY_VERSION < '2.3'
   gem "ruby-vips", "2.0.13"
 end
+gem 'sqlite3', '~> 1.3.6', platforms: :ruby
+gem "activerecord-jdbcsqlite3-adapter", platform: [:jruby, :truffleruby]
 
 gemspec :path => "../"

--- a/gemfiles/rails-5-1.gemfile
+++ b/gemfiles/rails-5-1.gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", "~> 5.1.0"
 gem "activemodel-serializers-xml"
-gem 'pg', '~> 0.21.0', platforms: :ruby
-gem "activerecord-jdbcpostgresql-adapter", '~> 51.0',  platforms: :jruby
+gem 'sqlite3', '~> 1.3.6', platforms: :ruby
+gem "activerecord-jdbcsqlite3-adapter", platform: [:jruby, :truffleruby]
 
 gemspec :path => "../"

--- a/gemfiles/rails-5-2.gemfile
+++ b/gemfiles/rails-5-2.gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", "~> 5.2.0"
 gem "activemodel-serializers-xml"
-gem 'pg', '~> 0.21.0', platforms: :ruby
+gem 'sqlite3', platforms: :ruby
+gem "activerecord-jdbcsqlite3-adapter", platform: [:jruby, :truffleruby]
 
 gemspec :path => "../"

--- a/gemfiles/rails-6-0.gemfile
+++ b/gemfiles/rails-6-0.gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", "~> 6.0.0"
 gem "activemodel-serializers-xml"
-gem 'pg', '~> 0.21.0', platforms: :ruby
+gem 'sqlite3', platforms: :ruby
+gem "activerecord-jdbcsqlite3-adapter", platform: [:jruby, :truffleruby]
 
 gemspec :path => "../"

--- a/gemfiles/rails-6-1.gemfile
+++ b/gemfiles/rails-6-1.gemfile
@@ -6,5 +6,8 @@ if RUBY_VERSION >= '3'
   gem 'rmagick', github: 'rmagick/rmagick', platform: :ruby
   gem 'fog-google', github: 'binti-family/fog-google', branch: 'ruby-3.0'
 end
+gem 'sqlite3', platforms: :ruby
+gem "activerecord-jdbcsqlite3-adapter", platform: [:jruby, :truffleruby]
+
 
 gemspec :path => "../"

--- a/gemfiles/rails-master.gemfile
+++ b/gemfiles/rails-master.gemfile
@@ -10,5 +10,7 @@ gem "activemodel-serializers-xml"
 gem "activerecord-jdbcpostgresql-adapter", github: "jruby/activerecord-jdbc-adapter", platforms: :jruby
 gem 'rmagick', platform: :ruby
 gem 'fog-google', github: 'binti-family/fog-google', branch: 'ruby-3.0'
+gem 'sqlite3', platforms: :ruby
+gem "activerecord-jdbcsqlite3-adapter", platform: [:jruby, :truffleruby]
 
 gemspec :path => "../"

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'support/activerecord'
 
+
 def create_table(name)
   ActiveRecord::Base.connection.create_table(name, force: true) do |t|
     t.column :image, :string
@@ -17,7 +18,13 @@ end
 
 def reset_class(class_name)
   Object.send(:remove_const, class_name) rescue nil
-  Object.const_set(class_name, Class.new(ActiveRecord::Base))
+  klass = Object.const_set(class_name, Class.new(ActiveRecord::Base))
+  # TODO Remove when Rails 5.2 is dropped
+  klass.class_eval do
+    attribute :images, :json
+    attribute :textfiles, :json
+  end
+  klass
 end
 
 describe CarrierWave::ActiveRecord do

--- a/spec/support/activerecord.rb
+++ b/spec/support/activerecord.rb
@@ -1,33 +1,40 @@
-if RUBY_ENGINE == 'jruby'
-  require 'activerecord-jdbcpostgresql-adapter'
-else
-  require 'pg'
-end
 require 'active_record'
 require 'carrierwave/orm/activerecord'
 Bundler.require
 
-# Change this if PG is unavailable
-dbconfig = {
-  :host     => '127.0.0.1',
-  :adapter  => 'postgresql',
-  :database => 'carrierwave_test',
-  :encoding => 'utf8',
-  :username => 'postgres',
-  :password => 'postgres'
-}
-
-database = dbconfig.delete(:database)
-
-ActiveRecord::Base.establish_connection(dbconfig.merge(database: "template1"))
-begin
-  ActiveRecord::Base.connection.create_database database
-rescue ActiveRecord::StatementInvalid => e # database already exists
-end
-ActiveRecord::Base.establish_connection(dbconfig.merge(:database => database))
+ActiveRecord::Base.establish_connection({ adapter: 'sqlite3', database: ':memory:' })
 
 ActiveRecord::Migration.verbose = false
 
-if ActiveRecord::VERSION::STRING >= '4.2' && ActiveRecord::VERSION::STRING < '5.0'
-  ActiveRecord::Base.raise_in_transactional_callbacks = true
+if ActiveRecord.version < Gem::Version.new("5.2")
+  module ActiveRecord
+    module Type
+      class Json < ActiveModel::Type::Value
+        include ActiveModel::Type::Helpers::Mutable
+
+        def type
+          :json
+        end
+
+        def deserialize(value)
+          return value unless value.is_a?(::String)
+          ActiveSupport::JSON.decode(value) rescue nil
+        end
+
+        def serialize(value)
+          ActiveSupport::JSON.encode(value) unless value.nil?
+        end
+
+        def changed_in_place?(raw_old_value, new_value)
+          deserialize(raw_old_value) != new_value
+        end
+
+        def accessor
+          ActiveRecord::Store::StringKeyedHashAccessor
+        end
+      end
+    end
+  end
+
+  ActiveRecord::Type.register(:json, ActiveRecord::Type::Json, override: false)
 end


### PR DESCRIPTION
I removed Postgres service and used In Memory Sqlite3. This change made the test run much faster as they don't depend on other services.