### PR TITLE
Allow uploaders to accept unless conditions

### DIFF
--- a/lib/carrierwave/uploader/processing.rb
+++ b/lib/carrierwave/uploader/processing.rb
@@ -18,7 +18,7 @@ module CarrierWave
         # Adds a processor callback which applies operations as a file is uploaded.
         # The argument may be the name of any method of the uploader, expressed as a symbol,
         # or a list of such methods, or a hash where the key is a method and the value is
-        # an array of arguments to call the method with
+        # an array of arguments to call the method with. Also accepts an :if or :unless condition
         #
         # === Parameters
         #
@@ -31,6 +31,7 @@ module CarrierWave
         #       process :sepiatone, :vignette
         #       process :scale => [200, 200]
         #       process :scale => [200, 200], :if => :image?
+        #       process :scale => [200, 200], :unless => :disallowed_image_type?
         #       process :sepiatone, :if => :image?
         #
         #       def sepiatone
@@ -49,6 +50,10 @@ module CarrierWave
         #         ...
         #       end
         #
+        #       def disallowed_image_type?
+        #         ...
+        #       end
+        #
         #     end
         #
         def process(*args)
@@ -57,12 +62,12 @@ module CarrierWave
             hash.merge!(arg)
           end
 
-          condition = new_processors.delete(:if)
+          condition_type = new_processors.keys.select { |key| [:if, :unless].include?(key) }[0]
+          condition = new_processors.delete(:if) || new_processors.delete(:unless)
           new_processors.each do |processor, processor_args|
-            self.processors += [[processor, processor_args, condition]]
+            self.processors += [[processor, processor_args, condition, condition_type]]
           end
         end
-
       end # ClassMethods
 
       ##
@@ -72,13 +77,19 @@ module CarrierWave
         return unless enable_processing
 
         with_callbacks(:process, new_file) do
-          self.class.processors.each do |method, args, condition|
-            if(condition)
+          self.class.processors.each do |method, args, condition, condition_type|
+            if(condition && condition_type == :if)
               if condition.respond_to?(:call)
                 next unless condition.call(self, :args => args, :method => method, :file => new_file)
               else
                 next unless self.send(condition, new_file)
               end
+            elsif(condition && condition_type == :unless)
+             if condition.respond_to?(:call)
+               next if condition.call(self, :args => args, :method => method, :file => new_file)
+             else
+               next if self.send(condition, new_file)
+             end
             end
             self.send(method, *args)
           end

--- a/spec/mount_multiple_spec.rb
+++ b/spec/mount_multiple_spec.rb
@@ -114,15 +114,15 @@ describe CarrierWave::Mount do
       end
 
       context "defined processors inheritance works" do
-        it { expect(uploader_1.processors).to eq([[:rotate, [], nil]]) }
+        it { expect(uploader_1.processors).to eq([[:rotate, [], nil, nil]]) }
 
-        it { expect(uploader_2.processors).to eq([[:rotate, [], nil], [:shrink, [], nil]]) }
+        it { expect(uploader_2.processors).to eq([[:rotate, [], nil, nil], [:shrink, [], nil, nil]]) }
 
-        it { expect(uploader_1.versions[:thumb].processors).to eq([[:compress, [], nil]]) }
+        it { expect(uploader_1.versions[:thumb].processors).to eq([[:compress, [], nil, nil]]) }
 
-        it { expect(uploader_2.versions[:thumb].processors).to eq([[:compress, [], nil]]) }
+        it { expect(uploader_2.versions[:thumb].processors).to eq([[:compress, [], nil, nil]]) }
 
-        it { expect(uploader_2.versions[:secret].processors).to eq([[:encrypt, [], nil]]) }
+        it { expect(uploader_2.versions[:secret].processors).to eq([[:encrypt, [], nil, nil]]) }
       end
     end
 

--- a/spec/mount_single_spec.rb
+++ b/spec/mount_single_spec.rb
@@ -84,11 +84,11 @@ describe CarrierWave::Mount do
       end
 
       it "should inherit defined processors properly" do
-        expect(@uploader1.processors).to eq([[:rotate, [], nil]])
-        expect(@uploader2.processors).to eq([[:rotate, [], nil], [:shrink, [], nil]])
-        expect(@uploader1.versions[:thumb].processors).to eq([[:compress, [], nil]])
-        expect(@uploader2.versions[:thumb].processors).to eq([[:compress, [], nil]])
-        expect(@uploader2.versions[:secret].processors).to eq([[:encrypt, [], nil]])
+        expect(@uploader1.processors).to eq([[:rotate, [], nil, nil]])
+        expect(@uploader2.processors).to eq([[:rotate, [], nil, nil], [:shrink, [], nil, nil]])
+        expect(@uploader1.versions[:thumb].processors).to eq([[:compress, [], nil, nil]])
+        expect(@uploader2.versions[:thumb].processors).to eq([[:compress, [], nil, nil]])
+        expect(@uploader2.versions[:secret].processors).to eq([[:encrypt, [], nil, nil]])
       end
     end
 

--- a/spec/uploader/processing_spec.rb
+++ b/spec/uploader/processing_spec.rb
@@ -50,40 +50,80 @@ describe CarrierWave::Uploader do
       uploader.process!
     end
 
