### PR TITLE
Test against Ruby 3.2 in CI for 1.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,15 @@ jobs:
             gemfile: gemfiles/rails-7-0.gemfile
             experimental: false
           - ruby: '3.1'
+            gemfile: gemfiles/rails-7-0.gemfile
+            experimental: false
+          - ruby: '3.1'
+            gemfile: gemfiles/rails-main.gemfile
+            experimental: false
+          - ruby: '3.2'
+            gemfile: gemfiles/rails-7-0.gemfile
+            experimental: false
+          - ruby: '3.2'
             gemfile: gemfiles/rails-main.gemfile
             experimental: false
         exclude:

--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -40,7 +40,11 @@ Gem::Specification.new do |s|
   s.add_development_dependency "fog-rackspace"
   s.add_development_dependency "mini_magick", ">= 3.6.0"
   if RUBY_ENGINE != 'jruby'
-    s.add_development_dependency "rmagick", "~> 2.16"
+    if RUBY_VERSION < '3.2'
+      s.add_development_dependency "rmagick", "~> 2.16"
+    else
+      s.add_development_dependency "rmagick", ">= 2.16"
+    end
   end
   s.add_development_dependency "timecop"
   s.add_development_dependency "generator_spec", ">= 0.9.1"

--- a/lib/carrierwave/processing/rmagick.rb
+++ b/lib/carrierwave/processing/rmagick.rb
@@ -228,7 +228,7 @@ module CarrierWave
       height = dimension_from height
       manipulate! do |img|
         img.resize_to_fit!(width, height)
-        new_img = ::Magick::Image.new(width, height) { self.background_color = background == :transparent ? 'rgba(255,255,255,0)' : background.to_s }
+        new_img = ::Magick::Image.new(width, height) { |img| img.background_color = background == :transparent ? 'rgba(255,255,255,0)' : background.to_s }
         if background == :transparent
           filled = new_img.matte_floodfill(1, 1)
         else


### PR DESCRIPTION
This PR targets the `1.x-stable` branch.

* Adding Ruby 3.2 for tests in CI.
* Use latest `rmagick` for Ruby 3.2 as `rmagick 2.16.0` calls the deprecated `rb_obj_tainted`
  * Also fix the usage for the newer `rmagick` version to use `::Magick::Image.new(width, height) { |img| img.background_color = ...}` pattern.

More context on why 1.x is still being used: https://github.com/carrierwaveuploader/carrierwave/pull/2640#issuecomment-1323532577.

Would also appreciate if the maintainer could release a new gem for 1.x 🙏 

