### PR TITLE
Show warning if #filename is safeguarded as in the pre-3.x style

### DIFF
--- a/spec/uploader/store_spec.rb
+++ b/spec/uploader/store_spec.rb
@@ -247,6 +247,24 @@ describe CarrierWave::Uploader do
     end
   end
 
+  context "with a filename safeguarded by 'if original_filename'" do
+    before do
+      @uploader_class.class_eval do
+        def filename
+          "foo.jpg" if original_filename
+        end
+      end
+    end
+
+    it "shows warning on store only once" do
+      expect(@uploader).to receive(:warn).with(/Your uploader's #filename method .+ didn't return value/).once
+      @file = File.open(file_path('test.jpg'))
+      @uploader.store!(@file)
+      @file = File.open(file_path('bork.txt'))
+      @uploader.store!(@file)
+    end
+  end
+
   describe 'without a store dir' do
     before do
       @uploader_class.class_eval do


### PR DESCRIPTION
Context: https://github.com/carrierwaveuploader/carrierwave/issues/2708#issuecomment-1890328537

I'm not totally sure that this is side-effect-free (there can be a legitimate case for #filename not to return value?) , but at least it can be helpful to some people.
I want to hear your opinion.
@y-yagi @RachalCassity @rajyan @ryan-mcneil

Closes #2708, Refs. #2659