### PR TITLE
Persist deduplicated filename with ActiveRecord

### DIFF
--- a/lib/carrierwave/mount.rb
+++ b/lib/carrierwave/mount.rb
@@ -426,6 +426,11 @@ module CarrierWave
       #
       def write_uploader(column, identifier); end
 
+      ##
+      # overwrite this to persist a serialized attribute
+      #
+      def persist_uploader(column, identifier); end
+
     private
 
       def _mounter(column)

--- a/lib/carrierwave/mounter.rb
+++ b/lib/carrierwave/mounter.rb
@@ -142,7 +142,10 @@ module CarrierWave
       additions, remains = uploaders.partition(&:cached?)
       existing_paths = (@removed_uploaders + remains).map(&:store_path)
       additions.each do |uploader|
-        uploader.deduplicate(existing_paths)
+        if uploader.deduplicate(existing_paths)
+          persist_identifier
+        end
+
         uploader.store!
         existing_paths << uploader.store_path
       end
@@ -154,6 +157,10 @@ module CarrierWave
 
       clear! if remove?
       record.write_uploader(serialization_column, identifier)
+    end
+
+    def persist_identifier
+      record.persist_uploader(serialization_column, identifier)
     end
 
     def urls(*args)

--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -22,7 +22,7 @@ module CarrierWave
       validates_processing_of column if uploader_option(column.to_sym, :validate_processing)
       validates_download_of column if uploader_option(column.to_sym, :validate_download)
 
-      after_save :"store_#{column}!"
+      before_save :"store_#{column}!"
       before_save :"write_#{column}_identifier"
       after_commit :"remove_#{column}!", :on => :destroy
       after_commit :"mark_remove_#{column}_false", :on => :update

--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -13,8 +13,10 @@ module CarrierWave
 
       alias_method :read_uploader, :read_attribute
       alias_method :write_uploader, :write_attribute
+      alias_method :persist_uploader, :update_column
       public :read_uploader
       public :write_uploader
+      public :persist_uploader
 
       include CarrierWave::Validations::ActiveModel
 
@@ -22,7 +24,7 @@ module CarrierWave
       validates_processing_of column if uploader_option(column.to_sym, :validate_processing)
       validates_download_of column if uploader_option(column.to_sym, :validate_download)
 
-      before_save :"store_#{column}!"
+      after_save :"store_#{column}!"
       before_save :"write_#{column}_identifier"
       after_commit :"remove_#{column}!", :on => :destroy
       after_commit :"mark_remove_#{column}_false", :on => :update

--- a/lib/carrierwave/uploader/store.rb
+++ b/lib/carrierwave/uploader/store.rb
@@ -125,6 +125,8 @@ module CarrierWave
           @deduplication_index = i
           break unless current_paths.include?(store_path)
         end
+
+        true
       end
 
     private

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -775,6 +775,8 @@ describe CarrierWave::ActiveRecord do
         expect(@event.save).to be_truthy
         expect(@event.image.current_path).to eq public_path('uploads/old(2).jpeg')
         expect(File.exist?(public_path('uploads/old.jpeg'))).to be_falsey
+        @event.reload
+        expect(@event.image.current_path).to eq public_path('uploads/old(2).jpeg')
       end
 
       it "should not remove file if validations fail on save" do


### PR DESCRIPTION
I noticed an issue that when using ActiveRecord and trying to update the mounted file with a different file of the same name it is deduplicated logically but that change is not persisted, resulting in `current_path` or `url` pointing to the "old" filename which does not exist (cause it was deleted). So deduplication works but it's not persisted. There was a spec for this case but in spec record was not reloaded (dirty) so it passed. Spec failure before code changes:

```
Failures:

  1) CarrierWave::ActiveRecord#mount_uploader removing old files normally should give a different name to new file and remove the old file
     Failure/Error: expect(@event.image.current_path).to eq public_path('uploads/old(2).jpeg')
     
       expected: "/Users/krasnoukhov/Projects/Simplepractice/carrierwave/spec/public/uploads/old(2).jpeg"
            got: "/Users/krasnoukhov/Projects/Simplepractice/carrierwave/spec/public/uploads/old.jpeg"
     
       (compared using ==)
     # ./spec/orm/activerecord_spec.rb:779:in `block (4 levels) in <top (required)>'
```

Changing to `before_save` makes `write_identifier` also kick in before record is persisted which makes issue go away. Not sure if `before_save` can have other complications, but it seems like it's working... The alternative would be to move this `deduplicate` call to happen before save:

https://github.com/carrierwaveuploader/carrierwave/blob/478eccc3cdf955406266f57027fb367f47b64c38/lib/carrierwave/mounter.rb#L145

Another alternative would be to perform another save after store.