### PR TITLE
Change version constant naming pattern

### DIFF
--- a/lib/carrierwave/uploader/versions.rb
+++ b/lib/carrierwave/uploader/versions.rb
@@ -20,7 +20,7 @@ module CarrierWave
         def build(superclass)
           return @klass if @klass
           @klass = Class.new(superclass)
-          superclass.const_set("#{@name.to_s.camelize}VersionUploader", @klass)
+          superclass.const_set("VersionUploader#{@name.to_s.camelize}", @klass)
 
           @klass.version_names += [@name]
           @klass.versions = {}

--- a/spec/uploader/versions_spec.rb
+++ b/spec/uploader/versions_spec.rb
@@ -72,7 +72,7 @@ describe CarrierWave::Uploader do
 
     it "should set the class name" do
       @uploader_class.version :thumb
-      expect(@uploader.thumb.class).to eq @uploader_class.const_get :ThumbVersionUploader
+      expect(@uploader.thumb.class).to eq @uploader_class.const_get :VersionUploaderThumb
     end
 
     it "should remember mount options" do
@@ -151,6 +151,13 @@ describe CarrierWave::Uploader do
     it "should accept option :from_version" do
       @uploader_class.version :small_thumb, :from_version => :thumb
       expect(@uploader.small_thumb.class.version_options[:from_version]).to eq(:thumb)
+    end
+
+    context 'when version name starts with non-alphabetic character' do
+      it "should set the class name" do
+        @uploader_class.version :_800x600
+        expect(@uploader._800x600.class).to eq @uploader_class.const_get :VersionUploader800x600
+      end
     end
 
     describe 'with nested versions' do


### PR DESCRIPTION
Because of the restriction that Ruby constant names must always begin with `[A-Z]`, it would be desirable to make sure that this restriction is satisfied when naming dynamic constants.

- Fix https://github.com/carrierwaveuploader/carrierwave/issues/2722

It was implemented well in carrierwave v2, but when `object_id` was removed from the constant name  at https://github.com/carrierwaveuploader/carrierwave/commit/a9de7565eabb4cdca05bb090cdf797eb1720c09c, `Uploader` prefix was also removed at the same time for some reason.
