### PR TITLE
CI against Ruby 3.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.7', '3.0', '3.1', '3.2', jruby ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2', '3.3', jruby ]
         gemfile: [ gemfiles/rails-7-0.gemfile ]
         experimental: [ false ]
         include:
@@ -18,10 +18,10 @@ jobs:
           - ruby: '2.6'
             gemfile: gemfiles/rails-6-1.gemfile
             experimental: false
-          - ruby: '3.2'
+          - ruby: '3.3'
             gemfile: gemfiles/rails-7-1.gemfile
             experimental: false
-          - ruby: '3.2'
+          - ruby: '3.3'
             gemfile: gemfiles/rails-main.gemfile
             experimental: true
           - ruby: ruby-head


### PR DESCRIPTION
This PR adds Ruby 3.3 to the CI matrix to confirm `carrierwave` working with Ruby 3.3.