### PR TITLE
Fix dup with multiple mounters or not cached

### DIFF
--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -93,12 +93,10 @@ module CarrierWave
 
         # Reset cached mounter on record dup
         def initialize_dup(other)
-          old_mounters = @_mounters
-          @_mounters = nil
+          old_uploaders = _mounter(:"#{column}").uploaders
+          @_mounters[:"#{column}"] = nil
           super
-          old_mounters.each do |column, mounter|
-            _mounter(:#{column}).cache(mounter.uploaders)
-          end
+          _mounter(:"#{column}").cache(old_uploaders)
         end
       RUBY
     end

--- a/spec/processing/rmagick_spec.rb
+++ b/spec/processing/rmagick_spec.rb
@@ -235,7 +235,9 @@ describe CarrierWave::RMagick, :rmagick => true do
 
     it 'does not allow invocation of non-public methods' do
       Kernel.module_eval do
-        private def foo=(value); raise; end
+      private
+
+        def foo=(value); raise; end
       end
       expect do
         instance.manipulate! :read => {


### PR DESCRIPTION
- Don't call `each` if `@_mounters` is unitialized or nil. It will be nil for calls to later mounters, or if not referenced or saved.
- Don't interpolate `column` when it should be a local variable.
- Don't define global functions in specs. Make them local to the block.
- Cover more missing scenarios.
- Fix some rubocop failures.

[Fixes #1962]