### PR TITLE
chore: minor refactor from select first to detect

### DIFF
--- a/lib/carrierwave/uploader/processing.rb
+++ b/lib/carrierwave/uploader/processing.rb
@@ -62,7 +62,7 @@ module CarrierWave
             hash.merge!(arg)
           end
 
-          condition_type = new_processors.keys.select { |key| [:if, :unless].include?(key) }[0]
+          condition_type = new_processors.keys.detect { |key| [:if, :unless].include?(key) }
           condition = new_processors.delete(:if) || new_processors.delete(:unless)
           new_processors.each do |processor, processor_args|
             self.processors += [[processor, processor_args, condition, condition_type]]


### PR DESCRIPTION
Minor refactor to use performant `Array#detect` vs `Array#select[0]`

```zsh
Warming up --------------------------------------
Enumerable#select.first
                        17.450k i/100ms
   Enumerable#detect    78.375k i/100ms
Calculating -------------------------------------
Enumerable#select.first
                        173.654k (± 2.9%) i/s -      3.473M in  20.016201s
   Enumerable#detect    788.926k (± 0.6%) i/s -     15.832M in  20.068122s

Comparison:
   Enumerable#detect:   788926.2 i/s
Enumerable#select.first:   173654.0 i/s - 4.54x  (± 0.00) slower

```

Test Code

```ruby
require 'benchmark/ips'

ARRAY = [*1..100]

def slow
  ARRAY.select { |x| x.eql?(15) }.first
end

def fast
  ARRAY.detect { |x| x.eql?(15) }
end

Benchmark.ips(20) do |x|
  x.report('Enumerable#select.first') { slow }
  x.report('Enumerable#detect') { fast }
  x.compare!
end 
```
source: https://github.com/fastruby/fast-ruby/blob/main/code/enumerable/select-first-vs-detect.rb