### PR TITLE
Use helper method to access fog_provider

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -198,12 +198,12 @@ module CarrierWave
         # [NilClass] no authenticated url available
         #
         def authenticated_url(options = {})
-          if ['AWS', 'Google', 'Rackspace', 'OpenStack', 'AzureRM', 'Aliyun', 'backblaze'].include?(@uploader.fog_credentials[:provider])
+          if ['AWS', 'Google', 'Rackspace', 'OpenStack', 'AzureRM', 'Aliyun', 'backblaze'].include?(fog_provider)
             # avoid a get by using local references
             local_directory = connection.directories.new(:key => @uploader.fog_directory)
             local_file = local_directory.files.new(:key => path)
             expire_at = options[:expire_at] || ::Fog::Time.now.since(@uploader.fog_authenticated_url_expiration.to_i)
-            case @uploader.fog_credentials[:provider]
+            case fog_provider
             when 'AWS', 'Google'
               # Older versions of fog-google do not support options as a parameter
               if url_options_supported?(local_file)


### PR DESCRIPTION
Replaces instances of: `@uploader.fog_credentials[:provider]` with it's helper method: `fog_provider`

This proves to be helpful for me because I am trying to build my own Fog provider. In many scenarios, my provider behaves like AWS and in some scenarios it behaves like Google.

Having the ability to monkeypatch a single method: `CarrierWave::Storage::Fog#fog_provider` cleans up my implementation greatly.