### PR TITLE
Added dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
How about using dependabot in this way?
When this works, a PullRequest is created as follows:
- ruby/bigdecimal#242

It was created with reference to the following:
- ruby/csv#265