### PR TITLE
Set `:content_type` in `copy_options` for GCS.

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -487,7 +487,7 @@ module CarrierWave
         def copy_options
           options = {}
           options.merge!(acl_header) if acl_header.present?
-          options['Content-Type'] ||= content_type if content_type
+          options['Content-Type'] = options[:content_type] ||= content_type if content_type
           options.merge(@uploader.fog_attributes)
         end
 

--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -487,7 +487,7 @@ module CarrierWave
         def copy_options
           options = {}
           options.merge!(acl_header) if acl_header.present?
-          options['Content-Type'] = options[:content_type] ||= content_type if content_type
+          options[fog_provider == "Google" ? :content_type : 'Content-Type'] ||= content_type if content_type
           options.merge(@uploader.fog_attributes)
         end
 

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -606,15 +606,14 @@ end
           if @provider == 'AWS'
             expect(@storage.connection).to receive(:copy_object)
                                              .with(anything, anything, anything, anything,
-                                                   { "Content-Type"=>@fog_file.content_type, content_type: @fog_file.content_type, "x-amz-acl"=>"public-read", 'x-amz-server-side-encryption' => 'AES256' }).and_call_original
+                                                   { "Content-Type"=>@fog_file.content_type, "x-amz-acl"=>"public-read", 'x-amz-server-side-encryption' => 'AES256' }).and_call_original
           elsif @provider == 'Google'
             expect(@storage.connection).to receive(:copy_object)
                                              .with(anything, anything, anything, anything,
-                                                   { "Content-Type"=>@fog_file.content_type, content_type: @fog_file.content_type, destination_predefined_acl: "publicRead" }).and_call_original
+                                                   { content_type: @fog_file.content_type, destination_predefined_acl: "publicRead" }).and_call_original
           else
             expect(@storage.connection).to receive(:copy_object)
-                                             .with(anything, anything, anything, anything,
-                                                   { "Content-Type"=>@fog_file.content_type, content_type: @fog_file.content_type }).and_call_original
+                                             .with(anything, anything, anything, anything, { "Content-Type"=>@fog_file.content_type }).and_call_original
           end
 
           @fog_file.copy_to('uploads/new_path.jpg')
@@ -625,16 +624,14 @@ end
         it 'includes acl_header when necessary' do
           if @provider == 'AWS'
             expect(@storage.connection).to receive(:copy_object)
-                                             .with(anything, anything, anything, anything,
-                                                   { "Content-Type"=>@fog_file.content_type, content_type: @fog_file.content_type, "x-amz-acl"=>"public-read" }).and_call_original
+                                             .with(anything, anything, anything, anything, { "Content-Type"=>@fog_file.content_type, "x-amz-acl"=>"public-read" }).and_call_original
           elsif @provider == 'Google'
             expect(@storage.connection).to receive(:copy_object)
                                              .with(anything, anything, anything, anything,
-                                                   { "Content-Type"=>@fog_file.content_type, content_type: @fog_file.content_type, destination_predefined_acl: "publicRead" }).and_call_original
+                                                   { content_type: @fog_file.content_type, destination_predefined_acl: "publicRead" }).and_call_original
           else
             expect(@storage.connection).to receive(:copy_object)
-                                             .with(anything, anything, anything, anything,
-                                                   { "Content-Type"=>@fog_file.content_type, content_type: @fog_file.content_type }).and_call_original
+                                             .with(anything, anything, anything, anything, { "Content-Type"=>@fog_file.content_type }).and_call_original
           end
 
           @fog_file.copy_to('uploads/new_path.jpg')

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -606,13 +606,15 @@ end
           if @provider == 'AWS'
             expect(@storage.connection).to receive(:copy_object)
                                              .with(anything, anything, anything, anything,
-                                                   { "Content-Type"=>@fog_file.content_type, "x-amz-acl"=>"public-read", 'x-amz-server-side-encryption' => 'AES256' }).and_call_original
+                                                   { "Content-Type"=>@fog_file.content_type, content_type: @fog_file.content_type, "x-amz-acl"=>"public-read", 'x-amz-server-side-encryption' => 'AES256' }).and_call_original
           elsif @provider == 'Google'
             expect(@storage.connection).to receive(:copy_object)
-                                             .with(anything, anything, anything, anything, { "Content-Type"=>@fog_file.content_type, destination_predefined_acl: "publicRead" }).and_call_original
+                                             .with(anything, anything, anything, anything,
+                                                   { "Content-Type"=>@fog_file.content_type, content_type: @fog_file.content_type, destination_predefined_acl: "publicRead" }).and_call_original
           else
             expect(@storage.connection).to receive(:copy_object)
-                                             .with(anything, anything, anything, anything, { "Content-Type"=>@fog_file.content_type }).and_call_original
+                                             .with(anything, anything, anything, anything,
+                                                   { "Content-Type"=>@fog_file.content_type, content_type: @fog_file.content_type }).and_call_original
           end
 
           @fog_file.copy_to('uploads/new_path.jpg')
@@ -623,13 +625,16 @@ end
         it 'includes acl_header when necessary' do
           if @provider == 'AWS'
             expect(@storage.connection).to receive(:copy_object)
-                                             .with(anything, anything, anything, anything, { "Content-Type"=>@fog_file.content_type, "x-amz-acl"=>"public-read" }).and_call_original
+                                             .with(anything, anything, anything, anything,
+                                                   { "Content-Type"=>@fog_file.content_type, content_type: @fog_file.content_type, "x-amz-acl"=>"public-read" }).and_call_original
           elsif @provider == 'Google'
             expect(@storage.connection).to receive(:copy_object)
-                                             .with(anything, anything, anything, anything, { "Content-Type"=>@fog_file.content_type, destination_predefined_acl: "publicRead" }).and_call_original
+                                             .with(anything, anything, anything, anything,
+                                                   { "Content-Type"=>@fog_file.content_type, content_type: @fog_file.content_type, destination_predefined_acl: "publicRead" }).and_call_original
           else
             expect(@storage.connection).to receive(:copy_object)
-                                             .with(anything, anything, anything, anything, { "Content-Type"=>@fog_file.content_type }).and_call_original
+                                             .with(anything, anything, anything, anything,
+                                                   { "Content-Type"=>@fog_file.content_type, content_type: @fog_file.content_type }).and_call_original
           end
 
           @fog_file.copy_to('uploads/new_path.jpg')


### PR DESCRIPTION
## Issue Description
Files lose their correct content type when copied on Google Cloud Storage. For example an SVG file with content type "image/svg+xml" becomes "application/octet-stream" when copied to another path on the same bucket.

## Reason
Google Storage API only [considers the `:content_type` option](https://github.com/googleapis/google-api-ruby-client/blob/16c46ef4deb499a390effe9d4edd6a5cbba6cf04/generated/google-apis-storage_v1/lib/google/apis/storage_v1/classes.rb#L1635), so `'Content-Type'` as [defined in `copy_options`](https://github.com/carrierwaveuploader/carrierwave/blob/3cfabaf/lib/carrierwave/storage/fog.rb#L490) is ignored.

## Solution
Set both keys. Beware, I assume that 'Content-Type' is required by AWS but I haven’t checked that.
