### PR TITLE
Fix Ruby 2.7 deprecation warning on Mounter#remove?

### DIFF
--- a/lib/carrierwave/mounter.rb
+++ b/lib/carrierwave/mounter.rb
@@ -110,7 +110,7 @@ module CarrierWave
     end
 
     def remove?
-      remove.present? && remove !~ /\A0|false$\z/
+      remove.present? && (remove == true || remove !~ /\A0|false$\z/)
     end
 
     def remove!


### PR DESCRIPTION
We're currently working on our Ruby 2.7 to 3.0 upgrade and we're testing with deprecation warnings enabled on Ruby 2.7. Most of the warnings we've seen have been related to keyword arguments, but there was a different one coming from Carrierwave:

```
.../carrierwave-1.3.2/lib/carrierwave/mounter.rb:113: warning: deprecated Object#=~ is called on TrueClass; it always returns nil
```

This PR aims to silence that warning with no change in behaviour on any version of Ruby.

Unfortunately I wasn't able to get the tests running in my M1 Mac development environment. It looks like the project has GitHub actions set up so hopefully that will work ok 😄 

Sorry we're still on 1.x 😰 Many thanks to all the maintainers 🙏 