### PR TITLE
Remove invalid byte sequences from the sanitized filename

### DIFF
--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -291,6 +291,7 @@ module CarrierWave
 
     # Sanitize the filename, to prevent hacking
     def sanitize(name)
+      name = name.scrub
       name = name.tr("\\", "/") # work-around for IE
       name = File.basename(name)
       name = name.gsub(sanitize_regexp,"_")

--- a/spec/sanitized_file_spec.rb
+++ b/spec/sanitized_file_spec.rb
@@ -151,6 +151,11 @@ describe CarrierWave::SanitizedFile do
       expect(sanitized_file).to receive(:original_filename).at_least(:once).and_return("ТестоВый Ёжик.jpg")
       expect(sanitized_file.filename).to eq("ТестоВый_Ёжик.jpg")
     end
+
+    it "should remove invalid byte sequences from the filename" do
+      expect(sanitized_file).to receive(:original_filename).at_least(:once).and_return("test\xDD.jpg")
+      expect(sanitized_file.filename).to eq("test_.jpg")
+    end
   end
 
   describe "#filename with an overridden sanitize_regexp" do


### PR DESCRIPTION
When uploading a file whose filename contains a sequence like `%dd` (e.g. `test%dd.jpg`) it gets treated as a hex-encoded character.

The encoding happens [here inside ActionDispatch::HTTP::UploadedFile](https://github.com/rails/rails/blob/89471b2d7d3e6df631b1c236573c6674ac7f2502/actionpack/lib/action_dispatch/http/upload.rb#L34-L38).  If the hex-encoded character is invalid, Rails calls `@original_filename.force_encoding(Encoding::UTF_8)` and now we have an invalid string that gets passed down as the `original_filename` all the way to Carrierwave.

This PR calls [`String#scrub`](https://ruby-doc.org/core-2.7.2/String.html#method-i-scrub) to strip out any invalid bytes so we can then continue with the normal sanitization logic.
