### PR TITLE
[BREAKING CHANGE] Use the resulting file extension on changing format by :convert

### DIFF
--- a/lib/carrierwave/uploader/cache.rb
+++ b/lib/carrierwave/uploader/cache.rb
@@ -103,7 +103,7 @@ module CarrierWave
       # [String] a cache name, in the format TIMEINT-PID-COUNTER-RND/filename.txt
       #
       def cache_name
-        File.join(cache_id, full_original_filename) if cache_id && original_filename
+        File.join(cache_id, original_filename) if cache_id && original_filename
       end
 
       ##
@@ -166,7 +166,7 @@ module CarrierWave
           self.cache_id, self.original_filename = cache_name.to_s.split('/', 2)
           @staged = true
           @filename = original_filename
-          @file = cache_storage.retrieve_from_cache!(full_filename(original_filename))
+          @file = cache_storage.retrieve_from_cache!(full_original_filename)
         end
       end
 
@@ -181,7 +181,7 @@ module CarrierWave
       #
       # [String] the cache path
       #
-      def cache_path(for_file=full_filename(original_filename))
+      def cache_path(for_file=full_original_filename)
         File.join(*[cache_dir, @cache_id, for_file].compact)
       end
 
@@ -197,9 +197,6 @@ module CarrierWave
 
       attr_reader :original_filename
 
-      # We can override the full_original_filename method in other modules
-      alias_method :full_original_filename, :original_filename
-
       def cache_id=(cache_id)
         # Earlier version used 3 part cache_id. Thus we should allow for
         # the cache_id to have both 3 part and 4 part formats.
@@ -214,6 +211,11 @@ module CarrierWave
 
       def cache_storage
         @cache_storage ||= (self.class.cache_storage || self.class.storage).new(self)
+      end
+
+      # We can override the full_original_filename method in other modules
+      def full_original_filename
+        forcing_extension(original_filename)
       end
     end # Cache
   end # Uploader

--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -24,6 +24,7 @@ module CarrierWave
         add_config :move_to_store
         add_config :remove_previously_stored_files_after_update
         add_config :downloader
+        add_config :force_extension
 
         # fog
         add_deprecated_config :fog_provider
@@ -202,6 +203,7 @@ module CarrierWave
             config.move_to_store = false
             config.remove_previously_stored_files_after_update = true
             config.downloader = CarrierWave::Downloader::Base
+            config.force_extension = false
             config.ignore_integrity_errors = true
             config.ignore_processing_errors = true
             config.ignore_download_errors = true

--- a/lib/carrierwave/uploader/processing.rb
+++ b/lib/carrierwave/uploader/processing.rb
@@ -66,6 +66,11 @@ module CarrierWave
           condition = new_processors.delete(:if) || new_processors.delete(:unless)
           new_processors.each do |processor, processor_args|
             self.processors += [[processor, processor_args, condition, condition_type]]
+
+            if processor == :convert
+              # Treat :convert specially, since it should trigger the file extension change
+              force_extension processor_args
+            end
           end
         end
       end # ClassMethods
@@ -106,6 +111,15 @@ module CarrierWave
         end
       end
 
+    private
+
+      def forcing_extension(filename)
+        if force_extension && filename
+          Pathname.new(filename).sub_ext(".#{force_extension.to_s.delete_prefix('.')}").to_s
+        else
+          filename
+        end
+      end
     end # Processing
   end # Uploader
 end # CarrierWave

--- a/lib/carrierwave/uploader/store.rb
+++ b/lib/carrierwave/uploader/store.rb
@@ -92,7 +92,7 @@ module CarrierWave
     private
 
       def full_filename(for_file)
-        for_file
+        forcing_extension(for_file)
       end
 
       def storage

--- a/spec/processing/rmagick_spec.rb
+++ b/spec/processing/rmagick_spec.rb
@@ -348,4 +348,39 @@ describe CarrierWave::RMagick, :rmagick => true do
       end
     end
   end
