### PR TITLE
bump image_processing version to avoid project being stuck on old version

### DIFF
--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", ">= 6.0.0"
   s.add_dependency "activemodel", ">= 6.0.0"
-  s.add_dependency "image_processing", "~> 1.1"
+  s.add_dependency "image_processing", "~> 1.12"
   s.add_dependency "marcel", "~> 1.0.0"
   s.add_dependency "addressable", "~> 2.6"
   s.add_dependency "ssrf_filter", "~> 1.0"


### PR DESCRIPTION
To resolve my app being stuck on 1.1, which is causing problems with 

```
Active Storage's ImageProcessing transformer doesn't support :combine_options, as it always generates a single ImageMagick command.`
```

https://github.com/rails/rails/issues/41322#issuecomment-899719446