### PR TITLE
Fix typos

### DIFF
--- a/spec/mount_multiple_spec.rb
+++ b/spec/mount_multiple_spec.rb
@@ -287,7 +287,7 @@ describe CarrierWave::Mount do
           expect(instance.images.map { |u| u.file.filename }).to eq ['test.jpg']
         end
 
-        context "when adding a file which has the same filename with the exsting one" do
+        context "when adding a file which has the same filename with the existing one" do
           before { FileUtils.cp(file_path('bork.json'), tmp_path('bork.txt')) }
           after { FileUtils.rm(tmp_path('bork.txt')) }
 
@@ -362,7 +362,7 @@ describe CarrierWave::Mount do
           expect(instance.images.map(&:identifier)).to eq ['bork.txt']
         end
 
-        context "when adding a file which has the same filename with the exsting one" do
+        context "when adding a file which has the same filename with the existing one" do
           before { FileUtils.cp(file_path('bork.json'), tmp_path('bork.txt')) }
           after { FileUtils.rm(tmp_path('bork.txt')) }
 

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -2125,7 +2125,7 @@ describe CarrierWave::ActiveRecord do
         end
       end
 
-      it "wont affect the duplicated object's saved path" do
+      it "won't affect the duplicated object's saved path" do
         @event.image = stub_file('test.jpeg')
         expect(@event.save).to be_truthy
         expect(@event.image.current_path).to eq public_path("uploads/event/image/#{@event.id}/test.jpeg")


### PR DESCRIPTION
Found via `codespell -S *.ai -L te,ser`