### PR TITLE
suppress some rspec deprecation warning

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,8 +6,6 @@ require 'rspec'
 require 'carrierwave'
 require "webmock/cucumber"
 
-alias :running :lambda
-
 def file_path( *paths )
   File.expand_path(File.join('..', *paths), File.dirname(__FILE__))
 end

--- a/spec/mount_multiple_spec.rb
+++ b/spec/mount_multiple_spec.rb
@@ -973,7 +973,7 @@ describe CarrierWave::Mount do
     end
 
     context "when a cached image fails an integrity check" do
-      it { expect(running { instance.images = [test_file_stub] }).to raise_error(CarrierWave::IntegrityError) }
+      it { expect { instance.images = [test_file_stub] }.to raise_error(CarrierWave::IntegrityError) }
     end
 
     context "when a downloaded image fails an integity check" do
@@ -981,7 +981,7 @@ describe CarrierWave::Mount do
         stub_request(:get, "http://www.example.com/#{test_file_name}").to_return(body: test_file_stub)
       end
 
-      it { expect(running {instance.remote_images_urls = ["http://www.example.com/#{test_file_name}"]}).to raise_error(CarrierWave::IntegrityError) }
+      it { expect {instance.remote_images_urls = ["http://www.example.com/#{test_file_name}"]}.to raise_error(CarrierWave::IntegrityError) }
     end
   end
 
@@ -1005,7 +1005,7 @@ describe CarrierWave::Mount do
     end
 
     context "when a cached image fails an integrity check" do
-      it { expect(running { instance.images = [test_file_stub] }).to raise_error(CarrierWave::ProcessingError) }
+      it { expect { instance.images = [test_file_stub] }.to raise_error(CarrierWave::ProcessingError) }
     end
 
     context "when a downloaded image fails an integity check" do
@@ -1013,7 +1013,7 @@ describe CarrierWave::Mount do
         stub_request(:get, "http://www.example.com/#{test_file_name}").to_return(body: test_file_stub)
       end
 
-      it { expect(running {instance.remote_images_urls = ["http://www.example.com/#{test_file_name}"]}).to raise_error(CarrierWave::ProcessingError) }
+      it { expect {instance.remote_images_urls = ["http://www.example.com/#{test_file_name}"]}.to raise_error(CarrierWave::ProcessingError) }
     end
   end
 
@@ -1036,7 +1036,7 @@ describe CarrierWave::Mount do
     end
 
     context "when the image fail to be processed" do
-      it { expect(running {instance.remote_images_urls = ["http://www.example.com/#{test_file_name}"]}).to raise_error(CarrierWave::DownloadError) }
+      it { expect {instance.remote_images_urls = ["http://www.example.com/#{test_file_name}"]}.to raise_error(CarrierWave::DownloadError) }
     end
   end
 

--- a/spec/mount_single_spec.rb
+++ b/spec/mount_single_spec.rb
@@ -702,17 +702,17 @@ describe CarrierWave::Mount do
     end
 
     it "should raise an error if the image fails an integrity check when cached" do
-      expect(running {
+      expect {
         @instance.image = stub_file('test.jpg')
-      }).to raise_error(CarrierWave::IntegrityError)
+      }.to raise_error(CarrierWave::IntegrityError)
     end
 
     it "should raise an error if the image fails an integrity check when downloaded" do
       stub_request(:get, "http://www.example.com/test.jpg").to_return(body: File.read(file_path("test.jpg")))
 
-      expect(running {
+      expect {
         @instance.remote_image_url = "http://www.example.com/test.jpg"
-      }).to raise_error(CarrierWave::IntegrityError)
+      }.to raise_error(CarrierWave::IntegrityError)
     end
   end
 
@@ -736,17 +736,17 @@ describe CarrierWave::Mount do
     end
 
     it "should raise an error if the image fails to be processed when cached" do
-      expect(running {
+      expect {
         @instance.image = stub_file('test.jpg')
-      }).to raise_error(CarrierWave::ProcessingError)
+      }.to raise_error(CarrierWave::ProcessingError)
     end
 
     it "should raise an error if the image fails to be processed when downloaded" do
       stub_request(:get, "http://www.example.com/test.jpg").to_return(body: File.read(file_path("test.jpg")))
 
-      expect(running {
+      expect {
         @instance.remote_image_url = "http://www.example.com/test.jpg"
-      }).to raise_error(CarrierWave::ProcessingError)
+      }.to raise_error(CarrierWave::ProcessingError)
     end
 
   end
