### PR TITLE
Keep original image format when using MiniMagick unless explicited

### DIFF
--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -289,14 +289,17 @@ module CarrierWave
     #
     # [CarrierWave::ProcessingError] if processing failed.
     def minimagick!(block = nil)
-      builder = ImageProcessing::MiniMagick.source(current_path)
-      builder = yield(builder)
+      builder = ImageProcessing::MiniMagick.source(current_path).convert(content_type)
 
+      original_format = builder.options[:format]
+      builder = yield(builder)
+      new_format = builder.options[:format]
       result = builder.call
       result.close
 
       # backwards compatibility (we want to eventually move away from MiniMagick::Image)
       if block
+        # TODO: do we want to still support this, or remove it?
         image  = ::MiniMagick::Image.new(result.path, result)
         image  = block.call(image)
         result = image.instance_variable_get(:@tempfile)
@@ -304,7 +307,7 @@ module CarrierWave
 
       FileUtils.mv result.path, current_path
 
-      if File.extname(result.path) != File.extname(current_path)
+      if original_format != new_format
         move_to = current_path.chomp(File.extname(current_path)) + File.extname(result.path)
         file.content_type = Marcel::Magic.by_path(move_to).try(:type)
         file.move_to(move_to, permissions, directory_permissions)


### PR DESCRIPTION
# Context

We recently switched from `RMagick` to `MiniMagick` in our codebase. This lead to an important change of behaviour in the uploader process

# Summary

When using minimagick, it seems like the image is **always converted to jpeg** when running `process resize_to_limit: ...`, thus failing to have another `process` afterwards expecting an image that would still be in png format.

# Reproduction

