### PR TITLE
CI against Rails 7.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.7', '3.0', '3.1', '3.2', '3.3', jruby ]
-        gemfile: [ gemfiles/rails-7-0.gemfile ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2', '3.3' ]
+        gemfile: [ gemfiles/rails-7-1.gemfile ]
         experimental: [ false ]
         include:
           - ruby: '2.5'
@@ -18,15 +18,21 @@ jobs:
           - ruby: '2.6'
             gemfile: gemfiles/rails-6-1.gemfile
             experimental: false
+          - ruby: '2.7'
+            gemfile: gemfiles/rails-7-0.gemfile
+            experimental: false
           - ruby: '3.3'
-            gemfile: gemfiles/rails-7-1.gemfile
+            gemfile: gemfiles/rails-7-2.gemfile
             experimental: false
           - ruby: '3.3'
             gemfile: gemfiles/rails-main.gemfile
             experimental: true
           - ruby: ruby-head
-            gemfile: gemfiles/rails-7-1.gemfile
+            gemfile: gemfiles/rails-7-2.gemfile
             experimental: false
+          - ruby: jruby
+            gemfile: gemfiles/rails-7-0.gemfile
+            experimental: true
           - ruby: jruby-head
             gemfile: gemfiles/rails-7-0.gemfile
             experimental: true

--- a/gemfiles/rails-7-2.gemfile
+++ b/gemfiles/rails-7-2.gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 7.2.0"
+gem "activemodel-serializers-xml"
+gem "sqlite3", platforms: :ruby
+gem "activerecord-jdbcsqlite3-adapter", platform: [:jruby, :truffleruby]
+
+gemspec :path => "../"


### PR DESCRIPTION
This PR adds Rails 7.2 to the CI matrix to confirm `carrierwave` working with Rails 7.2.

Currently, the latest Rails runs against only the latest Ruby and the previous Rails version runs against multiple Rubies. So I updated the matrix to follow it.