### PR TITLE
Use RFC2396_REGEXP explicitly

### DIFF
--- a/lib/carrierwave/utilities/uri.rb
+++ b/lib/carrierwave/utilities/uri.rb
@@ -4,7 +4,7 @@ module CarrierWave
   module Utilities
     module Uri
       # based on Ruby < 2.0's URI.encode
-      PATH_SAFE = URI::REGEXP::PATTERN::UNRESERVED + '\/'
+      PATH_SAFE = URI::RFC2396_REGEXP::PATTERN::UNRESERVED + '\/'
       PATH_UNSAFE = Regexp.new("[^#{PATH_SAFE}]", false)
       NON_ASCII = /[^[:ascii:]]/.freeze
 


### PR DESCRIPTION
Because uri > 1.0 switched to RFC3986 as the default parser

Fixes https://github.com/carrierwaveuploader/carrierwave/issues/2759