### PR TITLE
delete duplicate tests

### DIFF
--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -904,16 +904,6 @@ describe CarrierWave::ActiveRecord do
       end
       expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
     end
-
-    it 'should remove new file if transaction is rollback' do
-      Event.transaction do
-        @event.image = stub_file('new.jpeg')
-        @event.save
-        expect(File.exist?(public_path('uploads/new.jpeg'))).to be_truthy
-        raise ActiveRecord::Rollback
-      end
-      expect(File.exist?(public_path('uploads/new.jpeg'))).to be_falsey
-    end
   end
 
   describe "#mount_uploader into transaction" do


### PR DESCRIPTION
I was reading carrierwave codebase and noticed that this test is a complete duplicate of 
https://github.com/carrierwaveuploader/carrierwave/blob/d339c275f49de70547c2e5e6145e72fdfdc6379a/spec/orm/activerecord_spec.rb#L879-L887

confirmed that it was added in this commit https://github.com/carrierwaveuploader/carrierwave/commit/8d98ecd19c043b32c97f7745790def0051de94f8 and seems safe to delete



