### PR TITLE
Bugfix: fix Kernel#=~ removal in Ruby 3.2

### DIFF
--- a/lib/carrierwave/mounter.rb
+++ b/lib/carrierwave/mounter.rb
@@ -116,7 +116,7 @@ module CarrierWave
     end
 
     def remove?
-      remove.present? && (remove == true || remove !~ /\A0|false$\z/)
+      remove.present? && (remove == true || remove.to_s !~ /\A0|false$\z/)
     end
 
     def remove!


### PR DESCRIPTION
Since the release of Ruby 3.2 `Kernel#=~` has been removed. Which that `IntegerClass`, `FalseClass` doesn't respond to `def =~` anymore. 

![Screenshot 2023-01-23 at 16 10 18](https://user-images.githubusercontent.com/1116942/214075084-e9895a47-22fd-4fc5-9558-bca5d5e1508c.png)
![Screenshot 2023-01-23 at 16 10 09](https://user-images.githubusercontent.com/1116942/214075092-4c523a72-3f11-452f-b50e-5778ae3c336b.png)

Since the String class still respond to it we could infer `remove` to a string and keep the same check than before. I'm open a more complicated solution which check all types: `Numeric`, `FalseClass` and `String`