### PR TITLE
Support ssrf_filter 1.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup ImageMagick policy
       run: sudo sh -c 'echo '\''<policymap><policy domain="coder" rights="read|write" pattern="PDF" /></policymap>'\'' > /etc/ImageMagick-6/policy.xml'
+    - name: Update package list
+      run: sudo apt update
     - name: Install ghostscript to process PDF
       run: sudo apt-get -y install ghostscript
     - name: Install libvips-dev for Carrierwave::Vips

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,7 @@ source "https://rubygems.org"
 gem "activemodel-serializers-xml"
 gem 'sqlite3', platforms: :ruby
 gem "activerecord-jdbcsqlite3-adapter", platform: [:jruby, :truffleruby]
+# See https://github.com/fog/fog-google/issues/535 for this restriction.
+gem "fog-google", "~> 1.13.0" if RUBY_VERSION.to_f < 2.6
 
 gemspec

--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -46,5 +46,4 @@ Gem::Specification.new do |s|
   if RUBY_ENGINE != 'jruby'
     s.add_development_dependency "pry-byebug"
   end
-  s.add_development_dependency "ssrf_filter", "< 1.1.0"
 end

--- a/lib/carrierwave/downloader/base.rb
+++ b/lib/carrierwave/downloader/base.rb
@@ -30,8 +30,12 @@ module CarrierWave
             response = OpenURI.open_uri(process_uri(url.to_s), headers)
           else
             request = nil
-            response = SsrfFilter.get(uri, headers: headers) do |req|
-              request = req
+            if ::SsrfFilter::VERSION.to_f < 1.1
+              response = SsrfFilter.get(uri, headers: headers) do |req|
+                request = req
+              end
+            else
+              response = SsrfFilter.get(uri, headers: headers, request_proc: ->(req) { request = req })
             end
             response.uri = request.uri
             response.value


### PR DESCRIPTION
Includes a backwards compatibility mode for SsrfFilter 1.0,
which is needed for Ruby 2.5 and JRuby 9.2.

Also includes a local version constraint for fog-google for
Ruby 2.5 and JRuby 9.2 because of a known but undeclared
incompatibility in that gem.

[Fixes #2625]