### PR TITLE
Raise DownloadError when no content is returned

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup ImageMagick policy
       run: sudo sh -c 'echo '\''<policymap><policy domain="coder" rights="read|write" pattern="PDF" /></policymap>'\'' > /etc/ImageMagick-6/policy.xml'
+    - name: Update package list
+      run: sudo apt update
     - name: Install ghostscript to process PDF
       run: sudo apt-get -y install ghostscript
     - name: Install libvips-dev for Carrierwave::Vips

--- a/lib/carrierwave/downloader/remote_file.rb
+++ b/lib/carrierwave/downloader/remote_file.rb
@@ -8,7 +8,10 @@ module CarrierWave
         when String
           @file = StringIO.new(file)
         when Net::HTTPResponse
-          @file = StringIO.new(file.body)
+          body = file.body
+          raise CarrierWave::DownloadError, 'could not download file: No Content' if body.nil?
+
+          @file = StringIO.new(body)
           @content_type = file.content_type
           @headers = file
           @uri = file.uri

--- a/spec/downloader/remote_file_spec.rb
+++ b/spec/downloader/remote_file_spec.rb
@@ -26,6 +26,23 @@ describe CarrierWave::Downloader::RemoteFile do
     end
   end
 
+  { 
+    '204' => Net::HTTPNoContent, 
+    '205' => Net::HTTPResetContent
+  }.each do |response_code, response_class|
+    context "with a #{response_class} instance" do
+      let!(:file) do
+        response_class.new('1.0', response_code, '').tap do |response|
+          response.reading_body(StringIO.new, true) {}
+        end
+      end
+
+      it 'raises CarrierWave::DownloadError' do
+        expect { subject }.to raise_error(CarrierWave::DownloadError, 'could not download file: No Content')
+      end
+    end
+  end
+
   context 'with OpenURI::Meta instance' do
     let(:file) do
       File.open(file_path("test.jpg")).tap { |f| OpenURI::Meta.init(f) }.tap do |file|


### PR DESCRIPTION
Have RemoteFile raise CarrierWave::DownloadError when the HTTP response is of a type that has no content, according to the standards. In those cases, response.body returns nil.

There are 8 response types that have no body, 4 of which we can get, so just check whether the body was nil.

Fixes #2632