### PR TITLE
Local storage clean_cache! fix for off-topic files

### DIFF
--- a/lib/carrierwave/storage/file.rb
+++ b/lib/carrierwave/storage/file.rb
@@ -111,8 +111,9 @@ module CarrierWave
       def clean_cache!(seconds)
         Dir.glob(::File.expand_path(::File.join(uploader.cache_dir, '*'), CarrierWave.root)).each do |dir|
           # generate_cache_id returns key formatted TIMEINT-PID(-COUNTER)-RND
-          time = dir.scan(/(\d+)-\d+-\d+(?:-\d+)?/).first.map(&:to_i)
-          time = Time.at(*time)
+          matched = dir.scan(/(\d+)-\d+-\d+(?:-\d+)?/).first
+          next unless matched
+          time = Time.at(matched[0].to_i)
           if time < (Time.now.utc - seconds)
             FileUtils.rm_rf(dir)
           end

--- a/spec/storage/file_spec.rb
+++ b/spec/storage/file_spec.rb
@@ -101,5 +101,18 @@ describe CarrierWave::Storage::File do
 
       expect(Dir.glob("#{cache_dir}/*").size).to eq(0)
     end
+
+    context "when a file which does not conform to the cache_id format exists" do
+      before do
+        FileUtils.touch File.expand_path("invalid", cache_dir)
+      end
+
+      it "should just ignore that" do
+        Timecop.freeze(today) { uploader_class.clean_cached_files!(0) }
+
+        expect(Dir.glob("#{cache_dir}/*").size).to eq(1)
+        expect(File).to exist("#{cache_dir}/invalid")
+      end
+    end
   end
 end


### PR DESCRIPTION
Given that it is not advised to put other stuff in the same directory as CarrierWave's cache, this fix makes clean_cache! not break if you do.

Based on the similar fix for the Fog storage clean_cache!.