```ruby
# frozen_string_literal: true

require "bundler/inline"
require "bundler/version"

puts "ruby=#{RUBY_VERSION} bundler=#{Bundler::VERSION}"

gemfile do
  source "https://rubygems.org"

  gem "activerecord", "7.0.3.1"
  gem "rails", "7.0.3.1", require: "action_dispatch"
  gem "carrierwave", "2.2.2"
  gem "sqlite3", "1.4.4", require: false
end

require "base64"
require "carrierwave/orm/activerecord"
require "tempfile"


# The base uploader, enforces basic rules, mostly for security reasons.
# It should not do a format conversion, yet, it does.
class BaseUploader < CarrierWave::Uploader::Base
  include CarrierWave::MiniMagick

  storage :file

  process resize_to_limit: [4096, 4096] # This will convert the image to jpeg

  def filename # This won't help (even by remove the ext or changing it)
    return unless original_filename.present?

    "some.png"
  end
end

# A specific uploader that handles some conversion.
class SignatureUploader < BaseUploader
   process convert_and_fill: ["jpg", "#FFFFFF"]


   def convert_and_fill(format, color)
    raise "Cannot work with a non-transparent original image" unless file.content_type == "image/png"

     minimagick! do |image|
       # Actually operate conversion from png to jpg, but it is too late
       image.convert("jpg")
       # NOTE: here would be the filling operation, cut for demo length purpose
     end
  end
end

class AR < ActiveRecord::Base
  self.abstract_class = true
  establish_connection(
    adapter:  "sqlite3",
    database: "tmp/db"
  )
end

class Document < AR
  mount_uploader :signature, SignatureUploader
end
AR.connection.execute <<~SQL
  CREATE TABLE IF NOT EXISTS documents(
    id INTEGER PRIMARY KEY,
    signature TEXT
  );
SQL

doc = Document.new
b64png_img = "iVBORw0KGgoAAAANSUhEUgAAAXsAAAI9CAYAAADb19jnAAAAAXNSR0IArs4c6QAAAARzQklUCAgICHwIZIgAAAxASURBVHic7d3tdRNJFgbgd/fMf7QRrDJAG8F4IsAbAZ4ImI0AJgLYCGAiwESAiQATASYC7Ai8P0q13ZI/JNlSf7if5xwfG4Pllozfrr5VfSsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAtvcmyfXyPfBE/b3vAwDg8IQ9wAQIe4AJEPYAEyDsASZA2ANMgLAHmABhDzABwh5gAoQ9wAQIe4AJEPYAEyDsASZA2ANMgLAHmABhDzzWUcqeCGd9Hwh3+6XvA4AJmSf55xb/7keSiwMfCxMj7KE7J0leb/lvL5Ocp4yWz5J8W34OHkTYQ/c2jdwXSWYp5ZGj1uf/dsiDeoRZ3wfAZsIeuvchm/f8naeE/iLbXw30YZHk/fLj8z4PBLjfHymTa1/7PpAJeOjm7tfLt6GZJ/mZcmwfej4WYINZSknhISHEbmrYf81upY8hhf2LJG+TfE9zXEb0MBJ16dx1ymU5h7FIc2LdNvBnGUbYH2c14K9TJoxPo2YPo/IuyjldmKWMhK9TSiAvc39Y1quBvtawHyX5nCbgL1L+rxzd90XAcCnndKcd+DX03+dmgM7S1MS7Dtf58pjao/iTjo8BOJBFml/uz+kmYN6mBMvUzFLC8yyrpZG3aUb6XY/qF8vv/zWrIf8mSjXw5Jyk/ILXX/bvKaWGQ6hhNvUJvnmaMlod6b9KN/MoNeBvq8d/yDRPxDAZs5QlmbWsU0P/VfY3wuuzRDFU89wc6R9iSeNtK2pqPf5DymQsMDEnWQ396yQfUwLjMepIVvOsm9pllF2Xad7lRUoNvp5g1ydcrcICkpTR3mlWg+Jnyghx16CYtx5j6GWCeZJfN7zt0/qk6EMDf5ZSfhPwwIPUEk97NUkNpE3LCKuP6f+uy0VKUL9IaUfwenlcn7M6st727XNKmeuhAbq+xPEkq6t2tg382r5gPeDPU35uQz+5ciBDbazEOCxSAuQ4ybPW50/TdGz8svY1xymhepUSPA/t5Phy+Vi7jHhn2T2MNzUtmyV5vva5izTdKj/l/ud4lHKiqfMWVymvaT0RzpaP8zzlNf09Nye06yj+JKvP79vycU43PAcmQNizLycp4XtbLf88Tfi/Swmn/yw/3sUiZfS8a8jfprYMrq2E63HWYN5lLqF2qDxevl/vWX+eErjr2l0tr1Jej3e5eXJoB/5lkn8v/zxPOVG0179fpQT8uwh4WoQ9+zZPCbDF8v36qLeqI9/zlOC9K5jmKSeQ9RLEt+weaO1gP6T63I+zuaZ/X8i3tQM/KSePozQnvU9pRvFwg7DvR730v8o01pgfpYw+71uvX0f+pymln1qmaS8D/LH8+zGNWuuo/7byUV3Lvm0pa5by3Nuv42WS3zKN/0c8grDvR52M+5JprDGfpUwwzpP8maa3yqL1/tmdX93YpbRymVLffkq7O71O08riR5pyUb3L9b99HBRwt6lt0FzX1N82+pxl9W7Rfb7ta416346yegNUnfdYZPUmrM+x2oY7GNn3Y0oj+0WaTpr/ShP4L9JM6lZ1cnEfded3aVaw/JZxjvBnKaP5P5Z//rb8eH2QcJzyuj1LeZ7vUq6ggJ5NaWRf16zXZlqvcvM2/dPs/xb99TXqY7M+mt/UiXSWEvjt9hZPfSABgzeVsK+Nzuqdtu0bfS5SRqmHKrPUeYJa9hiLWVbvoj3PbvcGHGW1vYXSDvRoCmHfbonQfjtLNyPOGpjnGU/dfpFmNH+ZpnzzEG+y2r203ToZ6Ejd5HtMI85dHOVmy4EP6a6scJImMMfS/6U9Sb3raP4u66Wd2joZ6EhtKPbUdv5Z7+9SQ77LMsIiTbloDK/vLE2voEMNANZX7XyNej50ol6qj2XUuUm7/NDu2Nh1X/R2nb7PJmvbWi/bHPr1Os5qPf9jlHbgYGote4xLAW9zkpsdFmvfli61R/RjqNOvH2+Xr1e7nv9U7kWAwTnO05mcfZv+R/PJar37LMMPr3bQ93UFsojAh4OqyxE/9n0gj7BeZ66h1XVgdFHv3rchBH37WNqBr44Pe1RXilynLA8cm3pHbHvlSB8h0XW9ex+GFPTVIqt1fEs0nyjtEvpRV0c8S9Pqd5OLlPYKXXd7rB06Fyl15bqD0lXKVUofo+mTNKH0Lc3E45AtUlYqzZL8leGtFHqT0pohKa/l73kapUaWhH1/2oG/i9oK+Cz7n+StzbXmafrS3+ZTSlh1Pck8Swn5GpR/pdyzMIbJ7g8prYmHGPTVIuU4n6f8jMdwtcSWhH2/Ftn+F6q2A9715PBYV8v39fv+mc19Wg5hnlKfX+Tm1n1j8DPlZNVuBjdEX1Ne498zrteXDYT9+BxldTu7fTtLuYy/SBNK31OCqq8AOE6Z36hlm5MMOzDX1XmOHxl2n5p6nFdRt4fJqbfb91W/bS/vPM04Q6i2xxj6SLn+rMewqgnYo9qw7TLdj0jbd8Ne53FNwfo2hvYYszQrhYZ89QEcQF3a2HWN/ihN8Fxk/G0lxhCidUmwFTgwMfXmr66XNL7OuO6G3UZ9PkNWT+xDvvoA9myeZjTa1Q1TdbXNtjszjcnQw77uEXyRp3FyBbZUR/X72At2k7rPaj25XObp3bY/5LCvvZqeUhdWYEs17A89un6Z1Y6ZXfe+78pQw759BTfmCXDggQ4d9us7WXW1VWFfhhr29WfQxRUcMECHCvt5Vneyusg0JgSHGPbq9MDew36e1ZujLvf42GMwtLBXpweSNGH/2E0tjjKMvvd9G1LYq9MD/zdL6T3zkMCfpewctb4n7VOdfN3GkMJenR5YsUvgz1NW1rzP6uqai5SrhKmN5NcNJezfR51+snS95D6zlJUyz1OCf300WNsurwfHl5QJQKPHogb9P9Jf7/2TNDujDb3NMtCD9gj/rrfLlGB/k+mWau5zlvI69bUZSLvJ2RRWP3GLX/o+AAav3tF622TeRZr+99ztNMmvKWHfx9VO3QvgU4bfZhlgtBYpo+rvPXzvusyyjzbVAJNzme7XtbfLN5ZZAnSgj12g6uobPeoBOlJLOV21jVa+AehJ+87kQ1K+AejZRQ7fPrq2qFC+AehJ3cT9OqU53L4p3wAMRN3c+zql5fO+Whco3wAMzCLNcsyf2c+STOUbgAGqvYfqKP/VIx6rXi0o3wAMVN01qt5l+3LHr1+kKd/01X8HgC0cp1mps0vot4Ne3xuAkTjJ5tC/bf8AQQ8wQreF/tvc3AFM0AM8Aeuh394/4I/YMJwt2akKxuEkpXxzGrtMAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0In/AZFlR8TVsNgCAAAAAElFTkSuQmCC"


data = Base64.decode64(b64png_img)
tempfile = Tempfile.new("filename")
tempfile.binmode
tempfile.write(data)
tempfile.rewind
content_type = `file --mime -b #{tempfile.path}`.split(";")[0] # image/png

