### PR TITLE
add skip_ssrf_protection config

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,7 +659,7 @@ end
 ## Testing with CarrierWave
 
 It's a good idea to test your uploaders in isolation. In order to speed up your
-tests, it's recommended to switch off processing in your tests, and to use the
+tests, it's recommended to switch off processing in your tests, disable SSRF protection, and to use the
 file storage. In Rails you could do that by adding an initializer with:
 
 ```ruby
@@ -667,6 +667,7 @@ if Rails.env.test? or Rails.env.cucumber?
   CarrierWave.configure do |config|
     config.storage = :file
     config.enable_processing = false
+    config.skip_ssrf_protection = true
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -659,7 +659,11 @@ end
 ## Testing with CarrierWave
 
 It's a good idea to test your uploaders in isolation. In order to speed up your
-tests, it's recommended to switch off processing in your tests, disable SSRF protection, and to use the
+tests, it's recommended to switch off processing in your tests, and to use the file storage.
+Also, you can disable SSRF protection at your own risk using the `skip_ssrf_protection` configuration.
+
+In Rails you could do that by adding an initializer with:
+
 file storage. In Rails you could do that by adding an initializer with:
 
 ```ruby

--- a/lib/carrierwave/downloader/base.rb
+++ b/lib/carrierwave/downloader/base.rb
@@ -94,7 +94,7 @@ module CarrierWave
       #     my_uploader.downloader = CarrierWave::Downloader::CustomDownloader
       #
       def skip_ssrf_protection?(uri)
-        false
+        @uploader.skip_ssrf_protection
       end
     end
   end

--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -47,6 +47,7 @@ module CarrierWave
         add_config :cache_only
         add_config :download_retry_count
         add_config :download_retry_wait_time
+        add_config :skip_ssrf_protection
 
         # set default values
         reset_config
@@ -216,6 +217,7 @@ module CarrierWave
             config.ensure_multipart_form = true
             config.download_retry_count = 0
             config.download_retry_wait_time = 5
+            config.skip_ssrf_protection = false
           end
         end
       end

--- a/spec/downloader/base_spec.rb
+++ b/spec/downloader/base_spec.rb
@@ -267,14 +267,27 @@ describe CarrierWave::Downloader::Base do
   end
 
   describe "#skip_ssrf_protection?" do
-    let(:uri) { 'http://localhost/test.jpg' }
-    before do
-      WebMock.stub_request(:get, uri).to_return(body: file)
-      allow(subject).to receive(:skip_ssrf_protection?).and_return(true)
+    context "when ssrf_protection is skipped" do
+      let(:uri) { 'http://localhost/test.jpg' }
+      before do
+        WebMock.stub_request(:get, uri).to_return(body: file)
+        allow(subject).to receive(:skip_ssrf_protection?).and_return(true)
+      end
+
+      it "allows local request to be made" do
+        expect(subject.download(uri).read).to eq 'this is stuff'
+      end
     end
 
-    it "allows local request to be made" do
-      expect(subject.download(uri).read).to eq 'this is stuff'
+    context 'skip_ssrf_protection configuration' do
+      it 'defaults to false' do
+        expect(subject.skip_ssrf_protection?(uri)).to be_falsey
+      end
+
+      it 'can be configured by skip_ssrf_protection config' do
+        uploader.skip_ssrf_protection = true
+        expect(subject.skip_ssrf_protection?(uri)).to be_truthy
+      end
     end
   end
 end


### PR DESCRIPTION
closes https://github.com/carrierwaveuploader/carrierwave/issues/2695

Looking at these issues, a lot of people are looking for a way to disable ssrf filter in testing.
https://github.com/carrierwaveuploader/carrierwave/issues/2695
https://github.com/arkadiyt/ssrf_filter/issues/33
https://github.com/arkadiyt/ssrf_filter/issues/59
https://github.com/carrierwaveuploader/carrierwave/issues/2573

I believe it might worth making `skip_ssrf_protection` configurable.