### PR TITLE
Support to configure download retry wait time

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,12 +529,13 @@ disable CarrierWave's `validate_download` option, you'll need to handle those
 errors yourself.
 
 ### Retry option for download from remote location
-If you want to retry the download from the Remote URL, enable the download_retry_count option, an error occurs during download, it will try to execute the specified number of times every 5 second.
+If you want to retry the download from the Remote URL, enable the download_retry_count option, an error occurs during download, it will try to execute the specified number of times.
 This option is effective when the remote destination is unstable.
 
 ```rb
 CarrierWave.configure do |config|
   config.download_retry_count = 3 # Default 0
+  config.download_retry_wait_time = 3 # Default 5
 end
 ```
 

--- a/lib/carrierwave/downloader/base.rb
+++ b/lib/carrierwave/downloader/base.rb
@@ -45,7 +45,7 @@ module CarrierWave
         rescue StandardError => e
           if @current_download_retry_count < @uploader.download_retry_count
             @current_download_retry_count += 1
-            sleep 5
+            sleep @uploader.download_retry_wait_time
             retry
           else
             raise CarrierWave::DownloadError, "could not download file: #{e.message}"

--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -45,6 +45,7 @@ module CarrierWave
         add_config :mount_on
         add_config :cache_only
         add_config :download_retry_count
+        add_config :download_retry_wait_time
 
         # set default values
         reset_config
@@ -212,6 +213,7 @@ module CarrierWave
             config.enable_processing = true
             config.ensure_multipart_form = true
             config.download_retry_count = 0
+            config.download_retry_wait_time = 5
           end
         end
       end

--- a/spec/downloader/base_spec.rb
+++ b/spec/downloader/base_spec.rb
@@ -142,14 +142,19 @@ describe CarrierWave::Downloader::Base do
     let(:instance) { described_class.new(uploader) }
     subject { instance.download uri }
     context 'when download_retry_count == 0 ' do
-      before { uploader.download_retry_count = 0 }
+      before do
+        uploader.download_retry_count = 0
+      end
       it 'throws an exception' do
         expect { subject }.to raise_error CarrierWave::DownloadError
       end
     end
 
     context 'when download_retry_count > 0' do
-      before { uploader.download_retry_count = 1 }
+      before do
+        uploader.download_retry_count = 1
+        uploader.download_retry_wait_time = 0.01
+      end
       it 'does not throw an exception' do
         expect { subject }.not_to raise_error
       end


### PR DESCRIPTION
https://github.com/carrierwaveuploader/carrierwave/pull/2577 is good change that I wanted.
I'll add a config for download retry wait time.

Since the appropriate wait time depends on the each of the remote server, it is better to be able to configure the wait time on the application side.