@@ -770,9 +770,9 @@ describe CarrierWave::Mount do
         end
       end
 
-      expect(running {
+      expect {
         @instance.remote_image_url = "http://www.example.com/test.jpg"
-      }).to raise_error(CarrierWave::DownloadError)
+      }.to raise_error(CarrierWave::DownloadError)
     end
 
   end

--- a/spec/sanitized_file_spec.rb
+++ b/spec/sanitized_file_spec.rb
@@ -413,7 +413,7 @@ describe CarrierWave::SanitizedFile do
         end
 
         it "should not raise an error when moved" do
-          expect(running { upcased_sanitized_file.move_to(upcased_sanitized_file.path.downcase) }).not_to raise_error
+          expect { upcased_sanitized_file.move_to(upcased_sanitized_file.path.downcase) }.not_to raise_error
         end
       end
     end
@@ -432,11 +432,11 @@ describe CarrierWave::SanitizedFile do
       end
 
       it "should not have changed its path when copied" do
-        expect(running { sanitized_file.copy_to(file_path("gurr.png")) }).not_to change(sanitized_file, :path)
+        expect { sanitized_file.copy_to(file_path("gurr.png")) }.not_to change(sanitized_file, :path)
       end
 
       it "should not have changed its filename when copied" do
-        expect(running { sanitized_file.copy_to(file_path("gurr.png")) }).not_to change(sanitized_file, :filename)
+        expect { sanitized_file.copy_to(file_path("gurr.png")) }.not_to change(sanitized_file, :filename)
       end
 
       it "should return an object of the same class when copied" do
@@ -492,7 +492,7 @@ describe CarrierWave::SanitizedFile do
   shared_examples_for "all valid sanitized files that are stored on disk" do
     describe "#move_to" do
       it "should not raise an error when moved to its own location" do
-        expect(running { sanitized_file.move_to(sanitized_file.path) }).not_to raise_error
+        expect { sanitized_file.move_to(sanitized_file.path) }.not_to raise_error
       end
 
       it "should remove the original file" do
@@ -505,10 +505,10 @@ describe CarrierWave::SanitizedFile do
 
     describe '#copy_to' do
       it "should return a new instance when copied to its own location" do
-        expect(running {
+        expect {
           new_file = sanitized_file.copy_to(sanitized_file.path)
           expect(new_file).to be_an_instance_of(sanitized_file.class)
-        }).not_to raise_error
+        }.not_to raise_error
       end
 
       it "should not remove the original file" do
@@ -663,7 +663,7 @@ describe CarrierWave::SanitizedFile do
 
     describe "#delete" do
       it "should not raise an error" do
-        expect(running { sanitized_file.delete }).not_to raise_error
+        expect { sanitized_file.delete }.not_to raise_error
       end
     end
 
@@ -847,7 +847,7 @@ describe CarrierWave::SanitizedFile do
 
     describe "#delete" do
       it "should not raise an error" do
-        expect(running { empty.delete }).not_to raise_error
+        expect { empty.delete }.not_to raise_error
       end
     end
 
@@ -917,7 +917,7 @@ describe CarrierWave::SanitizedFile do
 
     describe "#delete" do
       it "should not raise an error" do
-        expect(running { empty.delete }).not_to raise_error
+        expect { empty.delete }.not_to raise_error
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -158,6 +158,7 @@ RSpec.configure do |config|
   config.prepend CarrierWave::Test::SsrfProtectionAwareWebMock
   config.verbose_retry = true
   config.display_try_failure_messages = true
+  config.raise_errors_for_deprecations!
   config.around :each, :with_retry do |example|
     example.run_with_retry retry: 2
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,8 +24,6 @@ require 'rspec/retry'
 
 I18n.enforce_available_locales = false
 
-alias :running :lambda
-
 def file_path( *paths )
   File.expand_path(File.join(File.dirname(__FILE__), 'fixtures', *paths))
 end

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -283,7 +283,7 @@ end
 
     describe '#delete_dir' do
       it "should do nothing" do
-        expect(running{ @storage.delete_dir!('foobar') }).not_to raise_error
+        expect { @storage.delete_dir!('foobar') }.not_to raise_error
       end
     end
 
@@ -457,7 +457,7 @@ end
               let(:fog_public) { false }
 
               it "is not accessible" do
