### PR TITLE
Require manually features and frameworks.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,17 +8,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.5, 2.6, 2.7, 3.0, jruby ]
+        ruby: [ 2.5, 2.6, 2.7, '3.0', jruby ]
         gemfile: [ gemfiles/rails-6-1.gemfile ]
         experimental: [ false ]
         include:
-          - ruby: 3.0
+          - ruby: '3.0'
             gemfile: gemfiles/rails-6-0.gemfile
             experimental: false
-          - ruby: 3.0
+          - ruby: '3.0'
             gemfile: gemfiles/rails-7-0.gemfile
             experimental: false
-          - ruby: 3.0
+          - ruby: '3.0'
             gemfile: gemfiles/rails-master.gemfile
             experimental: false
           - ruby: ruby-head

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,7 +26,7 @@ Style/PredicateName:
   - is_
   - has_
   - have_
-  NamePrefixBlacklist:
+  ForbiddenPrefixes:
   - is_
   Exclude:
   - spec/**/*
@@ -109,12 +109,12 @@ Lint/EachWithObjectArgument:
   Description: Check for immutable argument given to each_with_object.
   Enabled: true
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Description: Don't suppress exception.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions
   Enabled: false
 
-Lint/LiteralInCondition:
+Lint/LiteralAsCondition:
   Description: Checks of literals used in conditions.
   Enabled: false
 
@@ -231,7 +231,7 @@ Style/IfUnlessModifier:
   Description: Favor modifier if/unless usage when you have a single-line body.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
   Enabled: false
-  MaxLineLength: 80
+  Layout/LineLength: Max
 
 Style/OptionHash:
   Description: Don't use option hashes when you can use keyword arguments.
@@ -252,11 +252,9 @@ Style/PercentLiteralDelimiters:
     "%W": "()"
     "%x": "()"
 
-Style/TrailingComma:
-  Description: Checks for trailing comma in parameter lists and literals.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
+Style/TrailingCommaInArguments:
   Enabled: false