-    it "calls the processor if the condition method returns true" do
-      uploader_class.process :resize => [200, 300], :if => :true?
-      uploader_class.process :fancy, :if => :true?
-      expect(uploader).to receive(:true?).with("test.jpg").twice.and_return(true)
-      expect(uploader).to receive(:resize).with(200, 300)
-      expect(uploader).to receive(:fancy)
-      uploader.process!("test.jpg")
-    end
+    context "when there is an 'if' condition" do
+      it "calls the processor if the condition method returns true" do
+        uploader_class.process :resize => [200, 300], :if => :true?
+        uploader_class.process :fancy, :if => :true?
+        expect(uploader).to receive(:true?).with("test.jpg").twice.and_return(true)
+        expect(uploader).to receive(:resize).with(200, 300)
+        expect(uploader).to receive(:fancy)
+        uploader.process!("test.jpg")
+      end
+       
+      it "doesn't call the processor if the condition method returns false" do
+        uploader_class.process :resize => [200, 300], :if => :false?
+        uploader_class.process :fancy, :if => :false?
+        expect(uploader).to receive(:false?).with("test.jpg").twice.and_return(false)
+        expect(uploader).not_to receive(:resize)
+        expect(uploader).not_to receive(:fancy)
+        uploader.process!("test.jpg")
+      end
+       
+      it "calls the processor if the condition block returns true" do
+        uploader_class.process :resize => [200, 300], :if => lambda{|record, args| record.true?(args[:file])}
+        uploader_class.process :fancy, :if => :true?
+        expect(uploader).to receive(:true?).with("test.jpg").twice.and_return(true)
+        expect(uploader).to receive(:resize).with(200, 300)
+        expect(uploader).to receive(:fancy)
+        uploader.process!("test.jpg")
+      end
 
-    it "doesn't call the processor if the condition method returns false" do
-      uploader_class.process :resize => [200, 300], :if => :false?
-      uploader_class.process :fancy, :if => :false?
-      expect(uploader).to receive(:false?).with("test.jpg").twice.and_return(false)
-      expect(uploader).not_to receive(:resize)
-      expect(uploader).not_to receive(:fancy)
-      uploader.process!("test.jpg")
+      it "doesn't call the processor if the condition block returns false" do
+        uploader_class.process :resize => [200, 300], :if => lambda{|record, args| record.false?(args[:file])}
+        uploader_class.process :fancy, :if => :false?
+        expect(uploader).to receive(:false?).with("test.jpg").twice.and_return(false)
+        expect(uploader).not_to receive(:resize)
+        expect(uploader).not_to receive(:fancy)
+        uploader.process!("test.jpg")
+      end
     end
+       
+    context "when there is an 'unless' condition" do
+      it "doesn't call the processor if the condition method returns true" do
+        uploader_class.process :resize => [200, 300], :unless => :true?
+        uploader_class.process :fancy, :unless => :true?
+        expect(uploader).to receive(:true?).with("test.jpg").twice.and_return(true)
+        expect(uploader).not_to receive(:resize).with(200, 300)
+        expect(uploader).not_to receive(:fancy)
+        uploader.process!("test.jpg")
+      end
 
-    it "calls the processor if the condition block returns true" do
-      uploader_class.process :resize => [200, 300], :if => lambda{|record, args| record.true?(args[:file])}
-      uploader_class.process :fancy, :if => :true?
-      expect(uploader).to receive(:true?).with("test.jpg").twice.and_return(true)
-      expect(uploader).to receive(:resize).with(200, 300)
-      expect(uploader).to receive(:fancy)
-      uploader.process!("test.jpg")
-    end
+      it "calls the processor if the condition method returns false" do
+        uploader_class.process :resize => [200, 300], :unless => :false?
+        uploader_class.process :fancy, :unless => :false?
+        expect(uploader).to receive(:false?).with("test.jpg").twice.and_return(false)
+        expect(uploader).to receive(:resize)
+        expect(uploader).to receive(:fancy)
+        uploader.process!("test.jpg")
+      end
 
-    it "doesn't call the processor if the condition block returns false" do
-      uploader_class.process :resize => [200, 300], :if => lambda{|record, args| record.false?(args[:file])}
-      uploader_class.process :fancy, :if => :false?
-      expect(uploader).to receive(:false?).with("test.jpg").twice.and_return(false)
-      expect(uploader).not_to receive(:resize)
-      expect(uploader).not_to receive(:fancy)
-      uploader.process!("test.jpg")
+      it "doesn't call the processor if the condition block returns true" do
+        uploader_class.process :resize => [200, 300], :unless => lambda{|record, args| record.true?(args[:file])}
+        uploader_class.process :fancy, :unless => :true?
+        expect(uploader).to receive(:true?).with("test.jpg").twice.and_return(true)
+        expect(uploader).not_to receive(:resize).with(200, 300)
+        expect(uploader).not_to receive(:fancy)
+        uploader.process!("test.jpg")
+      end
+
+      it "calls the processor if the condition block returns false" do
+        uploader_class.process :resize => [200, 300], :unless => lambda{|record, args| record.false?(args[:file])}
+        uploader_class.process :fancy, :unless => :false?
+        expect(uploader).to receive(:false?).with("test.jpg").twice.and_return(false)
+        expect(uploader).to receive(:resize)
+        expect(uploader).to receive(:fancy)
+        uploader.process!("test.jpg")
+      end
     end
 
     context "when using RMagick", :rmagick => true do


### PR DESCRIPTION
Allows uploaders to accept `unless` conditions in their processor callbacks, previously only `if` conditions were allowed