### PR TITLE
Fix mounter cache duplication on dup

### DIFF
--- a/lib/carrierwave/mount.rb
+++ b/lib/carrierwave/mount.rb
@@ -428,6 +428,11 @@ module CarrierWave
 
     private
 
+      def initialize_dup(other)
+        @_mounters = @_mounters.dup
+        super
+      end
+
       def _mounter(column)
         # We cannot memoize in frozen objects :(
         return Mounter.build(self, column) if frozen?

--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -43,6 +43,7 @@ module CarrierWave
         # Reset cached mounter on record dup
         def initialize_dup(other)
           old_uploaders = _mounter(:"#{column}").uploaders
+          @_mounters =  @_mounters.dup
           @_mounters[:"#{column}"] = nil
           super
           # The attribute needs to be cleared to prevent it from picked up as identifier

--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -43,7 +43,6 @@ module CarrierWave
         # Reset cached mounter on record dup
         def initialize_dup(other)
           old_uploaders = _mounter(:"#{column}").uploaders
-          @_mounters =  @_mounters.dup
           @_mounters[:"#{column}"] = nil
           super
           # The attribute needs to be cleared to prevent it from picked up as identifier

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -2004,10 +2004,12 @@ describe CarrierWave::ActiveRecord do
         @event.image = stub_file('test.jpeg')
         expect(@event.save).to be_truthy
         expect(@event.image.current_path).to eq public_path("uploads/event/image/#{@event.id}/test.jpeg")
-        new_event = @event.dup
 
+        new_event = @event.dup
         expect(new_event).not_to be @event
         expect(new_event.image.model).to be new_event
+        expect(@event.image.current_path).to eq public_path("uploads/event/image/#{@event.id}/test.jpeg")
+
         expect(@event.save).to be_truthy
         expect(@event.image.current_path).to eq public_path("uploads/event/image/#{@event.id}/test.jpeg")
       end

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -1991,6 +1991,28 @@ describe CarrierWave::ActiveRecord do
       end
     end
 
+    context 'with store_dir using model attributes' do
+      before do
+        @uploader.class_eval do
+          def store_dir
+            "uploads/#{model.class.name.downcase}/#{mounted_as}/#{model.id}"
+          end
+        end
+      end
+
+      it "wont affect the duplicated object's saved path" do
+        @event.image = stub_file('test.jpeg')
+        expect(@event.save).to be_truthy
+        expect(@event.image.current_path).to eq public_path("uploads/event/image/#{@event.id}/test.jpeg")
+        new_event = @event.dup
+
+        expect(new_event).not_to be @event
+        expect(new_event.image.model).to be new_event
+        expect(@event.save).to be_truthy
+        expect(@event.image.current_path).to eq public_path("uploads/event/image/#{@event.id}/test.jpeg")
+      end
+    end
+
     context 'when #initialize_dup is overridden in the model' do
       before do
         Event.class_eval do


### PR DESCRIPTION
Added a failing test for https://github.com/carrierwaveuploader/carrierwave/issues/2689

duplication should not affect the duplicated objects path.

*Updated*

And now fixes https://github.com/carrierwaveuploader/carrierwave/issues/2689 