### PR TITLE
Remove redundant each after zip in `remote_urls=`

### DIFF
--- a/lib/carrierwave/mounter.rb
+++ b/lib/carrierwave/mounter.rb
@@ -92,7 +92,7 @@ module CarrierWave
       @remote_urls = urls
 
       clear_unstaged
-      urls.zip(remote_request_headers || []).each do |url, header|
+      urls.zip(remote_request_headers || []) do |url, header|
         handle_error do
           uploader = blank_uploader
           uploader.download!(url, header || {})


### PR DESCRIPTION
The return value changes from an Array to nil.
But it is usually ignored because it is in a setter method.