-                expect(running{ URI.open(@fog_file.public_url) }).to raise_error OpenURI::HTTPError
+                expect { URI.open(@fog_file.public_url) }.to raise_error OpenURI::HTTPError
               end
             end
           end

--- a/spec/uploader/cache_spec.rb
+++ b/spec/uploader/cache_spec.rb
@@ -40,15 +40,15 @@ describe CarrierWave::Uploader do
       end
 
       it "doesn't raise an error when trying to cache a string" do
-        expect(running {
-                 uploader.cache!(file_path(test_file_name))
-        }).not_to raise_error
+        expect {
+          uploader.cache!(file_path(test_file_name))
+        }.not_to raise_error
       end
 
       it "doesn't raise an error when trying to cache a pathname and " do
-        expect(running {
-                 uploader.cache!(Pathname.new(file_path(test_file_name)))
-        }).not_to raise_error
+        expect {
+          uploader.cache!(Pathname.new(file_path(test_file_name)))
+        }.not_to raise_error
       end
     end
   end
@@ -60,7 +60,7 @@ describe CarrierWave::Uploader do
       before { CarrierWave.configure { |config| config.ensure_multipart_form = true } }
 
       it "raises an error when trying to cache a string" do
-        expect(running { uploader.cache!(test_file_path) }).to raise_error(CarrierWave::FormNotMultipart)
+        expect { uploader.cache!(test_file_path) }.to raise_error(CarrierWave::FormNotMultipart)
       end
 
       it "raises an error when trying to cache a pathname" do
@@ -112,9 +112,9 @@ describe CarrierWave::Uploader do
         end
 
         it "doesn't raise an error when caching" do
-          expect(running {
-                   uploader.cache!(test_file)
-          }).not_to raise_error
+          expect {
+            uploader.cache!(test_file)
+          }.not_to raise_error
         end
       end
     end
@@ -250,22 +250,22 @@ describe CarrierWave::Uploader do
     end
 
     it "raises an error when the cache_id has an invalid format" do
-      expect(running {
+      expect {
         uploader.retrieve_from_cache!("12345/#{test_file_name}")
-      }).to raise_error(CarrierWave::InvalidParameter)
+      }.to raise_error(CarrierWave::InvalidParameter)
     end
 
     context "when the original filename has invalid characters" do
       it do
-        expect(running {
+        expect {
           uploader.retrieve_from_cache!('1369894322-345-1234-2255/te/st.jpeg')
-        }).to raise_error(CarrierWave::InvalidParameter)
+        }.to raise_error(CarrierWave::InvalidParameter)
       end
 
       it do
-        expect(running {
+        expect {
           uploader.retrieve_from_cache!('1369894322-345-1234-2255/te??%st.jpeg')
-        }).to raise_error(CarrierWave::InvalidParameter)
+        }.to raise_error(CarrierWave::InvalidParameter)
       end
     end
   end

--- a/spec/uploader/content_type_allowlist_spec.rb
+++ b/spec/uploader/content_type_allowlist_spec.rb
@@ -83,9 +83,9 @@ describe CarrierWave::Uploader do
         allow(uploader).to receive(:content_type_whitelist).and_return(['image/gif'])
 
         expect(ActiveSupport::Deprecation).to receive(:warn).with('#content_type_whitelist is deprecated, use #content_type_allowlist instead.')
-        expect(running {
+        expect {
           uploader.cache!(bork_file)
-        }).to raise_error(CarrierWave::IntegrityError)
+        }.to raise_error(CarrierWave::IntegrityError)
       end
 
       it "looks for content_type_allowlist first for I18n translation" do
@@ -97,9 +97,9 @@ describe CarrierWave::Uploader do
             :content_type_allowlist_error => "Het is niet toegestaan om %{content_type} bestanden te uploaden"
           }
         }) do
-          expect(running {
+          expect {
             uploader.cache!(bork_file)
-          }).to raise_error(CarrierWave::IntegrityError, 'Het is niet toegestaan om text/plain bestanden te uploaden')
+          }.to raise_error(CarrierWave::IntegrityError, 'Het is niet toegestaan om text/plain bestanden te uploaden')
         end
       end
     end

--- a/spec/uploader/extension_allowlist_spec.rb
+++ b/spec/uploader/extension_allowlist_spec.rb
@@ -19,9 +19,9 @@ describe CarrierWave::Uploader do
       it "does not raise an integrity error" do
         allow(@uploader).to receive(:extension_allowlist).and_return(nil)
 
