### PR TITLE
Fix dirty handling on update

### DIFF
--- a/lib/carrierwave/mounter.rb
+++ b/lib/carrierwave/mounter.rb
@@ -168,7 +168,7 @@ module CarrierWave
 
     def remove=(value)
       @remove = value
-      write_temporary_identifier if remove?
+      write_temporary_identifier
     end
 
     def remove?

--- a/lib/carrierwave/mounter.rb
+++ b/lib/carrierwave/mounter.rb
@@ -168,7 +168,7 @@ module CarrierWave
 
     def remove=(value)
       @remove = value
-      write_temporary_identifier
+      write_temporary_identifier if remove?
     end
 
     def remove?

--- a/lib/carrierwave/uploader/store.rb
+++ b/lib/carrierwave/uploader/store.rb
@@ -87,7 +87,7 @@ module CarrierWave
             end
             @file = new_file
             @identifier = storage.identifier
-            @cache_id = @deduplication_index = nil
+            @original_filename = @cache_id = @deduplication_index = nil
             @staged = false
           end
         end

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -689,6 +689,16 @@ describe CarrierWave::ActiveRecord do
           expect(@event.changes).to be_blank
           expect(@event).not_to be_changed
         end
+
+        it "shouldn't be generated when remove_image is canceled" do
+          @event.image = stub_file('test.jpeg')
+          @event.save!
+          @event.remove_image = true
+          @event.remove_image = false
+
+          expect(@event.changes).to be_blank
+          expect(@event).not_to be_changed
+        end
       end
     end
 

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -669,17 +669,6 @@ describe CarrierWave::ActiveRecord do
           expect(@event.changes).to eq({'image' => [nil, 'test.jpeg']})
         end
 
-        it "shouldn't be generated when the attribute value is unchanged" do
-          @event.image = stub_file('test.jpeg')
-          @event.save!
-          @event.image = @event[:image]
-
-          expect(@event.changes).to be_blank
-          expect(@event).not_to be_changed
-          @event.remote_image_url = ""
-          expect(@event).not_to be_changed
-        end
-
         it "shouldn't be generated after second save" do
           @event.image = stub_file('old.jpeg')
           @event.save!

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -426,6 +426,17 @@ describe CarrierWave::ActiveRecord do
         expect(@event.image_identifier).to eq(nil)
       end
 
+      it "should cancel removing image if remove_image is switched to false" do
+        @event.image = stub_file('test.jpeg')
+        @event.save!
+        @event.remove_image = true
+        @event.remove_image = false
+        @event.save!
+        @event.reload
+        expect(@event[:image]).to eq('test.jpeg')
+        expect(@event.image_identifier).to eq('test.jpeg')
+      end
+
       it "should mark image as changed when saving a new image" do
         expect(@event.image_changed?).to be_falsey
         @event.image = stub_file("test.jpeg")
@@ -1392,6 +1403,17 @@ describe CarrierWave::ActiveRecord do
         expect(@event.images).to be_empty
         expect(@event[:images]).to eq(nil)
         expect(@event.images_identifiers[0]).to eq(nil)
+      end
+
+      it "should cancel removing images if remove_images is switched to false" do
+        @event.images = [stub_file('test.jpeg')]
+        @event.save!
+        @event.remove_images = true
+        @event.remove_images = false
+        @event.save!
+        @event.reload
+        expect(@event[:images]).to eq(['test.jpeg'])
+        expect(@event.images_identifiers[0]).to eq('test.jpeg')
       end
 
       it "should mark images as changed when saving a new images" do


### PR DESCRIPTION
fixes https://github.com/carrierwaveuploader/carrierwave/issues/2702

`mark_remove_#{column}_false` is called after commit
https://github.com/rajyan/carrierwave/blob/e53c9c33674289ffabd8aa6ab3160e2ce60872dd/lib/carrierwave/mount.rb#L387-L389

which was the cause of this issue.
Changed to write a temporary identifier only if remove is changed to a truthy value.