file = ActionDispatch::Http::UploadedFile.new(
  tempfile: tempfile,
  type: content_type,
  filename: "filename"
)

doc.signature = file
```

```
ruby=3.1.2 bundler=2.3.21
signature-repro.rb:46:in `convert_and_fill': Cannot work with a non-transparent original image (RuntimeError)
        from /Users/u.buonomo/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/carrierwave-2.2.2/lib/carrierwave/uploader/processing.rb:83:in `block (2 levels) in process!'
        from /Users/u.buonomo/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/carrierwave-2.2.2/lib/carrierwave/uploader/processing.rb:75:in `each'
        from /Users/u.buonomo/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/carrierwave-2.2.2/lib/carrierwave/uploader/processing.rb:75:in `block in process!'
        from /Users/u.buonomo/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/carrierwave-2.2.2/lib/carrierwave/uploader/callbacks.rb:15:in `with_callbacks'
        from /Users/u.buonomo/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/carrierwave-2.2.2/lib/carrierwave/uploader/processing.rb:74:in `process!'
        from /Users/u.buonomo/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/carrierwave-2.2.2/lib/carrierwave/uploader/callbacks.rb:14:in `block in with_callbacks'
        from /Users/u.buonomo/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/carrierwave-2.2.2/lib/carrierwave/uploader/callbacks.rb:14:in `each'
        from /Users/u.buonomo/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/carrierwave-2.2.2/lib/carrierwave/uploader/callbacks.rb:14:in `with_callbacks'
        from /Users/u.buonomo/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/carrierwave-2.2.2/lib/carrierwave/uploader/cache.rb:144:in `cache!'
        from /Users/u.buonomo/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/carrierwave-2.2.2/lib/carrierwave/mounter.rb:63:in `block (2 levels) in cache'
        from /Users/u.buonomo/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/carrierwave-2.2.2/lib/carrierwave/mounter.rb:176:in `handle_error'
        from /Users/u.buonomo/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/carrierwave-2.2.2/lib/carrierwave/mounter.rb:47:in `block in cache'
        from /Users/u.buonomo/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/carrierwave-2.2.2/lib/carrierwave/mounter.rb:46:in `map'
        from /Users/u.buonomo/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/carrierwave-2.2.2/lib/carrierwave/mounter.rb:46:in `cache'
        from /Users/u.buonomo/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/carrierwave-2.2.2/lib/carrierwave/mount.rb:146:in `signature='
        from /Users/u.buonomo/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/carrierwave-2.2.2/lib/carrierwave/mount.rb:373:in `signature='
        from /Users/u.buonomo/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/carrierwave-2.2.2/lib/carrierwave/orm/activerecord.rb:75:in `signature='
        from signature-repro.rb:89:in `<main>'
```

