### PR TITLE
Change the year of the license to the first publication date only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1105,7 +1105,7 @@ See [CONTRIBUTING.md](https://github.com/carrierwaveuploader/carrierwave/blob/ma
 
 The MIT License (MIT)
 
-Copyright (c) 2008-2015 Jonas Nicklas
+Copyright (c) 2008 Jonas Nicklas
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
This PR change the year of the license to the first publication date only.
