### PR TITLE
Backport security fixes for 1.x-stable

### DIFF
--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -266,7 +266,7 @@ module CarrierWave
     def content_type
       return @content_type if @content_type
       if @file.respond_to?(:content_type) and @file.content_type
-        @content_type = @file.content_type.to_s.chomp
+        @content_type = ::MIME::Types[@file.content_type.to_s.chomp].first.to_s
       elsif path
         @content_type = ::MIME::Types.type_for(path).first.to_s
       end

--- a/lib/carrierwave/uploader/content_type_whitelist.rb
+++ b/lib/carrierwave/uploader/content_type_whitelist.rb
@@ -40,7 +40,7 @@ module CarrierWave
       end
 
       def whitelisted_content_type?(content_type)
-        Array(content_type_whitelist).any? { |item| content_type =~ /#{item}/ }
+        Array(content_type_whitelist).any? { |item| content_type =~ /\A#{item}/ }
       end
 
     end # ContentTypeWhitelist

--- a/spec/sanitized_file_spec.rb
+++ b/spec/sanitized_file_spec.rb
@@ -206,6 +206,33 @@ describe CarrierWave::SanitizedFile do
 
       expect(sanitized_file.content_type).to eq("image/jpeg")
     end
+
+    it "uses the first one when multiple mime types are given using a semicolon" do
+      file = File.open(file_path("bork.txt"))
+      allow(file).to receive(:content_type) { 'image/png; text/html' }
+
+      sanitized_file = CarrierWave::SanitizedFile.new(file)
+
+      expect(sanitized_file.content_type).to eq("image/png")
+    end
+
+    it "uses the first one when multiple mime types are given using a comma" do
+      file = File.open(file_path("bork.txt"))
+      allow(file).to receive(:content_type) { 'image/png, text/html' }
+
+      sanitized_file = CarrierWave::SanitizedFile.new(file)
+
+      expect(sanitized_file.content_type).to eq("image/png")
+    end
+
+    it "drops content type parameters" do
+      file = File.open(file_path("bork.txt"))
+      allow(file).to receive(:content_type) { 'text/html; charset=utf-8' }
+
+      sanitized_file = CarrierWave::SanitizedFile.new(file)
+
+      expect(sanitized_file.content_type).to eq("text/html")
+    end
   end
 
   describe "#content_type=" do

--- a/spec/uploader/content_type_whitelist_spec.rb
+++ b/spec/uploader/content_type_whitelist_spec.rb
@@ -64,6 +64,19 @@ describe CarrierWave::Uploader do
           expect { uploader.cache!(test_file) }.not_to raise_error
         end
       end
+
+      context "with a crafted content type" do
+        let(:bork_file) { File.open(file_path('bork.txt')) }
+
+        before do
+          allow(bork_file).to receive(:content_type).and_return('text/plain; image/png')
+          allow(uploader).to receive(:content_type_whitelist).and_return('image/png')
+        end
+
+        it "does not allow spoofing" do
+          expect { uploader.cache!(bork_file) }.to raise_error(CarrierWave::IntegrityError)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
There are two security vulnerabilities (https://github.com/carrierwaveuploader/carrierwave/security/advisories/GHSA-vfmv-jfc5-pjjw and https://github.com/carrierwaveuploader/carrierwave/security/advisories/GHSA-gxhx-g4fq-49hj) which were resolved for 2.x and 3.x versions. They have not been addressed in 1.x branch.

I'm aware that using 1.x should not happening anymore, but in our case migration to 3.0 is a painful way which will take time. This backport would allow us to resolve the security vulnerabilities from our systems.