### PR TITLE
Fix a `NoMethodError` when a record is rollbacked

### DIFF
--- a/lib/carrierwave/mounter.rb
+++ b/lib/carrierwave/mounter.rb
@@ -202,7 +202,7 @@ module CarrierWave
     end
 
     def remove_added
-      current_paths = (@removed_uploaders + @uploaders.select(&:staged)).map(&:path)
+      current_paths = (@removed_uploaders + uploaders.select(&:staged)).map(&:path)
       @added_uploaders
         .reject {|uploader| current_paths.include?(uploader.path) }
         .each { |uploader| uploader.remove! }

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -947,6 +947,18 @@ describe CarrierWave::ActiveRecord do
       expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
     end
 
+    it 'should not remove a file if transaction is rollback' do
+      @event.image = stub_file('new.jpeg')
+      @event.save
+
+      Event.transaction do
+        @event.destroy
+        raise ActiveRecord::Rollback
+      end
+
+      expect(File.exist?(public_path('uploads/new.jpeg'))).to be_truthy
+    end
+
     it "should clear @added_uploaders on commit" do
       # Simulate the commit behavior, since we're using the transactional fixture
       @event.run_callbacks(:commit) do


### PR DESCRIPTION
Since v3.0.0, Carrierwave raises `NoMethodError` when a record is rollbacked if uploaders methods don't call at all.

```
NoMethodError:
  private method `select' called for nil:NilClass

    current_paths = (@removed_uploaders + @uploaders.select(&:staged)).map(&:path)
```

This attempts to fix that error and makes work correctly.