# Current Lead

As far as I understood the problem, it seems like the `#minimagick!` tends to change the name and format of the file. However, it is likely that this change is just a reflection of the original format change, done within `ImageProcessing` (checked using `file --mime` within `#minimagick!`.

`ImageProcessing` is actually always converting to jpeg by default unless explicitely stated otherwise:

```ruby
# frozen_string_literal: true

require "action_dispatch"
require "base64"
require "image_processing"
require "tempfile"

b64png_img = "iVBORw0KGgoAAAANSUhEUgAAAXsAAAI9CAYAAADb19jnAAAAAXNSR0IArs4c6QAAAARzQklUCAgICHwIZIgAAAxASURBVHic7d3tdRNJFgbgd/fMf7QRrDJAG8F4IsAbAZ4ImI0AJgLYCGAiwESAiQATASYC7Ai8P0q13ZI/JNlSf7if5xwfG4Pllozfrr5VfSsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAtvcmyfXyPfBE/b3vAwDg8IQ9wAQIe4AJEPYAEyDsASZA2ANMgLAHmABhDzABwh5gAoQ9wAQIe4AJEPYAEyDsASZA2ANMgLAHmABhDzzWUcqeCGd9Hwh3+6XvA4AJmSf55xb/7keSiwMfCxMj7KE7J0leb/lvL5Ocp4yWz5J8W34OHkTYQ/c2jdwXSWYp5ZGj1uf/dsiDeoRZ3wfAZsIeuvchm/f8naeE/iLbXw30YZHk/fLj8z4PBLjfHymTa1/7PpAJeOjm7tfLt6GZJ/mZcmwfej4WYINZSknhISHEbmrYf81upY8hhf2LJG+TfE9zXEb0MBJ16dx1ymU5h7FIc2LdNvBnGUbYH2c14K9TJoxPo2YPo/IuyjldmKWMhK9TSiAvc39Y1quBvtawHyX5nCbgL1L+rxzd90XAcCnndKcd+DX03+dmgM7S1MS7Dtf58pjao/iTjo8BOJBFml/uz+kmYN6mBMvUzFLC8yyrpZG3aUb6XY/qF8vv/zWrIf8mSjXw5Jyk/ILXX/bvKaWGQ6hhNvUJvnmaMlod6b9KN/MoNeBvq8d/yDRPxDAZs5QlmbWsU0P/VfY3wuuzRDFU89wc6R9iSeNtK2pqPf5DymQsMDEnWQ396yQfUwLjMepIVvOsm9pllF2Xad7lRUoNvp5g1ydcrcICkpTR3mlWg+Jnyghx16CYtx5j6GWCeZJfN7zt0/qk6EMDf5ZSfhPwwIPUEk97NUkNpE3LCKuP6f+uy0VKUL9IaUfwenlcn7M6st727XNKmeuhAbq+xPEkq6t2tg382r5gPeDPU35uQz+5ciBDbazEOCxSAuQ4ybPW50/TdGz8svY1xymhepUSPA/t5Phy+Vi7jHhn2T2MNzUtmyV5vva5izTdKj/l/ud4lHKiqfMWVymvaT0RzpaP8zzlNf09Nye06yj+JKvP79vycU43PAcmQNizLycp4XtbLf88Tfi/Swmn/yw/3sUiZfS8a8jfprYMrq2E63HWYN5lLqF2qDxevl/vWX+eErjr2l0tr1Jej3e5eXJoB/5lkn8v/zxPOVG0179fpQT8uwh4WoQ9+zZPCbDF8v36qLeqI9/zlOC9K5jmKSeQ9RLEt+weaO1gP6T63I+zuaZ/X8i3tQM/KSePozQnvU9pRvFwg7DvR730v8o01pgfpYw+71uvX0f+pymln1qmaS8D/LH8+zGNWuuo/7byUV3Lvm0pa5by3Nuv42WS3zKN/0c8grDvR52M+5JprDGfpUwwzpP8maa3yqL1/tmdX93YpbRymVLffkq7O71O08riR5pyUb3L9b99HBRwt6lt0FzX1N82+pxl9W7Rfb7ta416346yegNUnfdYZPUmrM+x2oY7GNn3Y0oj+0WaTpr/ShP4L9JM6lZ1cnEfded3aVaw/JZxjvBnKaP5P5Z//rb8eH2QcJzyuj1LeZ7vUq6ggJ5NaWRf16zXZlqvcvM2/dPs/xb99TXqY7M+mt/UiXSWEvjt9hZPfSABgzeVsK+Nzuqdtu0bfS5SRqmHKrPUeYJa9hiLWVbvoj3PbvcGHGW1vYXSDvRoCmHfbonQfjtLNyPOGpjnGU/dfpFmNH+ZpnzzEG+y2r203ToZ6Ejd5HtMI85dHOVmy4EP6a6scJImMMfS/6U9Sb3raP4u66Wd2joZ6EhtKPbUdv5Z7+9SQ77LMsIiTbloDK/vLE2voEMNANZX7XyNej50ol6qj2XUuUm7/NDu2Nh1X/R2nb7PJmvbWi/bHPr1Os5qPf9jlHbgYGote4xLAW9zkpsdFmvfli61R/RjqNOvH2+Xr1e7nv9U7kWAwTnO05mcfZv+R/PJar37LMMPr3bQ93UFsojAh4OqyxE/9n0gj7BeZ66h1XVgdFHv3rchBH37WNqBr44Pe1RXilynLA8cm3pHbHvlSB8h0XW9ex+GFPTVIqt1fEs0nyjtEvpRV0c8S9Pqd5OLlPYKXXd7rB06Fyl15bqD0lXKVUofo+mTNKH0Lc3E45AtUlYqzZL8leGtFHqT0pohKa/l73kapUaWhH1/2oG/i9oK+Cz7n+StzbXmafrS3+ZTSlh1Pck8Swn5GpR/pdyzMIbJ7g8prYmHGPTVIuU4n6f8jMdwtcSWhH2/Ftn+F6q2A9715PBYV8v39fv+mc19Wg5hnlKfX+Tm1n1j8DPlZNVuBjdEX1Ne498zrteXDYT9+BxldTu7fTtLuYy/SBNK31OCqq8AOE6Z36hlm5MMOzDX1XmOHxl2n5p6nFdRt4fJqbfb91W/bS/vPM04Q6i2xxj6SLn+rMewqgnYo9qw7TLdj0jbd8Ne53FNwfo2hvYYszQrhYZ89QEcQF3a2HWN/ihN8Fxk/G0lxhCidUmwFTgwMfXmr66XNL7OuO6G3UZ9PkNWT+xDvvoA9myeZjTa1Q1TdbXNtjszjcnQw77uEXyRp3FyBbZUR/X72At2k7rPaj25XObp3bY/5LCvvZqeUhdWYEs17A89un6Z1Y6ZXfe+78pQw759BTfmCXDggQ4d9us7WXW1VWFfhhr29WfQxRUcMECHCvt5Vneyusg0JgSHGPbq9MDew36e1ZujLvf42GMwtLBXpweSNGH/2E0tjjKMvvd9G1LYq9MD/zdL6T3zkMCfpewctb4n7VOdfN3GkMJenR5YsUvgz1NW1rzP6uqai5SrhKmN5NcNJezfR51+snS95D6zlJUyz1OCf300WNsurwfHl5QJQKPHogb9P9Jf7/2TNDujDb3NMtCD9gj/rrfLlGB/k+mWau5zlvI69bUZSLvJ2RRWP3GLX/o+AAav3tF622TeRZr+99ztNMmvKWHfx9VO3QvgU4bfZhlgtBYpo+rvPXzvusyyjzbVAJNzme7XtbfLN5ZZAnSgj12g6uobPeoBOlJLOV21jVa+AehJ+87kQ1K+AejZRQ7fPrq2qFC+AehJ3cT9OqU53L4p3wAMRN3c+zql5fO+Whco3wAMzCLNcsyf2c+STOUbgAGqvYfqKP/VIx6rXi0o3wAMVN01qt5l+3LHr1+kKd/01X8HgC0cp1mps0vot4Ne3xuAkTjJ5tC/bf8AQQ8wQreF/tvc3AFM0AM8Aeuh394/4I/YMJwt2akKxuEkpXxzGrtMAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0In/AZFlR8TVsNgCAAAAAElFTkSuQmCC"


data = Base64.decode64(b64png_img)
tempfile = Tempfile.new("filename")
tempfile.binmode
tempfile.write(data)
tempfile.rewind
content_type = `file --mime -b #{tempfile.path}`.split(";")[0] # image/png

file = ActionDispatch::Http::UploadedFile.new(
  tempfile: tempfile,
  type: content_type,
  filename: "filename"
)

file = ImageProcessing::MiniMagick.source(tempfile.path).then { |builder|
  if ENV["ERROR"]
    builder
  else
    builder.convert(content_type)
  end
}.resize_to_limit(4096, 4096).call

new_content_type = `file --mime -b #{file.path}`.split(";")[0]

raise "content type changed from #{content_type} to #{new_content_type}" if content_type != new_content_type
```

Hence my bet is that we could actually change the way the extension is handled in `#minimagick!`:

1. ensure the `ImageProcessing` pipeline (a.k.a builder) contains a `.convert(file.content_type)`
2. check change not by using the extension, but the actual builder option, which is more reliable (ex: if some file did not have an extension)

# TODO

I had planned to open this as an issue first. Since I am not 100% sure that the lead here suits you, I'd rather discuss it first. Discuss the fact that this is likely to be a breaking change. And only then implement what is left:

- [ ] document the `#minimagick!` method according to the changes
- [ ] add tests
- [ ] decide what to do about the _backwards compatibility_ block
- [ ] add changelog entry