### PR TITLE
Mention `libvips` in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 CarrierWave thrives on a large number of [contributors](https://github.com/carrierwaveuploader/carrierwave/contributors),
 and pull requests are very welcome. Before submitting a pull request, please make sure that your changes are well tested.
 
-First, make sure you have `imagemagick` and `ghostscript` installed. You may need `libmagic` as well.
+First, make sure you have `imagemagick`, `ghostscript` and `libvips` installed. You may need `libmagic` as well.
 
 Then, you'll need to install the gem dependencies:
 


### PR DESCRIPTION
Since #2500, `libvips` is required to run tests.