-        expect(running {
+        expect {
           @uploader.cache!(File.open(file_path('test.jpg')))
-        }).not_to raise_error
+        }.not_to raise_error
       end
     end
 
@@ -30,73 +30,73 @@ describe CarrierWave::Uploader do
         it "does not raise an integrity error when the file has an allowlisted extension" do
           allow(@uploader).to receive(:extension_allowlist).and_return(%w(jpg gif png))
 
-          expect(running {
+          expect {
             @uploader.cache!(File.open(file_path('test.jpg')))
-          }).not_to raise_error
+          }.not_to raise_error
         end
 
         it "raises an integrity error if the file has not an allowlisted extension" do
           allow(@uploader).to receive(:extension_allowlist).and_return(%w(txt doc xls))
 
-          expect(running {
+          expect {
             @uploader.cache!(File.open(file_path('test.jpg')))
-          }).to raise_error(CarrierWave::IntegrityError, 'You are not allowed to upload "jpg" files, allowed types: txt, doc, xls')
+          }.to raise_error(CarrierWave::IntegrityError, 'You are not allowed to upload "jpg" files, allowed types: txt, doc, xls')
         end
 
         it "raises an integrity error if the file has not an allowlisted extension" do
           allow(@uploader).to receive(:extension_allowlist).and_return(%w(txt doc xls))
 
-          expect(running {
+          expect {
             @uploader.cache!(File.open(file_path('test.jpg')))
-          }).to raise_error(CarrierWave::IntegrityError)
+          }.to raise_error(CarrierWave::IntegrityError)
         end
 
         it "raises an integrity error if the file has not an allowlisted extension, using start of string matcher" do
           allow(@uploader).to receive(:extension_allowlist).and_return(%w(txt))
 
-          expect(running {
+          expect {
             @uploader.cache!(File.open(file_path('bork.ttxt')))
-          }).to raise_error(CarrierWave::IntegrityError)
+          }.to raise_error(CarrierWave::IntegrityError)
         end
 
         it "raises an integrity error if the file has not an allowlisted extension, using end of string matcher" do
           allow(@uploader).to receive(:extension_allowlist).and_return(%w(txt))
 
-          expect(running {
+          expect {
             @uploader.cache!(File.open(file_path('bork.txtt')))
-          }).to raise_error(CarrierWave::IntegrityError)
+          }.to raise_error(CarrierWave::IntegrityError)
         end
 
         it "compares extensions in a case insensitive manner when capitalized extension provided" do
           allow(@uploader).to receive(:extension_allowlist).and_return(%w(jpg gif png))
 
-          expect(running {
+          expect {
             @uploader.cache!(File.open(file_path('case.JPG')))
-          }).not_to raise_error
+          }.not_to raise_error
         end
 
         it "compares extensions in a case insensitive manner when lowercase extension provided" do
           allow(@uploader).to receive(:extension_allowlist).and_return(%w(JPG GIF PNG))
 
-          expect(running {
+          expect {
             @uploader.cache!(File.open(file_path('test.jpg')))
-          }).not_to raise_error
+          }.not_to raise_error
         end
 
         it "accepts extensions as regular expressions" do
           allow(@uploader).to receive(:extension_allowlist).and_return([/jpe?g/, 'gif', 'png'])
 
-          expect(running {
+          expect {
             @uploader.cache!(File.open(file_path('test.jpeg')))
-          }).not_to raise_error
+          }.not_to raise_error
         end
 
         it "accepts extensions as regular expressions in a case insensitive manner" do
 
           allow(@uploader).to receive(:extension_allowlist).and_return([/jpe?g/, 'gif', 'png'])
-          expect(running {
+          expect {
             @uploader.cache!(File.open(file_path('case.JPG')))
-          }).not_to raise_error
+          }.not_to raise_error
         end
       end
 
@@ -121,9 +121,9 @@ describe CarrierWave::Uploader do
         allow(@uploader).to receive(:extension_whitelist).and_return(%w(txt doc xls))
 
         expect(ActiveSupport::Deprecation).to receive(:warn).with('#extension_whitelist is deprecated, use #extension_allowlist instead.')
-        expect(running {
+        expect {
           @uploader.cache!(File.open(file_path('test.jpg')))
-        }).to raise_error(CarrierWave::IntegrityError)
+        }.to raise_error(CarrierWave::IntegrityError)
       end
 
       it "looks for extension_allowlist first for I18n translation" do