+
+  describe "when working with frames" do
+    before do
+      def instance.cover
+        manipulate! { |frame, index| frame if index.zero? }
+      end
+
+      klass.send :include, CarrierWave::RMagick
+    end
+
+    after { instance.instance_eval { undef cover } }
+
+    context "with a multi-page PDF" do
+      before { instance.cache! File.open(file_path("multi_page.pdf")) }
+
+      it "successfully processes" do
+        klass.process :convert => 'jpg'
+        instance.process!
+      end
+
+      it "supports page specific transformations" do
+        klass.process :cover
+        instance.process!
+      end
+    end
+
+    context "with a simple image" do
+      before { instance.cache! File.open(file_path("portrait.jpg")) }
+
+      it "allows page specific transformations" do
+        klass.process :cover
+        instance.process!
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Overview

With the current implementation, CarrierWave does not handle change of the file extension on converting a file. Suppose you have

```ruby
class MyUploader < CarrierWave::Uploader::Base
  include CarrierWave::MiniMagick
  process convert: :png
end
```

and upload a JPEG file named `test.jpg`, you'll get a PNG format file with the filename of `test.jpg`. This is often not what users want, as they expect the file extension also changes. The existing solution was to override `#filename` to set the desired extension, as suggested like [this](https://stackoverflow.com/a/70703162).

```ruby
class MyUploader < CarrierWave::Uploader::Base
  include CarrierWave::MiniMagick
  process convert: :png
  def filename
    super.chomp(File.extname(super)) + '.png' if original_filename.present?
  end
end
```

But even with this the cache file is still created with the original file extension, which differs with the actual format of the cached file. (#2254)

Furthermore, if we combine this with versions the situation gets worse, because there're several counterintuitive interactions between setting filename and version creation. (#2125, #2126)

This PR tries to solve those issues by performing extension change based on what is provided for `:convert`. That means just uploading `test.jpg` to this uploader:

```ruby
class MyUploader < CarrierWave::Uploader::Base
  include CarrierWave::MiniMagick
  process convert: :png
end
```

you'll get `test.png`.

## Incompatibilities

As this modification comes with the change of filename, some incompatibilities arise with pre-3.x implementations. We'll explore 2 scenarios here.

### Cache file retrieval issue

If your uploader performs a format conversion on the uploader itself (not within a version), the file extension of the cached file will change. That means if you serve both CarrierWave 2.x and 3.x simultaneously on the same workload (e.g. using blue-green deployment), a cache file stored by 2.x can't be retrieved by 3.x and vice versa.
So when a user tries to upload `test.jpg` and the first request goes to 2.x which results in a validation error (the file will be stored with the name `test.jpg`), then the user fixes the validation error and the next request reaches 3.x, the uploader will look for `test.png` but it's not there. This results in the file not being stored at all.

To avoid this situation, I recommend minimizing the co-existence of CarrierWave 2.x and 3.x. Doing a canary deployment might be acceptable if you keep the ratio high enough (i.e. if you have many 2.x application processes and very small 3.x), the majority of requests will go to 2.x process and handled consistently. Also make the co-existing situation short enough before switching over everything to 3.x.

Another option will be keeping the old behavior only for caching by doing:

```ruby
class MyUploader < CarrierWave::Uploader::Base
  include CarrierWave::MiniMagick
  process convert: :png
  alias_method :full_original_filename, :original_filename
end
```

### Stored version file retrieval issue

Another issue is versioning. With CarrierWave 2.x, when uploading a file `test.jpg` using an uploader like this

```ruby
class MyUploader < CarrierWave::Uploader::Base
  include CarrierWave::MiniMagick
  version :thumb do
    process convert: :png
  end
end
```

the version `thumb` will have the filename of `test.jpg` (though its format is in PNG). But with 3.x, it will be `test.png`.
If you have existing applications doing this, many version files should have been stored based on the old way. Switching over to new way results in unable to retrieve stored version files, as it will look for the new location.

The solution is either to preserve the old behavior by

```ruby
class MyUploader < CarrierWave::Uploader::Base
  include CarrierWave::MiniMagick
  version :thumb do
    process convert: :png
    force_extension false
  end
end
```

or performing [version recreation](https://github.com/carrierwaveuploader/carrierwave#recreating-versions) to create the files in new locations.

Please note that if you're setting `#full_filename` explicitly like

```ruby
class MyUploader < CarrierWave::Uploader::Base
  include CarrierWave::MiniMagick
  version :thumb do
    process convert: :png
    def full_filename(for_file)
      'thumb.png'
    end
  end
end
```

then you won't be affected by this issue, as the overridden `#full_filename` takes precedence.