### PR TITLE
Fix #clean_cache! to delete cache dirs under uploader root

### DIFF
--- a/lib/carrierwave/storage/file.rb
+++ b/lib/carrierwave/storage/file.rb
@@ -109,7 +109,7 @@ module CarrierWave
       end
 
       def clean_cache!(seconds)
-        Dir.glob(::File.expand_path(::File.join(uploader.cache_dir, '*'), CarrierWave.root)).each do |dir|
+        Dir.glob(::File.expand_path(::File.join(uploader.cache_dir, '*'), uploader.root)).each do |dir|
           # generate_cache_id returns key formatted TIMEINT-PID(-COUNTER)-RND
           matched = dir.scan(/(\d+)-\d+-\d+(?:-\d+)?/).first
           next unless matched


### PR DESCRIPTION
CarrierWave::Storage::File#clean_cache! can't delete cache direcotries if the uploader's root has changed.
This PR fix it.

[Fixes #2113]