@@ -135,9 +135,9 @@ describe CarrierWave::Uploader do
             :extension_allowlist_error => "Het is niet toegestaan om %{extension} bestanden te uploaden; toegestane bestandstypes: %{allowed_types}"
           }
         }) do
-          expect(running {
+          expect {
             @uploader.cache!(File.open(file_path('test.jpg')))
-          }).to raise_error(CarrierWave::IntegrityError, 'Het is niet toegestaan om "jpg" bestanden te uploaden; toegestane bestandstypes: txt, doc, xls')
+          }.to raise_error(CarrierWave::IntegrityError, 'Het is niet toegestaan om "jpg" bestanden te uploaden; toegestane bestandstypes: txt, doc, xls')
         end
       end
     end

--- a/spec/uploader/extension_denylist_spec.rb
+++ b/spec/uploader/extension_denylist_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe CarrierWave::Uploader do
-  subject { lambda { uploader.cache!(test_file) } }
+  subject { uploader.cache!(test_file) }
 
   let(:uploader_class) { Class.new(CarrierWave::Uploader::Base) }
   let(:uploader) { uploader_class.new }
@@ -18,7 +18,7 @@ describe CarrierWave::Uploader do
   describe '#cache!' do
     context "when there are no denylisted extensions" do
       it "doesn't raise an integrity error" do
-        is_expected.not_to raise_error
+        expect { subject }.not_to raise_error
       end
     end
 
@@ -33,7 +33,7 @@ describe CarrierWave::Uploader do
 
         it "shows up" do
           expect(ActiveSupport::Deprecation).to receive(:warn).with('Use of #extension_denylist is deprecated for the security reason, use #extension_allowlist instead to explicitly state what are safe to accept')
-          is_expected.to raise_error(CarrierWave::IntegrityError)
+          expect { subject }.to raise_error(CarrierWave::IntegrityError)
         end
       end
 
@@ -42,7 +42,7 @@ describe CarrierWave::Uploader do
           let(:extension_denylist) { %w(jpg gif png) }
 
           it "raises an integrity error" do
-            is_expected.to raise_error(CarrierWave::IntegrityError, 'You are not allowed to upload "jpg" files, prohibited types: jpg, gif, png')
+            expect { subject }.to raise_error(CarrierWave::IntegrityError, 'You are not allowed to upload "jpg" files, prohibited types: jpg, gif, png')
           end
         end
 
@@ -50,7 +50,7 @@ describe CarrierWave::Uploader do
           let(:extension_denylist) { %w(txt doc xls) }
 
           it "doesn't raise an integrity error" do
-            is_expected.to_not raise_error
+            expect { subject }.to_not raise_error
           end
         end
 
@@ -59,7 +59,7 @@ describe CarrierWave::Uploader do
           let(:extension_denylist) { %w(txt) }
 
           it "doesn't raise an integrity error" do
-            is_expected.to_not raise_error
+            expect { subject }.to_not raise_error
           end
         end
 
@@ -68,7 +68,7 @@ describe CarrierWave::Uploader do
           let(:extension_denylist) { %w(txt) }
 
           it "doesn't raise an integrity error" do
-            is_expected.to_not raise_error
+            expect { subject }.to_not raise_error
           end
         end
 
@@ -77,7 +77,7 @@ describe CarrierWave::Uploader do
           let(:extension_denylist) { %w(jpg gif png) }
 
           it "raise an integrity error" do
-            is_expected.to raise_error(CarrierWave::IntegrityError)
+            expect { subject }.to raise_error(CarrierWave::IntegrityError)
           end
         end
 
@@ -86,7 +86,7 @@ describe CarrierWave::Uploader do
           let(:extension_denylist) { %w(JPG GIF PNG) }
 
           it "raise an integrity error" do
-            is_expected.to raise_error(CarrierWave::IntegrityError)
+            expect { subject }.to raise_error(CarrierWave::IntegrityError)
           end
         end
 
@@ -95,7 +95,7 @@ describe CarrierWave::Uploader do
           let(:extension_denylist) { [/jpe?g/, 'gif', 'png'] }
 
           it "raise an integrity error" do
-            is_expected.to raise_error(CarrierWave::IntegrityError)
+            expect { subject }.to raise_error(CarrierWave::IntegrityError)
           end
         end
       end
@@ -106,7 +106,7 @@ describe CarrierWave::Uploader do
           let(:extension_denylist) { 'jpeg' }
 
           it "raises an integrity error" do
