### PR TITLE
remove deprecated configuration from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,7 +840,6 @@ Please read the [fog-google README](https://github.com/fog/fog-google/blob/maste
 For Google Storage JSON API (recommended):
 ```ruby
 CarrierWave.configure do |config|
-    config.fog_provider = 'fog/google'
     config.fog_credentials = {
         provider:               'Google',
         google_project:         'my-project',
@@ -854,7 +853,6 @@ end
 For Google Storage XML API:
 ```ruby
 CarrierWave.configure do |config|
-    config.fog_provider = 'fog/google'
     config.fog_credentials = {
         provider:                         'Google',
         google_storage_access_key_id:     'xxxxxx',


### PR DESCRIPTION
I've set up a project with carrierwave and fog-google [following the README](https://github.com/carrierwaveuploader/carrierwave/blob/master/README.md#using-google-cloud-storage). And got a deprecation warning message.

```ruby
DEPRECATION WARNING: #fog_provider is deprecated and has no effect (called from block in <main> at /Users/cou929/Desktop/ws-fog/test_carrierwave/config/initializers/carrierwave.rb:4)
```

```ruby
# config/initializers/carrierwave.rb

CarrierWave.configure do |config|
    config.fog_provider = 'fog/google'
    config.fog_credentials = {
        provider:               'Google',
        google_project:         'my-project',
        google_json_key_string: 'xxxxxx'
        # or use google_json_key_location if using an actual file
    }
    config.fog_directory = 'google_cloud_storage_bucket_name'
end
```

It seems that the `config.fog_provider` [was already deprecated ](https://github.com/carrierwaveuploader/carrierwave/commit/ca201ee2ceebe2d916be3bc1396fe381cc93afd7) but [came back to README after that](https://github.com/carrierwaveuploader/carrierwave/pull/2502/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R816).