### PR TITLE
Add retry option to download from remote url

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,16 @@ failures automatically with attribute validation errors. If you aren't, or you
 disable CarrierWave's `validate_download` option, you'll need to handle those
 errors yourself.
 
+### Retry option for douwload from remote location
+If you want to retry the download from the Remote URL, enable the download_retry_count option, an error occurs during download, it will try to execute the specified number of times every 5 second.
+This option is effective when the remote destination is unstable.
+
+```rb
+CarrierWave.configure do |config|
+  config.download_retry_count = 3 # Default 0
+end
+```
+
 ## Providing a default URL
 
 In many cases, especially when working with images, it might be a good idea to

--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -44,6 +44,7 @@ module CarrierWave
         add_config :validate_download
         add_config :mount_on
         add_config :cache_only
+        add_config :download_retry_count
 
         # set default values
         reset_config
@@ -210,6 +211,7 @@ module CarrierWave
             config.base_path = CarrierWave.base_path
             config.enable_processing = true
             config.ensure_multipart_form = true
+            config.download_retry_count = 0
           end
         end
       end

--- a/spec/downloader/base_spec.rb
+++ b/spec/downloader/base_spec.rb
@@ -135,6 +135,27 @@ describe CarrierWave::Downloader::Base do
     end
   end
 
+  context 'with download_retry_count' do
+    before do
+      stub_request(:get, uri).to_return({ status: 503 }, { status: 200 })
+    end
+    let(:instance) { described_class.new(uploader) }
+    subject { instance.download uri }
+    context 'when download_retry_count == 0 ' do
+      before { uploader.download_retry_count = 0 }
+      it 'throws an exception' do
+        expect { subject }.to raise_error CarrierWave::DownloadError
+      end
+    end
+
+    context 'when download_retry_count > 0' do
+      before { uploader.download_retry_count = 1 }
+      it 'does not throw an exception' do
+        expect { subject }.not_to raise_error
+      end
+    end
+  end
+
   describe '#process_uri' do
     it "converts a URL with internationalized domain name to Punycode URI" do
       uri = "http://ドメイン名例.jp/#{CGI.escape(filename)}"


### PR DESCRIPTION
Our project downloads image from imgix by use `remote_image_url`, but imgix occasionally returns a 503 error and download failed.
So I want to support to retry option in carrierwave.
This option will also be useful for other CDNs or storage.

Source: https://aws.amazon.com/premiumsupport/knowledge-center/s3-resolve-503-slowdown-throttling/?nc1=h_ls