-  EnforcedStyleForMultiline: no_comma
-  SupportedStyles:
-  - comma
-  - no_comma
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+Style/TrailingCommaInHashLiteral:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ## Removed
 * Remove support for Merb (@seuros [#2566](https://github.com/carrierwaveuploader/carrierwave/pull/2566))
+* Paperclip compatibility need to be required manually
+* Test matchers need to be required manually
+* Framework integration needs to be required manually
+* Drop support for sinatra before 1.3.0
 
 ## 2.2.2 - 2021-05-28
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ It works well with Rack based web applications, such as Ruby on Rails.
 
 [![Build Status](https://github.com/carrierwaveuploader/carrierwave/workflows/Test/badge.svg)](https://github.com/carrierwaveuploader/carrierwave/actions)
 [![Code Climate](https://codeclimate.com/github/carrierwaveuploader/carrierwave.svg)](https://codeclimate.com/github/carrierwaveuploader/carrierwave)
-[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=carrierwave&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=carrierwave&package-manager=bundler&version-scheme=semver)
-
+[![Gem Version](https://badge.fury.io/rb/carrierwave.svg)](http://badge.fury.io/rb/carrierwave)
 
 ## Information
 
@@ -35,8 +34,8 @@ gem 'carrierwave', '~> 2.0'
 
 Finally, restart the server to apply the changes.
 
-As of version 2.0, CarrierWave requires Rails 5.0 or higher and Ruby 2.2
-or higher. If you're on Rails 4, you should use 1.x.
+As of version 3.0, CarrierWave requires ActiveSupport 6.0 or higher and Ruby 2.5 or higher.
+if you are using a lower version you can use version 2 or 1.
 
 ## Getting Started
 
@@ -981,6 +980,8 @@ end
 If you are using Paperclip, you can use the provided compatibility module:
 
 ```ruby
+require 'carrierwave/compatibility/paperclip'
+
 class AvatarUploader < CarrierWave::Uploader::Base
   include CarrierWave::Compatibility::Paperclip
 end

--- a/gemfiles/rails-7-0.gemfile
+++ b/gemfiles/rails-7-0.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rails", "~> 7.0.0.alpha2"
+gem "rails", "~> 7.0.0"
 gem "activemodel-serializers-xml"
 gem 'sqlite3', platforms: :ruby
 gem "activerecord-jdbcsqlite3-adapter", platform: [:jruby, :truffleruby]

--- a/gemfiles/rails-master.gemfile
+++ b/gemfiles/rails-master.gemfile
@@ -1,11 +1,7 @@
 source "https://rubygems.org"
 
 gem "rails", github: "rails/rails", branch: "main"
-gem "rack", github: "rack/rack", branch: "master"
 gem "arel", github: "rails/arel", branch: "master"
-gem "sprockets", github: "rails/sprockets", branch: "master"
-gem "sprockets-rails", github: "rails/sprockets-rails", branch: "master"
-gem "sass-rails", github: "rails/sass-rails"
 gem "activemodel-serializers-xml"
 gem 'sqlite3', platforms: :ruby
 gem "activerecord-jdbcsqlite3-adapter", platform: [:jruby, :truffleruby]

--- a/lib/carrierwave.rb
+++ b/lib/carrierwave.rb
@@ -1,11 +1,12 @@
-require 'fileutils'
-require 'active_support/core_ext/object/blank'
-require 'active_support/core_ext/object/try'
-require 'active_support/core_ext/class/attribute'
-require 'active_support/concern'
+# frozen_string_literal: true
+
+require "fileutils"
+require "active_support/core_ext/object/blank"
+require "active_support/core_ext/object/try"
+require "active_support/core_ext/class/attribute"
+require "active_support/concern"
 
 module CarrierWave
-
   class << self
     attr_accessor :root, :base_path
     attr_writer :tmp_path
@@ -14,73 +15,12 @@ module CarrierWave
       CarrierWave::Uploader::Base.configure(&block)
     end
 
-    def clean_cached_files!(seconds=60*60*24)
+    def clean_cached_files!(seconds = 60 * 60 * 24)
       CarrierWave::Uploader::Base.clean_cached_files!(seconds)
     end
 
     def tmp_path
-      @tmp_path ||= File.expand_path(File.join('..', 'tmp'), root)
-    end
-  end
-
-end
-
-if defined?(Jets)
-
-  module CarrierWave
-    class Turbine < Jets::Turbine
-      initializer "carrierwave.setup_paths" do |app|
-        CarrierWave.root = Jets.root.to_s
-        CarrierWave.tmp_path = "/tmp/carrierwave"
-        CarrierWave.configure do |config|
-          config.cache_dir = "/tmp/carrierwave/uploads/tmp"
-        end
-      end
-
-      initializer "carrierwave.active_record" do
-        ActiveSupport.on_load :active_record do
-          require 'carrierwave/orm/activerecord'
-        end
-      end
-    end
-  end
-
-elsif defined?(Rails)
-
-  module CarrierWave
-    class Railtie < Rails::Railtie
-      initializer "carrierwave.setup_paths" do |app|
-        CarrierWave.root = Rails.root.join(Rails.public_path).to_s
-        CarrierWave.base_path = ENV['RAILS_RELATIVE_URL_ROOT']
-        available_locales = Array(app.config.i18n.available_locales || [])
-        if available_locales.blank? || available_locales.include?(:en)
-          I18n.load_path.prepend(File.join(File.dirname(__FILE__), 'carrierwave', 'locale', "en.yml"))
-        end
-      end
-
-      initializer "carrierwave.active_record" do
-        ActiveSupport.on_load :active_record do
-          require 'carrierwave/orm/activerecord'
-        end
-      end
-
-      config.before_eager_load do
-        CarrierWave::Storage::Fog.eager_load
-      end
-    end
-  end
-
-elsif defined?(Sinatra)
-  if defined?(Padrino) && defined?(PADRINO_ROOT)
-    CarrierWave.root = File.join(PADRINO_ROOT, "public")
-  else
-
-    CarrierWave.root = if Sinatra::Application.respond_to?(:public_folder)
-      # Sinatra >= 1.3
-      Sinatra::Application.public_folder
-    else
-      # Sinatra < 1.3
-      Sinatra::Application.public
+      @tmp_path ||= File.expand_path(File.join("..", "tmp"), root)
     end
   end
 end
@@ -94,5 +34,5 @@ require "carrierwave/processing"
 require "carrierwave/version"
 require "carrierwave/storage"
 require "carrierwave/uploader"
-require "carrierwave/compatibility/paperclip"
-require "carrierwave/test/matchers"
+
+require "carrierwave/frameworks/railtie" if defined?(Rails)

--- a/lib/carrierwave/frameworks/jets.rb
+++ b/lib/carrierwave/frameworks/jets.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+gem "jets", ">= 3.0.0"
+
+module CarrierWave
+  class Turbine < Jets::Turbine
+    initializer "carrierwave.setup_paths" do |_app|
+      CarrierWave.root = Jets.root.to_s
+      CarrierWave.tmp_path = "/tmp/carrierwave"
+      CarrierWave.configure do |config|
+        config.cache_dir = "/tmp/carrierwave/uploads/tmp"
+      end
+    end
+
+    initializer "carrierwave.active_record" do
+      ActiveSupport.on_load :active_record do
+        require "carrierwave/orm/activerecord"
+      end
+    end
+  end
+end

--- a/lib/carrierwave/frameworks/padrino.rb
+++ b/lib/carrierwave/frameworks/padrino.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+gem "padrino-core", "~> 0.10.5"
+CarrierWave.root = File.join(PADRINO_ROOT, "public")

--- a/lib/carrierwave/frameworks/railtie.rb
+++ b/lib/carrierwave/frameworks/railtie.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails/railtie"
+
+module CarrierWave
+  class Railtie < Rails::Railtie
+    initializer "carrierwave.setup_paths" do |app|
+      CarrierWave.root = Rails.root.join(Rails.public_path).to_s
+      CarrierWave.base_path = ENV["RAILS_RELATIVE_URL_ROOT"]
+      available_locales = Array(app.config.i18n.available_locales || [])
+      if available_locales.blank? || available_locales.include?(:en)
+        I18n.load_path.prepend(File.join(File.dirname(__FILE__), "..", "locale", "en.yml"))
+      end
+    end
+
+    initializer "carrierwave.active_record" do
+      ActiveSupport.on_load :active_record do
+        require "carrierwave/orm/activerecord"
+      end
+    end
+
+    config.before_eager_load do
+      CarrierWave::Storage::Fog.eager_load
+    end
+  end
+end

--- a/lib/carrierwave/frameworks/sinatra.rb
+++ b/lib/carrierwave/frameworks/sinatra.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+gem "sinatra", ">= 1.3.0"
+
+CarrierWave.root = Sinatra::Application.public_folder

--- a/spec/compatibility/paperclip_spec.rb
+++ b/spec/compatibility/paperclip_spec.rb
@@ -1,5 +1,8 @@
-require 'spec_helper'
-require 'carrierwave/orm/activerecord'
+# frozen_string_literal: true
+
+require "spec_helper"
+require "carrierwave/orm/activerecord"
+require "carrierwave/compatibility/paperclip"
 
 module Rails; end unless defined?(Rails)
 
@@ -13,21 +16,21 @@ describe CarrierWave::Compatibility::Paperclip do
     end
   end
 
-  let(:model) { double('model') }
+  let(:model) { double("model") }
 
   let(:uploader) { uploader_class.new(model, :monkey) }
 
   before do
-    allow(Rails).to receive(:root).and_return('/rails/root')
-    allow(Rails).to receive(:env).and_return('test')
+    allow(Rails).to receive(:root).and_return("/rails/root")
+    allow(Rails).to receive(:env).and_return("test")
     allow(model).to receive(:id).and_return(23)
-    allow(model).to receive(:ook).and_return('eek')
-    allow(model).to receive(:money).and_return('monkey.png')
+    allow(model).to receive(:ook).and_return("eek")
+    allow(model).to receive(:money).and_return("monkey.png")
   end
 
   after { FileUtils.rm_rf(public_path) }
 
-  describe '#store_path' do
+  describe "#store_path" do
     subject { uploader.store_path("monkey.png") }
 
     it "mimics paperclip default" do
@@ -36,7 +39,7 @@ describe CarrierWave::Compatibility::Paperclip do
 
     it "interpolates the root path" do
       allow(uploader).to receive(:paperclip_path).and_return(":rails_root/foo/bar")
-      is_expected.to eq(Rails.root + "/foo/bar")
+      is_expected.to eq("#{Rails.root}/foo/bar")
     end
 
     it "interpolates the attachment" do
@@ -65,30 +68,30 @@ describe CarrierWave::Compatibility::Paperclip do
     end
   end
 
-  describe '.interpolate' do
+  describe ".interpolate" do
     subject { uploader.store_path("monkey.png") }
 
     before do
-      uploader_class.interpolate :ook do |custom, style|
+      uploader_class.interpolate :ook do |custom, _style|
         custom.model.ook
       end
 
-      uploader_class.interpolate :aak do |model, style|
+      uploader_class.interpolate :aak do |_model, style|
         style
       end
     end
 
-    it 'allows you to add custom interpolations' do
+    it "allows you to add custom interpolations" do
       allow(uploader).to receive(:paperclip_path).and_return("/foo/:id/:ook")
-      is_expected.to eq('/foo/23/eek')
+      is_expected.to eq("/foo/23/eek")
     end
 
-    it 'mimics paperclips arguments' do
+    it "mimics paperclips arguments" do
       allow(uploader).to receive(:paperclip_path).and_return("/foo/:aak")
-      is_expected.to eq('/foo/original')
+      is_expected.to eq("/foo/original")
     end
 
-    context 'when multiple uploaders include the compatibility module' do
+    context "when multiple uploaders include the compatibility module" do
       let(:uploader) { uploader_class_other.new(model, :monkey) }
       let(:uploader_class_other) do
         Class.new(CarrierWave::Uploader::Base) do
@@ -102,17 +105,17 @@ describe CarrierWave::Compatibility::Paperclip do
       before { allow(uploader).to receive(:paperclip_path).and_return("/foo/:id/:ook") }
 
       it "doesn't share custom interpolations" do
-        is_expected.to eq('/foo/23/:ook')
+        is_expected.to eq("/foo/23/:ook")
       end
     end
 
-    context 'when there are multiple versions' do
+    context "when there are multiple versions" do
       let(:complex_uploader_class) do
         Class.new(CarrierWave::Uploader::Base) do
           include CarrierWave::Compatibility::Paperclip
 
-          interpolate :ook do |model, style|
-            'eek'
+          interpolate :ook do |_model, _style|
+            "eek"
           end
 
           version :thumb
@@ -125,11 +128,11 @@ describe CarrierWave::Compatibility::Paperclip do
       end
 
       let(:uploader) { complex_uploader_class.new(model, :monkey) }
-      let!(:file) { File.open(file_path('test.jpg')) }
+      let!(:file) { File.open(file_path("test.jpg")) }
 
       before { uploader.store!(file) }
 
-      it 'interpolates for all versions correctly' do
+      it "interpolates for all versions correctly" do
         expect(uploader.thumb.path).to eq("#{public_path}/foo/eek/23/thumb")
         expect(uploader.list.path).to eq("#{public_path}/foo/eek/23/list")
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,12 +14,12 @@ require 'logger'
 require 'csv'
 
 require 'carrierwave'
+require 'carrierwave/test/matchers'
 require 'timecop'
 require 'open-uri'
 require "webmock/rspec"
 require 'mini_magick'
 require "vips"
-require 'active_support/core_ext'
 require 'rspec/retry'
 
 I18n.enforce_available_locales = false


### PR DESCRIPTION
* Paperclip compatibility need to be required manually
   No need to have paperclip compatibility for all the apps
* Test matchers need to be required manually when needed in test/spec_helper.rb
   This don't need to be defined in runtime
* Framework integration needs to be required manually
  I created a Jets namespace (not related to the gem) and it started to break.
* Drop support for sinatra before 1.3.0