### PR TITLE
fix the code to comply with the Style::EmptyLiteral rule in RuboCop.

### DIFF
--- a/lib/carrierwave/uploader/callbacks.rb
+++ b/lib/carrierwave/uploader/callbacks.rb
@@ -6,8 +6,8 @@ module CarrierWave
       included do
         class_attribute :_before_callbacks, :_after_callbacks,
                         :instance_writer => false
-        self._before_callbacks = Hash.new []
-        self._after_callbacks = Hash.new []
+        self._before_callbacks = Hash.new { |hash, key| hash[key] = [] }
+        self._after_callbacks = Hash.new { |hash, key| hash[key] = [] }
       end
 
       def with_callbacks(kind, *args)


### PR DESCRIPTION
## Summary
I encountered an issue where Hash.new [] triggered a violation of the RuboCop rule Style/EmptyLiteral.
To address this, I revised the code.