### PR TITLE
Handle assignments in an ActiveModel::Dirty-friendly way

### DIFF
--- a/lib/carrierwave/uploader/proxy.rb
+++ b/lib/carrierwave/uploader/proxy.rb
@@ -34,6 +34,19 @@ module CarrierWave
       end
 
       ##
+      # Returns a String which is to be used as a temporary value which gets assigned to the column.
+      # The purpose is to mark the column that it will be updated. Finally before the save it will be
+      # overwritten by the #identifier value, which is usually #filename.
+      #
+      # === Returns
+      #
+      # [String] a temporary_identifier, by default @original_filename is used
+      #
+      def temporary_identifier
+        @original_filename || @identifier
+      end
+
+      ##
       # Read the contents of the file
       #
       # === Returns

--- a/spec/mount_multiple_spec.rb
+++ b/spec/mount_multiple_spec.rb
@@ -195,8 +195,7 @@ describe CarrierWave::Mount do
 
       it "does nothing when an empty string is assigned" do
         expect(instance).not_to receive(:write_uploader)
-
-        instance.images = [test_file_stub]
+        instance.images = ''
       end
 
       it "accepts another uploader instances" do
@@ -1086,8 +1085,8 @@ describe CarrierWave::Mount do
 
     describe '#write_images_identifier' do
       it "writes to the given column" do
-        expect(instance).to receive(:write_uploader).with(:monkey, [test_file_name])
         instance.images = [test_file_stub]
+        expect(instance).to receive(:write_uploader).with(:monkey, [test_file_name])
         instance.write_images_identifier
       end
 

--- a/spec/mount_single_spec.rb
+++ b/spec/mount_single_spec.rb
@@ -135,14 +135,14 @@ describe CarrierWave::Mount do
         expect(@instance.image.current_path).to match(/^#{public_path('uploads/tmp')}/)
       end
 
-      it "should do nothing when nil is assigned" do
-        expect(@instance).not_to receive(:write_uploader)
+      it "should not change the attribute when nil is assigned" do
+        expect(@instance).to receive(:write_uploader).with(:image, nil)
         @instance.image = nil
       end
 
-      it "should do nothing when an empty string is assigned" do
-        expect(@instance).not_to receive(:write_uploader)
-        @instance.image = stub_file('test.jpg')
+      it "should not change the attribute when an empty string is assigned" do
+        expect(@instance).to receive(:write_uploader).with(:image, nil)
+        @instance.image = ''
       end
 
       it "should fail silently if the image fails an allowlist integrity check" do
@@ -589,8 +589,8 @@ describe CarrierWave::Mount do
 
     describe '#write_image_identifier' do
       it "should write to the column" do
-        expect(@instance).to receive(:write_uploader).with(:image, "test.jpg")
         @instance.image = stub_file('test.jpg')
+        expect(@instance).to receive(:write_uploader).with(:image, "test.jpg")
         @instance.write_image_identifier
       end
 
@@ -819,8 +819,8 @@ describe CarrierWave::Mount do
 
     describe '#write_image_identifier' do
       it "should write to the given column" do
-        expect(@instance).to receive(:write_uploader).with(:monkey, "test.jpg")
         @instance.image = stub_file('test.jpg')
+        expect(@instance).to receive(:write_uploader).with(:monkey, "test.jpg")
         @instance.write_image_identifier
       end
 

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -511,6 +511,11 @@ describe CarrierWave::ActiveRecord do
     end
 
     describe "remove_image=" do
+      before do
+        @event.image = stub_file('test.jpeg')
+        @event.save!
+      end
+
       it "should mark the image as changed if changed" do
         expect(@event.image_changed?).to be_falsey
         expect(@event.remove_image).to be_nil
@@ -612,6 +617,22 @@ describe CarrierWave::ActiveRecord do
         expect(File.exist?(public_path('uploads/test.jpeg'))).to be_falsey
       end
 
+    end
+
+    describe '#changes' do
+      it "should be generated" do
+        @event.image = stub_file('test.jpeg')
+        expect(@event.changes).to eq({'image' => [nil, 'test.jpeg']})
+      end
+
+      it "shouldn't be generated when the attribute value is unchanged" do
+        @event.image = stub_file('test.jpeg')
+        @event.save!
+        @event.image = @event[:image]
+        expect(@event).not_to be_changed
+        @event.remote_image_url = ""
+        expect(@event).not_to be_changed
+      end
     end
 
     describe 'with overriddent filename' do
@@ -1352,6 +1373,11 @@ describe CarrierWave::ActiveRecord do
     end
 
     describe "remove_images=" do
+      before do
+        @event.images = [stub_file('test.jpeg')]
+        @event.save!
+      end
+
       it "should mark the images as changed if changed" do
         expect(@event.images_changed?).to be_falsey
         expect(@event.remove_images).to be_nil
@@ -1455,6 +1481,22 @@ describe CarrierWave::ActiveRecord do
         expect(File.exist?(public_path('uploads/test.jpeg'))).to be_falsey
       end
 
+    end
+
+    describe '#changes' do
+      it "should be generated" do
+        @event.images = [stub_file('test.jpeg')]
+        expect(@event.changes).to eq({'images' => [nil, ['test.jpeg']]})
+      end
+
+      it "shouldn't be generated when the attribute value is unchanged" do
+        @event.images = [stub_file('test.jpeg')]
+        @event.save!
+        @event.images = @event[:images]
+        expect(@event).not_to be_changed
+        @event.remote_images_urls = [""]
+        expect(@event).not_to be_changed
+      end
     end
 
     describe 'with overriddent filename' do


### PR DESCRIPTION
This is a proposal for solving ActiveModel::Dirty related issues.
Previously saving an attachment takes following process:

- On attachment assignment: does not assign the attribute value but call `#{column}_will_change!`
- Before save: assign identifier as the attribute value

After this PR, it will be like:

- On attachment assignment: assign temporary identifier as the attribute value (this marks the column as changed, so we don't need to call `#{column}_will_change!`)
- Before save: assign the true identifier as the attribute value

The reason for introducing the idea of _temporary identifier_ is that there are the cases we can't determine the identifier on the attachment assignment - an identifier is made from the filename, but filename [can be overridden to reference another attribute in the model](https://github.com/carrierwaveuploader/carrierwave/blob/5f00715747d44dd7f57ee990a6b471ed786ac764/spec/orm/activerecord_spec.rb#L773-L775) and in this case we can't determine the final filename until the record is saved (i.e. that column can be assigned after the attachment assignment). 

Doing this allows us to reflect `#changes` correctly, resulting in fixing #2404. Also not needing to call `#{column}_will_change!` fixes #2409 and #2468, as empty changes will no longer be picked up.

Any feedback would be appreciated, thanks.