### PR TITLE
Add image dimension validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1013,6 +1013,11 @@ errors:
     processing_error: "Failed to manipulate, maybe it is not an image?"
     min_size_error: "File size should be greater than %{min_size}"
     max_size_error: "File size should be less than %{max_size}"
+    min_width_error: "Image width should be greater than %{min_width}px"
+    max_width_error: "Image width should be less than %{max_width}px"
+    min_height_error: "Image height should be greater than %{min_height}px"
+    max_height_error: "Image height should be less than %{max_height}px"
+    no_processing_module_error: You need to include one of CarrierWave::MiniMagick, CarrierWave::RMagick, or CarrierWave::Vips
 ```
 
 The [`carrierwave-i18n`](https://github.com/carrierwaveuploader/carrierwave-i18n)

--- a/lib/carrierwave/locale/en.yml
+++ b/lib/carrierwave/locale/en.yml
@@ -11,3 +11,8 @@ en:
       processing_error: "Failed to manipulate, maybe it is not an image?"
       min_size_error: "File size should be greater than %{min_size}"
       max_size_error: "File size should be less than %{max_size}"
+      min_width_error: "Image width should be greater than %{min_width}px"
+      max_width_error: "Image width should be less than %{max_width}px"
+      min_height_error: "Image height should be greater than %{min_height}px"
+      max_height_error: "Image height should be less than %{max_height}px"
+      no_processing_module_error: You need to include one of CarrierWave::MiniMagick, CarrierWave::RMagick, or CarrierWave::Vips

--- a/lib/carrierwave/uploader.rb
+++ b/lib/carrierwave/uploader.rb
@@ -12,6 +12,7 @@ require "carrierwave/uploader/extension_blacklist"
 require "carrierwave/uploader/content_type_whitelist"
 require "carrierwave/uploader/content_type_blacklist"
 require "carrierwave/uploader/file_size"
+require "carrierwave/uploader/dimension"
 require "carrierwave/uploader/processing"
 require "carrierwave/uploader/versions"
 require "carrierwave/uploader/default_url"
@@ -57,6 +58,7 @@ module CarrierWave
       include CarrierWave::Uploader::ContentTypeWhitelist
       include CarrierWave::Uploader::ContentTypeBlacklist
       include CarrierWave::Uploader::FileSize
+      include CarrierWave::Uploader::Dimension
       include CarrierWave::Uploader::Processing
       include CarrierWave::Uploader::Versions
       include CarrierWave::Uploader::DefaultUrl

--- a/lib/carrierwave/uploader/dimension.rb
+++ b/lib/carrierwave/uploader/dimension.rb
@@ -1,0 +1,56 @@
+require 'active_support'
+
+module CarrierWave
+  module Uploader
+    module Dimension
+      extend ActiveSupport::Concern
+
+      included do
+        before :cache, :check_dimensions!
+      end
+
+      ##
+      # Override this method in your uploader to provide a tuple of
+      # width Range and height Range which are allowed to be uploaded.
+      # === Returns
+      #
+      # [NilClass, [Range, Range]]
+      # width range and height range which are permitted to be uploaded
+      #
+      # === Examples
+      #
+      #     def dimension_ranges
+      #       [1000..2000, 1000..]
+      #     end
+      #
+      def dimension_ranges; end
+
+      private
+
+      def check_dimensions!(new_file)
+        # NOTE: Skip the check for resized images
+        return if version_name.present?
+
+        expected_dimension_ranges = dimension_ranges
+        return unless expected_dimension_ranges.try(:all?) { |v| v.is_a?(::Range) }
+
+        unless respond_to?(:width) || respond_to?(:height)
+          raise CarrierWave::IntegrityError, I18n.translate(:"errors.messages.no_processing_module_error")
+        end
+
+        expected_width_range = expected_dimension_ranges[0]
+        expected_height_range = expected_dimension_ranges[1]
+        if expected_width_range.begin && width < expected_width_range.begin
+          raise CarrierWave::IntegrityError, I18n.translate(:"errors.messages.min_width_error", :min_width => ActiveSupport::NumberHelper.number_to_delimited(expected_width_range.begin))
+        elsif expected_width_range.end && width > expected_width_range.end
+          raise CarrierWave::IntegrityError, I18n.translate(:"errors.messages.max_width_error", :max_width => ActiveSupport::NumberHelper.number_to_delimited(expected_width_range.end))
+        elsif expected_height_range.begin && height < expected_height_range.begin
+          raise CarrierWave::IntegrityError, I18n.translate(:"errors.messages.min_height_error", :min_height => ActiveSupport::NumberHelper.number_to_delimited(expected_height_range.begin))
+        elsif expected_height_range.end && height > expected_height_range.end
+          raise CarrierWave::IntegrityError, I18n.translate(:"errors.messages.max_height_error", :max_height => ActiveSupport::NumberHelper.number_to_delimited(expected_height_range.end))
+        end
+      end
+
+    end # Dimension
+  end # Uploader
+end # CarrierWave

--- a/spec/uploader/callback_spec.rb
+++ b/spec/uploader/callback_spec.rb
@@ -9,6 +9,7 @@ describe CarrierWave::Uploader do
         :check_content_type_whitelist!,
         :check_content_type_blacklist!,
         :check_size!,
+        :check_dimensions!,
         :process!
       ]
     end

--- a/spec/uploader/dimension_spec.rb
+++ b/spec/uploader/dimension_spec.rb
@@ -1,0 +1,280 @@
+require 'spec_helper'
+
+describe CarrierWave::Uploader do
+  let(:uploader_class) { Class.new(CarrierWave::Uploader::Base) }
+  let(:uploader) { uploader_class.new }
+  let(:cache_id) { '20071201-1234-1234-2255' }
+  let(:test_file) { File.open(file_path('landscape.jpg')) }
+
+  after { FileUtils.rm_rf(public_path) }
+
+  describe '#cache!' do
+    subject { lambda { uploader.cache!(test_file) } }
+
+    before { allow(CarrierWave).to receive(:generate_cache_id).and_return(cache_id) }
+
+    describe "image width range and height range" do
+      before { allow(uploader).to receive(:dimension_ranges).and_return(ranges) }
+
+      context 'when no processing module' do
+        let(:ranges) { [1..1000, 1..1000] }
+
+        it "raises an integrity error" do
+          is_expected.to raise_error(CarrierWave::IntegrityError, 'You need to include one of CarrierWave::MiniMagick, CarrierWave::RMagick, or CarrierWave::Vips')
+        end
+      end
+
+      context 'when use MiniMagick' do
+        before { uploader_class.include(CarrierWave::MiniMagick) }
+
+        context "when not specified" do
+          let(:ranges) { nil }
+
+          it "doesn't raise an integrity error" do
+            is_expected.not_to raise_error
+          end
+        end
+
+        context "when below the width minimum" do
+          let(:ranges) { [641..1000, 1..1000] }
+
+          it "raises an integrity error" do
+            is_expected.to raise_error(CarrierWave::IntegrityError, 'Image width should be greater than 641px')
+          end
+        end
+
+        context "when below the width minimum (endless) " do
+          let(:ranges) { [641.., 1..] }
+
+          it "raises an integrity error" do
+            is_expected.to raise_error(CarrierWave::IntegrityError, 'Image width should be greater than 641px')
+          end
+        end
+
+        context "when above the width maximum" do
+          let(:ranges) { [1..639, 1..1000] }
+
+          it "raises an integrity error" do
+            is_expected.to raise_error(CarrierWave::IntegrityError, 'Image width should be less than 639px')
+          end
+        end
+
+        context "when above the width maximum (beginless)" do
+          let(:ranges) { [..639, ..1000] }
+
+          it "raises an integrity error" do
+            is_expected.to raise_error(CarrierWave::IntegrityError, 'Image width should be less than 639px')
+          end
+        end
+
+        context "when below the height minimum" do
+          let(:ranges) { [1..1000, 481..1000] }
+
+          it "raises an integrity error" do
+            is_expected.to raise_error(CarrierWave::IntegrityError, 'Image height should be greater than 481px')
+          end
+        end
+
+        context "when below the height minimum (endless) " do
+          let(:ranges) { [1.., 481..] }
+
+          it "raises an integrity error" do
+            is_expected.to raise_error(CarrierWave::IntegrityError, 'Image height should be greater than 481px')
+          end
+        end
+
+        context "when above the height maximum" do
+          let(:ranges) { [1..1000, 1..479] }
+
+          it "raises an integrity error" do
+            is_expected.to raise_error(CarrierWave::IntegrityError, 'Image height should be less than 479px')
+          end
+        end
+
+        context "when above the height maximum (beginless)" do
+          let(:ranges) { [..1000, ..479] }
+
+          it "raises an integrity error" do
+            is_expected.to raise_error(CarrierWave::IntegrityError, 'Image height should be less than 479px')
+          end
+        end
+
+        context "when inside the range" do
+          let(:ranges) { [1..1000, 1..1000] }
+
+          it "doesn't raise an integrity error" do
+            is_expected.not_to raise_error
+          end
+        end
+      end
+
+      context 'when use RMagick' do
+        before { uploader_class.include(CarrierWave::RMagick) }
+
+        context "when not specified" do
+          let(:ranges) { nil }
+
+          it "doesn't raise an integrity error" do
+            is_expected.not_to raise_error
+          end
+        end
+
+        context "when below the width minimum" do
+          let(:ranges) { [641..1000, 1..1000] }
+
+          it "raises an integrity error" do
+            is_expected.to raise_error(CarrierWave::IntegrityError, 'Image width should be greater than 641px')
+          end
+        end
+
+        context "when below the width minimum (endless) " do
+          let(:ranges) { [641.., 1..] }
+
+          it "raises an integrity error" do
+            is_expected.to raise_error(CarrierWave::IntegrityError, 'Image width should be greater than 641px')
+          end
+        end
+
+        context "when above the width maximum" do
+          let(:ranges) { [1..639, 1..1000] }
+
+          it "raises an integrity error" do
+            is_expected.to raise_error(CarrierWave::IntegrityError, 'Image width should be less than 639px')
+          end
+        end
+
+        context "when above the width maximum (beginless)" do
+          let(:ranges) { [..639, ..1000] }
+
+          it "raises an integrity error" do
+            is_expected.to raise_error(CarrierWave::IntegrityError, 'Image width should be less than 639px')
+          end
+        end
+
+        context "when below the height minimum" do
+          let(:ranges) { [1..1000, 481..1000] }
+
+          it "raises an integrity error" do
+            is_expected.to raise_error(CarrierWave::IntegrityError, 'Image height should be greater than 481px')
+          end
+        end
+
+        context "when below the height minimum (endless) " do
+          let(:ranges) { [1.., 481..] }
+
+          it "raises an integrity error" do
+            is_expected.to raise_error(CarrierWave::IntegrityError, 'Image height should be greater than 481px')
+          end
+        end
+
+        context "when above the height maximum" do
+          let(:ranges) { [1..1000, 1..479] }
+
+          it "raises an integrity error" do
+            is_expected.to raise_error(CarrierWave::IntegrityError, 'Image height should be less than 479px')
+          end
+        end
+
+        context "when above the height maximum (beginless)" do
+          let(:ranges) { [..1000, ..479] }
+
+          it "raises an integrity error" do
+            is_expected.to raise_error(CarrierWave::IntegrityError, 'Image height should be less than 479px')
+          end
+        end
+
+        context "when inside the range" do
+          let(:ranges) { [1..1000, 1..1000] }
+
+          it "doesn't raise an integrity error" do
+            is_expected.not_to raise_error
+          end
+        end
+      end
+
+      context 'when use Vips' do
+        before { uploader_class.include(CarrierWave::Vips) }
+
+        context "when not specified" do
+          let(:ranges) { nil }
+
+          it "doesn't raise an integrity error" do
+            is_expected.not_to raise_error
+          end
+        end
+
+        context "when below the width minimum" do
+          let(:ranges) { [641..1000, 1..1000] }
+
+          it "raises an integrity error" do
+            is_expected.to raise_error(CarrierWave::IntegrityError, 'Image width should be greater than 641px')
+          end
+        end
+
+        context "when below the width minimum (endless) " do
+          let(:ranges) { [641.., 1..] }
+
+          it "raises an integrity error" do
+            is_expected.to raise_error(CarrierWave::IntegrityError, 'Image width should be greater than 641px')
+          end
+        end
+
+        context "when above the width maximum" do
+          let(:ranges) { [1..639, 1..1000] }
+
+          it "raises an integrity error" do
+            is_expected.to raise_error(CarrierWave::IntegrityError, 'Image width should be less than 639px')
+          end
+        end
+
+        context "when above the width maximum (beginless)" do
+          let(:ranges) { [..639, ..1000] }
+
+          it "raises an integrity error" do
+            is_expected.to raise_error(CarrierWave::IntegrityError, 'Image width should be less than 639px')
+          end
+        end
+
+        context "when below the height minimum" do
+          let(:ranges) { [1..1000, 481..1000] }
+
+          it "raises an integrity error" do
+            is_expected.to raise_error(CarrierWave::IntegrityError, 'Image height should be greater than 481px')
+          end
+        end
+
+        context "when below the height minimum (endless) " do
+          let(:ranges) { [1.., 481..] }
+
+          it "raises an integrity error" do
+            is_expected.to raise_error(CarrierWave::IntegrityError, 'Image height should be greater than 481px')
+          end
+        end
+
+        context "when above the height maximum" do
+          let(:ranges) { [1..1000, 1..479] }
+
+          it "raises an integrity error" do
+            is_expected.to raise_error(CarrierWave::IntegrityError, 'Image height should be less than 479px')
+          end
+        end
+
+        context "when above the height maximum (beginless)" do
+          let(:ranges) { [..1000, ..479] }
+
+          it "raises an integrity error" do
+            is_expected.to raise_error(CarrierWave::IntegrityError, 'Image height should be less than 479px')
+          end
+        end
+
+        context "when inside the range" do
+          let(:ranges) { [1..1000, 1..1000] }
+
+          it "doesn't raise an integrity error" do
+            is_expected.not_to raise_error
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# About this PR

Added image dimension validation.
FYI: [How to: Validate image file size · carrierwaveuploader/carrierwave Wiki](https://github.com/carrierwaveuploader/carrierwave/wiki/How-to:-Validate-image-file-size)

# Usage

```rb
class PhotoUploader < CarrierWave::Uploader::Base
  # MiniMagick, RMagic, or Vips
  include CarrierWave::MiniMagick

  # width >= 1000 and height >= 1000
  def dimension_ranges
    [(1000..), 1000..]
  end
end
```