### PR TITLE
Mention that size_range is in bytes

### DIFF
--- a/lib/carrierwave/uploader/file_size.rb
+++ b/lib/carrierwave/uploader/file_size.rb
@@ -14,7 +14,7 @@ module CarrierWave
       # are allowed to be uploaded.
       # === Returns
       #
-      # [NilClass, Range] a size range which are permitted to be uploaded
+      # [NilClass, Range] a size range (in bytes) which are permitted to be uploaded
       #
       # === Examples
       #


### PR DESCRIPTION
This seems to be the case empirically when I tried using it.