### PR TITLE
Add config to disable ACL in fog storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ See `carrierwave/uploader/processing.rb` for details.
 ```ruby
 class MyUploader < CarrierWave::Uploader::Base
   process :scale => [200, 200], :if => :image?
-  
+
   def image?(carrier_wave_sanitized_file)
     true
   end
@@ -764,6 +764,7 @@ CarrierWave.configure do |config|
   config.fog_directory  = 'name_of_bucket'                                      # required
   config.fog_public     = false                                                 # optional, defaults to true
   config.fog_attributes = { cache_control: "public, max-age=#{365.days.to_i}" } # optional, defaults to {}
+  config.fog_acl        = false                                                 # optional, defaults to true
   # For an application which utilizes multiple servers but does not need caches persisted across requests,
   # uncomment the line :file instead of the default :storage.  Otherwise, it will use AWS as the temp cache store.
   # config.cache_storage = :file

--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -25,6 +25,7 @@ module CarrierWave
         add_config :remove_previously_stored_files_after_update
         add_config :downloader
         add_config :force_extension
+        add_config :fog_acl
 
         # fog
         add_deprecated_config :fog_provider
@@ -193,6 +194,7 @@ module CarrierWave
             config.fog_attributes = {}
             config.fog_credentials = {}
             config.fog_public = true
+            config.fog_acl = true
             config.fog_authenticated_url_expiration = 600
             config.fog_use_ssl_for_aws = true
             config.fog_aws_accelerate = false

--- a/spec/storage/fog_spec.rb
+++ b/spec/storage/fog_spec.rb
@@ -38,7 +38,12 @@ describe CarrierWave::Storage::Fog do
   end
 
   describe CarrierWave::Storage::Fog::File do
-    subject(:file) { CarrierWave::Storage::Fog::File.new(nil, nil, nil) }
+    subject(:file) { CarrierWave::Storage::Fog::File.new(uploader, base, path) }
+
+    let(:uploader) { instance_double(CarrierWave::Uploader::Base, fog_attributes: {some: :attribute}, fog_public: true, fog_acl: fog_acl, fog_credentials: {provider: 'AWS'}) }
+    let(:base) { instance_double(CarrierWave::Storage::Fog) }
+    let(:path) { 'path/to/file.txt' }
+    let(:fog_acl) { true }
 
     describe "#filename" do
       subject(:filename) { file.filename }
@@ -128,6 +133,94 @@ describe CarrierWave::Storage::Fog do
 
         it "return correct extension" do
           is_expected.to eq("")
+        end
+      end
+    end
+
+    describe '#store' do
+      subject(:store) { file.store(new_file) }
+
+      let(:fog_file) { double('Fog::File') }
+      let(:directory_files) { double('files', head: fog_file) }
+      let(:directory) { double('directory', files: directory_files) }
+      let(:fog_directory) { 'a-wonderful-fog-directory' }
+
+      before do
+        allow(uploader).to receive(:fog_directory).and_return(fog_directory)
+        connection = double('connection', directories: double('directories', new: directory))
+        allow(base).to receive(:connection).and_return(connection)
+      end
+
+      context 'when fog_acl is true' do
+        let(:fog_acl) { true }
+
+        context 'and new_file is a Fog::File' do
+          let(:new_file) { CarrierWave::Storage::Fog::File.new(uploader, base, path) }
+
+          it 'stores the file' do
+            expected_options = {some: :attribute, "x-amz-acl" => "public-read"}
+            expect(fog_file).to receive(:copy).with(fog_directory, path, expected_options)
+
+            expect(store).to be true
+          end
+        end
+
+        context 'and new_file is a SanitizedFile' do
+          let(:new_file) { CarrierWave::SanitizedFile.new(file_path('test.jpg')) }
+
+          before do
+            # stub this to always return the same value so that the equality comparison works
+            allow(new_file).to receive(:to_file).and_return(File.new(file_path('test.jpg')))
+          end
+
+          it 'stores the file' do
+            fog_create_file_params = {
+              body: new_file.to_file,
+              content_type: 'application/octet-stream',
+              key: path,
+              public: true,
+              some: :attribute
+            }
+            expect(directory_files).to receive(:create).with(fog_create_file_params)
+
+            expect(store).to be true
+          end
+        end
+      end
+
+      context 'when fog_acl is false' do
+        let(:fog_acl) { false }
+
+        context 'and new_file is a Fog::File' do
+          let(:new_file) { CarrierWave::Storage::Fog::File.new(uploader, base, path) }
+
+          it 'stores the file' do
+            expected_options = {some: :attribute}
+            expect(fog_file).to receive(:copy).with(fog_directory, path, expected_options)
+
+            expect(store).to be true
+          end
+        end
+
+        context 'and new_file is a SanitizedFile' do
+          let(:new_file) { CarrierWave::SanitizedFile.new(file_path('test.jpg')) }
+
+          before do
+            # stub this to always return the same value so that the equality comparison works
+            allow(new_file).to receive(:to_file).and_return(File.new(file_path('test.jpg')))
+          end
+
+          it 'stores the file' do
+            fog_create_file_params = {
+              body: new_file.to_file,
+              content_type: 'application/octet-stream',
+              key: path,
+              some: :attribute
+            }
+            expect(directory_files).to receive(:create).with(fog_create_file_params)
+
+            expect(store).to be true
+          end
         end
       end
     end


### PR DESCRIPTION
## Why?
AWS S3 used to use ACLs to control access to files. In recent times, AWS has moved away from this complicated permission model to one backed by the much-more-complicated (but widely used) IAM permission model. ACLs are now recommended against, and in fact new buckets created since April 2023 will have ACLs disabled by default.

This means that any upload to a newly-created bucket, and any upload to old buckets that have had ACLs disabled, will now fail with an error if the upload specifies an ACL.

CarrierWave _always_ specifies an ACL.

## Solution
Add a way to just not supply an ACL in the form of `config.fog_acl = false`. Since current versions of CarrierWave always specify an ACL, the default has been set to `true` to maintain backward compatibility, but since AWS now defaults to no ACL, the `README` has this value set to `false`.

Fixes #2664.

👀 I'm not familiar with Google's storage offering, but it appears they are in the same position according to #2634. However, I'm not sure if simply not setting Fog's `public` value is the right solution. If anyone who know's Google product can confirm, that'd be bananas.

## Attribution
I started with https://github.com/carrierwaveuploader/carrierwave/pull/2666. (Thank you @jalkoby!) However, it didn't cover every scenario. Please let me know if I should be doing something different to maintain attribution.

