### PR TITLE
backport ruby 2.7+ deprecations to 0.11.x

### DIFF
--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -291,7 +291,7 @@ module CarrierWave
     def mkdir!(path, directory_permissions)
       options = {}
       options[:mode] = directory_permissions if directory_permissions
-      FileUtils.mkdir_p(File.dirname(path), options) unless File.exists?(File.dirname(path))
+      FileUtils.mkdir_p(File.dirname(path), **options) unless File.exists?(File.dirname(path))
     end
 
     def chmod!(path, permissions)

--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -337,7 +337,7 @@ module CarrierWave
         #
         def filename(options = {})
           if file_url = url(options)
-            URI.decode(file_url).gsub(/.*\/(.*?$)/, '\1').split('?').first
+            URI::DEFAULT_PARSER.unescape(file_url).gsub(/.*\/(.*?$)/, '\1').split('?').first
           end
         end
 

--- a/lib/carrierwave/uploader/download.rb
+++ b/lib/carrierwave/uploader/download.rb
@@ -37,7 +37,7 @@ module CarrierWave
 
         def file
           if @file.blank?
-            @file = Kernel.open(@uri.to_s)
+            @file = URI.open(@uri.to_s)
             @file = @file.is_a?(String) ? StringIO.new(@file) : @file
           end
           @file

--- a/lib/carrierwave/uploader/download.rb
+++ b/lib/carrierwave/uploader/download.rb
@@ -84,8 +84,8 @@ module CarrierWave
       rescue URI::InvalidURIError
         uri_parts = uri.split('?')
         # regexp from Ruby's URI::Parser#regexp[:UNSAFE], with [] specifically removed
-        encoded_uri = URI.encode(uri_parts.shift, /[^\-_.!~*'()a-zA-Z\d;\/?:@&=+$,]/)
-        encoded_uri << '?' << URI.encode(uri_parts.join('?')) if uri_parts.any?
+        encoded_uri = URI::DEFAULT_PARSER.escape(uri_parts.shift, /[^\-_.!~*'()a-zA-Z\d;\/?:@&=+$,]/)
+        encoded_uri << '?' << URI::DEFAULT_PARSER.escape(uri_parts.join('?')) if uri_parts.any?
         URI.parse(encoded_uri) rescue raise CarrierWave::DownloadError, "couldn't parse URL"
       end
 

--- a/lib/carrierwave/version.rb
+++ b/lib/carrierwave/version.rb
@@ -1,3 +1,3 @@
 module CarrierWave
-  VERSION = "0.11.3"
+  VERSION = "0.11.2"
 end

--- a/lib/carrierwave/version.rb
+++ b/lib/carrierwave/version.rb
@@ -1,3 +1,3 @@
 module CarrierWave
-  VERSION = "0.11.2"
+  VERSION = "0.11.3"
 end


### PR DESCRIPTION
👋 Dear maintainers,

There is currently a pretty complicated legacy project that I'm working on, however, in the process of ruby upgrade, it's fairly difficult to upgrade from 0.11.x to 1.x due to sheer amount of breaking changes from [CHANGELOG.md](https://github.com/carrierwaveuploader/carrierwave/blob/master/CHANGELOG.md#100beta---2016-09-08). 
Ideally, a more organized migration guide from 0.11.x to 1.x would be awesome.

I have looked into v2 fix https://github.com/carrierwaveuploader/carrierwave/commit/9a37fc9e7ce2937c66d5419ce1943ed114385beb
I'm not sure this change relates to any deprecation and whether it should be backport as well? 🤷 
`remove.present? && (remove == true || remove !~ /\A0|false$\z/)`

Would it be possible to accept this patch similar to https://github.com/carrierwaveuploader/carrierwave/pull/2462 and have a version cut for it?

Changes:
- Remove automatic keyword arguments conversion
- Fix deprecation warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
  * `Kernel.open` -> `URI.open`
- Fix deprecation warning: URI.escape is obsolete
  * `URI.encode` -> `URI::DEFAULT_PARSER.escape`
- Fix deprecation warning: URI.encode is obsolete
  * `URI.decode` -> `URI::DEFAULT_PARSER.unescape`