### PR TITLE
Fixed non-existent branch name

### DIFF
--- a/gemfiles/rails-main.gemfile
+++ b/gemfiles/rails-main.gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", github: "rails/rails", branch: "main"
 gem "rack", github: "rack/rack", branch: "main"
-gem "sprockets", github: "rails/sprockets", branch: "master"
+gem "sprockets", github: "rails/sprockets", branch: "main"
 gem "sprockets-rails", github: "rails/sprockets-rails", branch: "master"
 gem "sass-rails", github: "rails/sass-rails"
 gem "activemodel-serializers-xml"


### PR DESCRIPTION
rails/sprockets already has no master branch.