### PR TITLE
Add Ruby 3.2 to CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
           bundler-cache: true
       - name: Run check
         run: bundle exec rubocop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,9 @@ jobs:
             gemfile: gemfiles/rails-7-0.gemfile
             experimental: false
           - ruby: '3.2'
+            gemfile: gemfiles/rails-7-0.gemfile
+            experimental: false
+          - ruby: '3.2'
             gemfile: gemfiles/rails-main.gemfile
             experimental: false
           - ruby: ruby-head

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           - ruby: '3.0'
             gemfile: gemfiles/rails-7-0.gemfile
             experimental: false
-          - ruby: '3.1'
+          - ruby: '3.2'
             gemfile: gemfiles/rails-main.gemfile
             experimental: false
           - ruby: ruby-head


### PR DESCRIPTION
Ruby 3.2.0 has been released.
https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/