### PR TITLE
Better error message for restrictive imagemagick security policies

### DIFF
--- a/lib/carrierwave/locale/en.yml
+++ b/lib/carrierwave/locale/en.yml
@@ -9,5 +9,6 @@ en:
       content_type_allowlist_error: "You are not allowed to upload %{content_type} files, allowed types: %{allowed_types}"
       content_type_denylist_error: "You are not allowed to upload %{content_type} files"
       processing_error: "Failed to manipulate, maybe it is not an image?"
+      rmagick_error_security_policy: "Failed to manipulate due to imagemagick's security policy for this filetype"
       min_size_error: "File size should be greater than %{min_size}"
       max_size_error: "File size should be less than %{max_size}"

--- a/lib/carrierwave/processing/rmagick.rb
+++ b/lib/carrierwave/processing/rmagick.rb
@@ -366,8 +366,12 @@ module CarrierWave
       end
 
       destroy_image(frames)
-    rescue ::Magick::ImageMagickError
-      raise CarrierWave::ProcessingError, I18n.translate(:"errors.messages.processing_error")
+    rescue ::Magick::ImageMagickError => e
+      if e.message.match?(/attempt to perform an operation not allowed by the security policy|error\/constitute.c\/IsCoderAuthorized\/408/)
+        raise CarrierWave::ProcessingError, I18n.translate(:"errors.messages.rmagick_error_security_policy")
+      else
+        raise CarrierWave::ProcessingError, I18n.translate(:"errors.messages.processing_error")
+      end
     end
 
   private

--- a/spec/processing/rmagick_spec.rb
+++ b/spec/processing/rmagick_spec.rb
@@ -333,6 +333,15 @@ describe CarrierWave::RMagick, :rmagick => true do
         end
       end
 
+      context "Imagemagick security policy" do
+        before do
+          allow(::Magick::Image).to receive(:read).and_raise(Magick::ImageMagickError, message: "attempt to perform an operation not allowed by the security policy `PDF' @ error/constitute.c/IsCoderAuthorized/408")
+        end
+        it "catches error message" do
+          expect {instance.manipulate!{|f, i| nil } }.to raise_exception(CarrierWave::ProcessingError, /^Failed to manipulate due to imagemagick's security policy for this filetype/)
+        end
+      end
+
       it "doesn't suppress errors when translation is unavailable" do
         change_locale_and_store_translations(:foo, {}) do
           expect { instance.resize_to_limit(200, 200) }.to raise_exception( CarrierWave::ProcessingError )


### PR DESCRIPTION
I stumbled across this problem when I moved the development on my local machine into a docker container and the original error message pushing the blame on my PDF wasn't helpful at all. I do understand the change a few years ago to not show any details from the original error message, but this was painful. https://github.com/carrierwaveuploader/carrierwave/commit/7af7db3636f79a811e0f4f5da32de50042994493

Some info about the imagemagick security policy can be found here https://imagemagick.org/script/security-policy.php and in this blogpost https://alexvanderbist.com/2018/fixing-imagick-error-unauthorized/

The error message I added will point anyone into the right direction. I had a bit of a trouble with the test, hope it is good enough