### PR TITLE
[backport] fix: ruby 2.7 kwarg warning in uploader process

### DIFF
--- a/lib/carrierwave/uploader/processing.rb
+++ b/lib/carrierwave/uploader/processing.rb
@@ -80,7 +80,17 @@ module CarrierWave
                 next unless self.send(condition, new_file)
               end
             end
-            self.send(method, *args)
+
+            if args.is_a? Array
+              kwargs, args = args.partition { |arg| arg.is_a? Hash }
+            end
+
+            if kwargs.present?
+              kwargs = kwargs.reduce(:merge)
+              self.send(method, *args, **kwargs)
+            else
+              self.send(method, *args)
+            end
           end
         end
       end

--- a/spec/uploader/processing_spec.rb
+++ b/spec/uploader/processing_spec.rb
@@ -86,6 +86,15 @@ describe CarrierWave::Uploader do
       uploader.process!("test.jpg")
     end
 
+    context "when there are additional method key word arguments" do
+      it "calls the processor if the condition method returns true" do
+        uploader_class.process :resize => [200, 300, combine_options: { quality: 70 }], :if => :true?
+        expect(uploader).to receive(:true?).with("test.jpg").once.and_return(true)
+        expect(uploader).to receive(:resize).with(200, 300, combine_options: { quality: 70 })
+        uploader.process!("test.jpg")
+      end
+    end
+
     context "when using RMagick", :rmagick => true do
       before do
         def uploader.cover


### PR DESCRIPTION
As mentioned in https://github.com/carrierwaveuploader/carrierwave/pull/2636#issuecomment-1437791368, I just cherry-picked the commit to the `2.x-stable` branch and created a new PR to backport it.

Can you please release a new 2.x version with this fix? I'm trying to upgrade to ruby 3.x, but the current stable 2.x version doesn't work with ruby 3.x and there is no stable release yet for carrierwave 3.x.