### PR TITLE
fix: call #dup would raise MissingAttributeError while putting :mount_on in options

### DIFF
--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -46,7 +46,7 @@ module CarrierWave
           @_mounters[:"#{column}"] = nil
           super
           # The attribute needs to be cleared to prevent it from picked up as identifier
-          write_attribute(:"#{column}", nil)
+          write_attribute(_mounter(:#{column}).serialization_column, nil)
           _mounter(:"#{column}").cache(old_uploaders)
         end
 

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -2005,6 +2005,17 @@ describe CarrierWave::ActiveRecord do
         expect(@event.dup.image.model).not_to eq @event
       end
     end
+
+    context ':mount_on in options' do
+      before { Event.mount_uploader(:image_v2, @uploader, mount_on: :image) }
+      it do
+        @event.image_v2 = stub_file('test.jpeg')
+        @event.save
+        new_event = @event.dup
+        expect(new_event).not_to be @event
+        expect(new_event.image_v2.model).to be new_event
+      end
+    end
   end
 
   describe 'when set as a nested attribute' do


### PR DESCRIPTION
If use :mount_on option and call #dup, it would raise `ActiveModel::MissingAttributeError`

```ruby
class Attachment < ::ApplicationRecord
  mount_uploader(:file, FileUploader, mount_on: :stored_filename)
end

attachment.dup
```

Got error:

```
ActiveModel::MissingAttributeError:
       can't write unknown attribute `file`
```