### PR TITLE
Fix deduplicated filename not being persisted

### DIFF
--- a/lib/carrierwave/uploader/store.rb
+++ b/lib/carrierwave/uploader/store.rb
@@ -108,22 +108,22 @@ module CarrierWave
       end
 
       ##
-      # Look for a store path which doesn't collide with the given already-stored paths.
+      # Look for an identifier which doesn't collide with the given already-stored identifiers.
       # It is done by adding a index number as the suffix.
       # For example, if there's 'image.jpg' and the @deduplication_index is set to 2,
       # The stored file will be named as 'image(2).jpg'.
       #
       # === Parameters
       #
-      # [current_paths (Array[String])] List of paths for already-stored files
+      # [current_identifiers (Array[String])] List of identifiers for already-stored files
       #
-      def deduplicate(current_paths)
+      def deduplicate(current_identifiers)
         @deduplication_index = nil
-        return unless current_paths.include?(store_path)
+        return unless current_identifiers.include?(identifier)
 
-        (1..current_paths.size + 1).each do |i|
+        (1..current_identifiers.size + 1).each do |i|
           @deduplication_index = i
-          break unless current_paths.include?(store_path)
+          break unless current_identifiers.include?(identifier)
         end
       end
 

--- a/spec/mount_multiple_spec.rb
+++ b/spec/mount_multiple_spec.rb
@@ -368,6 +368,7 @@ describe CarrierWave::Mount do
 
           it "renames the latter file to avoid filename duplication" do
             instance.images = ['bork.txt', File.open(tmp_path('bork.txt'))]
+            instance.write_images_identifier
             instance.store_images!
             expect(instance.images.map(&:identifier)).to eq ['bork.txt', 'bork(2).txt']
             expect(instance.images[0].read).not_to eq instance.images[1].read

--- a/spec/mount_single_spec.rb
+++ b/spec/mount_single_spec.rb
@@ -404,7 +404,7 @@ describe CarrierWave::Mount do
         expect(@instance.image.current_path).to eq(public_path('uploads/test.jpg'))
       end
 
-      context "when adding a file which has the same filename with the exsting one" do
+      context "when adding a file which has the same filename with the existing one" do
         before { FileUtils.cp(file_path('bork.txt'), tmp_path('test.jpg')) }
         after { FileUtils.rm(tmp_path('test.jpg')) }
 
@@ -414,6 +414,7 @@ describe CarrierWave::Mount do
           old_uploader = @instance.image
 
           @instance.image = File.open(tmp_path('test.jpg'))
+          @instance.write_image_identifier
           @instance.store_image!
           expect(@instance.image.identifier).to eq 'test(2).jpg'
           expect(old_uploader.read).to eq 'this is stuff'

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -777,6 +777,13 @@ describe CarrierWave::ActiveRecord do
         expect(File.exist?(public_path('uploads/old.jpeg'))).to be_falsey
       end
 
+      it "should persist the deduplicated filename" do
+        @event.image = stub_file('old.jpeg')
+        expect(@event.save).to be_truthy
+        @event.reload
+        expect(@event.image.current_path).to eq public_path('uploads/old(2).jpeg')
+      end
+
       it "should not remove file if validations fail on save" do
         Event.validate { |r| r.errors.add :textfile, "FAIL!" }
         @event.image = stub_file('new.jpeg')
@@ -1679,6 +1686,13 @@ describe CarrierWave::ActiveRecord do
         @event.images = [stub_file('old.jpeg')]
         expect(@event.save).to be_truthy
         expect(File.exist?(public_path('uploads/old.jpeg'))).to be_falsey
+        expect(@event.images[0].current_path).to eq public_path('uploads/old(2).jpeg')
+      end
+
+      it "should persist the deduplicated filename" do
+        @event.images = [stub_file('old.jpeg')]
+        expect(@event.save).to be_truthy
+        @event.reload
         expect(@event.images[0].current_path).to eq public_path('uploads/old(2).jpeg')
       end
 

--- a/spec/uploader/store_spec.rb
+++ b/spec/uploader/store_spec.rb
@@ -415,23 +415,23 @@ describe CarrierWave::Uploader do
     end
 
     it "tries to find a non-duplicate filename" do
-      @uploader.deduplicate(['uploads/test.jpg'])
+      @uploader.deduplicate(['test.jpg'])
       expect(@uploader.deduplicated_filename).to eq('test(2).jpg')
     end
 
     it "does nothing when filename doesn't collide" do
-      @uploader.deduplicate(['uploads/file.jpg'])
+      @uploader.deduplicate(['file.jpg'])
       expect(@uploader.deduplicated_filename).to eq('test.jpg')
     end
 
     it "chooses the first non-colliding name" do
-      @uploader.deduplicate(['uploads/test.jpg', 'uploads/test(2).jpg', 'uploads/test(4).jpg'])
+      @uploader.deduplicate(['test.jpg', 'test(2).jpg', 'test(4).jpg'])
       expect(@uploader.deduplicated_filename).to eq('test(3).jpg')
     end
 
     it "resets the deduplication index value from the previous attempt" do
-      @uploader.deduplicate(['uploads/test.jpg'])
-      @uploader.deduplicate(['uploads/test.png'])
+      @uploader.deduplicate(['test.jpg'])
+      @uploader.deduplicate(['test.png'])
       expect(@uploader.deduplicated_filename).to eq('test.jpg')
     end
 


### PR DESCRIPTION
I'm sorry that the deduplication feature introduced in the 3.0 release is completely broken, as reported by #2677. This PR is another attempt to fix it.

The approach is to move the deduplication logic from #store! to `#write_identifier`, which is invoked on before_save thus allowing the modified filename(identifier) to be persisted. To work around the limitation that the deduplication timing can't be made earlier because `#store_dir` relies on the model's id, the scope of deduplication was narrowed down only to filename, instead of whole `#store_path`. This sometimes can lead to unnecessary deduplication in a case like a user decided to use a custom `#store_dir` to handle deduplication by their own, but even if that happens it does not harm data consistency, so I think it's acceptable.

@krasnoukhov I want your opinion on this, what do you think?