### PR TITLE
Enable to override configurations by 'false' on a per-uploader basis

### DIFF
--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -124,7 +124,7 @@ module CarrierWave
             @#{name} = nil
 
             def self.#{name}(value=nil)
-              @#{name} = value if value
+              @#{name} = value unless value.nil?
               return @#{name} if self.object_id == #{self.object_id} || defined?(@#{name})
               name = superclass.#{name}
               return nil if name.nil? && !instance_variable_defined?(:@#{name})

--- a/spec/uploader/configuration_spec.rb
+++ b/spec/uploader/configuration_spec.rb
@@ -116,11 +116,11 @@ describe CarrierWave::Uploader::Base do
     end
 
     it "adds a convenient in-class setter" do
-      uploader_class.foo_bar('bar')
-      expect(uploader_class.foo_bar).to eq('bar')
+      expect(uploader_class.foo_bar).to eq('foo')
+    end
 
-      uploader_class.foo_bar(false)
-      expect(uploader_class.foo_bar).to eq(false)
+    it "adds a convenient in-class setter which can assign 'false' as a value" do
+      expect { uploader_class.foo_bar(false) }.to change { uploader_class.foo_bar }.from('foo').to(false)
     end
 
     ['foo', :foo, 45, ['foo', :bar]].each do |val|

--- a/spec/uploader/configuration_spec.rb
+++ b/spec/uploader/configuration_spec.rb
@@ -116,7 +116,11 @@ describe CarrierWave::Uploader::Base do
     end
 
     it "adds a convenient in-class setter" do
-      expect(uploader_class.foo_bar).to eq('foo')
+      uploader_class.foo_bar('bar')
+      expect(uploader_class.foo_bar).to eq('bar')
+
+      uploader_class.foo_bar(false)
+      expect(uploader_class.foo_bar).to eq(false)
     end
 
     ['foo', :foo, 45, ['foo', :bar]].each do |val|


### PR DESCRIPTION
## motivation

- fixes #2417
- Currently, it's not possible to set `false` to some boolean values (e.g. `fog_public`) via in-class configuring.
- There are some workarounds already, but it would be more convenient and intuitive.
    - [How to: Define different storage configuration for each Uploader.](https://github.com/carrierwaveuploader/carrierwave/wiki/How-to:-Define-different-storage-configuration-for-each-Uploader.)
    - [How to: Secure uploaded file in S3 and make it only accessible by supplying secret token?](https://github.com/carrierwaveuploader/carrierwave/wiki/How-to:-Secure-uploaded-file-in-S3-and-make-it-only-accessible-by-supplying-secret-token%3F)

## step to reproduce

In `config/initializers/carrierwave.rb` :

```ruby
CarrierWave.configure do |config|
  config.fog_public = true
  ...
end
```

and `avatar_uploader.rb` :

```ruby
class AvatarUploader < CarrierWave::Uploader::Base
  fog_public false
end
```

## expected behavior

```ruby
AvatarUploader.fog_public # => false
```

## actual behavior

```ruby
AvatarUploader.fog_public # => true
```