-            is_expected.to raise_error(CarrierWave::IntegrityError)
+            expect { subject }.to raise_error(CarrierWave::IntegrityError)
           end
         end
 
@@ -115,7 +115,7 @@ describe CarrierWave::Uploader do
           let(:extension_denylist) { /jpe?g/ }
 
           it "raise an integrity error" do
-            is_expected.to raise_error(CarrierWave::IntegrityError)
+            expect { subject }.to raise_error(CarrierWave::IntegrityError)
           end
         end
       end
@@ -126,7 +126,7 @@ describe CarrierWave::Uploader do
         allow(uploader).to receive(:extension_blacklist).and_return(%w(jpg gif png))
 
         expect(ActiveSupport::Deprecation).to receive(:warn).with('#extension_blacklist is deprecated, use #extension_denylist instead.')
-        is_expected.to raise_error(CarrierWave::IntegrityError)
+        expect { subject }.to raise_error(CarrierWave::IntegrityError)
       end
 
       it "looks for extension_denylist first for I18n translation" do
@@ -138,7 +138,7 @@ describe CarrierWave::Uploader do
             :extension_denylist_error => "Het is niet toegestaan om %{extension} bestanden te uploaden; verboden bestandstypes: %{prohibited_types}"
           }
         }) do
-          is_expected.to raise_error(CarrierWave::IntegrityError, 'Het is niet toegestaan om "jpg" bestanden te uploaden; verboden bestandstypes: jpg, gif, png')
+          expect { subject }.to raise_error(CarrierWave::IntegrityError, 'Het is niet toegestaan om "jpg" bestanden te uploaden; verboden bestandstypes: jpg, gif, png')
         end
       end
     end

--- a/spec/uploader/file_size_spec.rb
+++ b/spec/uploader/file_size_spec.rb
@@ -9,7 +9,7 @@ describe CarrierWave::Uploader do
   after { FileUtils.rm_rf(public_path) }
 
   describe '#cache!' do
-    subject { lambda { uploader.cache!(test_file) } }
+    subject { uploader.cache!(test_file) }
 
     before { allow(CarrierWave).to receive(:generate_cache_id).and_return(cache_id) }
 
@@ -20,7 +20,7 @@ describe CarrierWave::Uploader do
         let(:range) { nil }
 
         it "doesn't raise an integrity error" do
-          is_expected.not_to raise_error
+          expect { subject }.not_to raise_error
         end
       end
 
@@ -28,7 +28,7 @@ describe CarrierWave::Uploader do
         let(:range) { 2097152..4194304 }
 
         it "raises an integrity error" do
-          is_expected.to raise_error(CarrierWave::IntegrityError, 'File size should be greater than 2 MB')
+          expect { subject }.to raise_error(CarrierWave::IntegrityError, 'File size should be greater than 2 MB')
         end
       end
 
@@ -36,7 +36,7 @@ describe CarrierWave::Uploader do
         let(:range) { 0..10 }
 
         it "raises an integrity error" do
-          is_expected.to raise_error(CarrierWave::IntegrityError, 'File size should be less than 10 Bytes')
+          expect { subject }.to raise_error(CarrierWave::IntegrityError, 'File size should be less than 10 Bytes')
         end
       end
 
@@ -44,7 +44,7 @@ describe CarrierWave::Uploader do
         let(:range) { 0..100 }
 
         it "doesn't raise an integrity error" do
-          is_expected.not_to raise_error
+          expect { subject }.not_to raise_error
         end
       end
     end

--- a/spec/uploader/url_spec.rb
+++ b/spec/uploader/url_spec.rb
@@ -61,7 +61,7 @@ describe CarrierWave::Uploader do
     end
 
     context "File#url" do
-      let(:file_class) { FileX = Class.new }
+      let(:file_class) { Class.new }
       let(:file) { file_class.new }
 
       before do


### PR DESCRIPTION
suppress rspec deprecation warnings

e.g)

```
The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports_value_expectations?`. e.g  `expect { value }.to raise CarrierWave::DownloadError` not `expect(value).to raise CarrierWave::DownloadError`

/home/runner/work/carrierwave/carrierwave/spec/uploader/url_spec.rb:64: warning: already initialized constant FileX
/home/runner/work/carrierwave/carrierwave/spec/uploader/url_spec.rb:64: warning: previous definition of FileX was here
```