### PR TITLE
Use Marcel::Magic.new(content_type).extensions instead of Marcel::TYPES[content_type]

### DIFF
--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", ">= 6.0.0"
   s.add_dependency "activemodel", ">= 6.0.0"
   s.add_dependency "image_processing", "~> 1.1"
-  s.add_dependency "marcel", "~> 1.0.3"
+  s.add_dependency "marcel", "~> 1.0.0"
   s.add_dependency "addressable", "~> 2.6"
   s.add_dependency "ssrf_filter", "~> 1.0"
   s.add_development_dependency "csv", "~> 3.0"

--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", ">= 6.0.0"
   s.add_dependency "activemodel", ">= 6.0.0"
   s.add_dependency "image_processing", "~> 1.1"
-  s.add_dependency "marcel", "~> 1.0.0"
+  s.add_dependency "marcel", "~> 1.0.3"
   s.add_dependency "addressable", "~> 2.6"
   s.add_dependency "ssrf_filter", "~> 1.0"
   s.add_development_dependency "csv", "~> 3.0"

--- a/lib/carrierwave/downloader/remote_file.rb
+++ b/lib/carrierwave/downloader/remote_file.rb
@@ -33,9 +33,9 @@ module CarrierWave
 
       def original_filename
         filename = filename_from_header || filename_from_uri
-        mime_type = Marcel::TYPES[content_type]
-        unless File.extname(filename).present? || mime_type.blank?
-          extension = mime_type[0].first
+        extensions = Marcel::TYPE_EXTS[content_type]
+        unless File.extname(filename).present? || extensions.blank?
+          extension = extensions.first
           filename = "#{filename}.#{extension}"
         end
         filename

--- a/lib/carrierwave/downloader/remote_file.rb
+++ b/lib/carrierwave/downloader/remote_file.rb
@@ -33,7 +33,7 @@ module CarrierWave
 
       def original_filename
         filename = filename_from_header || filename_from_uri
-        extensions = Marcel::TYPE_EXTS[content_type]
+        extensions = Marcel::Magic.new(content_type).extensions
         unless File.extname(filename).present? || extensions.blank?
           extension = extensions.first
           filename = "#{filename}.#{extension}"

--- a/spec/processing/rmagick_spec.rb
+++ b/spec/processing/rmagick_spec.rb
@@ -255,7 +255,7 @@ describe CarrierWave::RMagick, :rmagick => true do
         instance.manipulate! :read => {
           :foo => "1"
         }
-      end.to raise_error NoMethodError, /private method `foo=' called/
+      end.to raise_error NoMethodError, /private method .foo=. called/
     end
   end
 


### PR DESCRIPTION
This [commit](https://github.com/rails/marcel/commit/e413daeffaed05d1e34b31e0ff1de95182d2d418) of the Marcel gem, which has just shipped in version 1.0.3, breaks Carrierwave as the `Marcel::TYPES` constant used [here](https://github.com/carrierwaveuploader/carrierwave/blob/ed8799191824a4d2762eb1028c01220102699377/lib/carrierwave/downloader/remote_file.rb#L36) has been removed.

This PR is to switch to using `Marcel::Magic.new(content_type).extensions` to return the extensions and not use constants.