### PR TITLE
Remove Support for Merb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## Changed
+* Remove support for Merb (@seuros [#2564](https://github.com/carrierwaveuploader/carrierwave/pull/2564))
+
 ## 2.2.1 - 2021-03-30
 ### Changed
 * Replace mimemagic with marcel due to licensing concern (@pjmartorell [#2551](https://github.com/carrierwaveuploader/carrierwave/pull/2551), [#2548](https://github.com/carrierwaveuploader/carrierwave/issues/2548))

--- a/lib/carrierwave.rb
+++ b/lib/carrierwave.rb
@@ -25,16 +25,7 @@ module CarrierWave
 
 end
 
-if defined?(Merb)
-
-  CarrierWave.root = Merb.dir_for(:public)
-  Merb::BootLoader.before_app_loads do
-    # Setup path for uploaders and load all of them before classes are loaded
-    Merb.push_path(:uploaders, Merb.root / 'app' / 'uploaders', '*.rb')
-    Dir.glob(File.join(Merb.load_paths[:uploaders])).each {|f| require f }
-  end
-
-elsif defined?(Jets)
+if defined?(Jets)
 
   module CarrierWave
     class Turbine < Jets::Turbine


### PR DESCRIPTION
Merb was deprecated in 2010. And dont work with current version of ruby 