### PR TITLE
Support AWS S3 FIPS endpoints

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -395,7 +395,7 @@ module CarrierWave
                 # GovCloud doesn't support S3 Transfer Acceleration https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-s3.html
                 # S3 Transfer Acceleration doesn't support FIPS endpoints.  When both fog_aws_accelerate=true and AWS_USE_FIPS_ENDPOINT=true, don't use Accelerate.
                 if @uploader.fog_aws_accelerate && (AWS_GOVCLOUD_REGIONS.include?(region) || ENV['AWS_USE_FIPS_ENDPOINT'] == 'true')
-                  warn "S3 Transfer Acceleration is not available in GovCloud regions or when AWS_USE_FIPS_ENDPOINT=true. Disabling accelearation."
+                  warn "S3 Transfer Acceleration is not available in GovCloud regions or when AWS_USE_FIPS_ENDPOINT=true. Disabling acceleration."
                   @uploader.fog_aws_accelerate = false
                 end
 

--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -395,6 +395,7 @@ module CarrierWave
                 # GovCloud doesn't support S3 Transfer Acceleration https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-s3.html
                 # S3 Transfer Acceleration doesn't support FIPS endpoints.  When both fog_aws_accelerate=true and AWS_USE_FIPS_ENDPOINT=true, don't use Accelerate.
                 if @uploader.fog_aws_accelerate && (AWS_GOVCLOUD_REGIONS.include?(region) || ENV['AWS_USE_FIPS_ENDPOINT'] == 'true')
+                  warn "S3 Transfer Acceleration is not available in GovCloud regions or when AWS_USE_FIPS_ENDPOINT=true. Disabling accelearation."
                   @uploader.fog_aws_accelerate = false
                 end
 

--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -376,7 +376,12 @@ module CarrierWave
             when 'AWS'
               # check if some endpoint is set in fog_credentials
               if @uploader.fog_credentials.has_key?(:endpoint)
-                "#{@uploader.fog_credentials[:endpoint]}/#{@uploader.fog_directory}/#{encoded_path}"
+                if !@uploader.fog_aws_fips
+                  "#{@uploader.fog_credentials[:endpoint]}/#{@uploader.fog_directory}/#{encoded_path}"
+                else
+                  warn 'Use of options :endpoint and :fog_aws_fips=true together will fail, as FIPS endpoints do not support path-style URLs.'
+                  nil
+                end
               else
                 protocol = @uploader.fog_use_ssl_for_aws ? "https" : "http"
 

--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -164,7 +164,6 @@ module CarrierWave
       class File
         DEFAULT_S3_REGION = 'us-east-1'.freeze
         AWS_FIPS_REGIONS = %w(us-east-1 us-east-2 us-west-1 us-west-2 us-gov-east-1 us-gov-west-1 ca-central-1 ca-west-1).freeze
-        AWS_GOVCLOUD_REGIONS = %w(us-gov-east-1 us-gov-west-1).freeze
 
         include CarrierWave::Utilities::Uri
         include CarrierWave::Utilities::FileName
@@ -390,13 +389,6 @@ module CarrierWave
                   regional_host = "s3-fips.#{region}.amazonaws.com" # https://aws.amazon.com/compliance/fips/
                 elsif ![DEFAULT_S3_REGION, ''].include?(region)
                   regional_host = "s3.#{region}.amazonaws.com"
-                end
-
-                # GovCloud doesn't support S3 Transfer Acceleration https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-s3.html
-                # S3 Transfer Acceleration doesn't support FIPS endpoints.  When both fog_aws_accelerate=true and AWS_USE_FIPS_ENDPOINT=true, don't use Accelerate.
-                if @uploader.fog_aws_accelerate && (AWS_GOVCLOUD_REGIONS.include?(region) || ENV['AWS_USE_FIPS_ENDPOINT'] == 'true')
-                  warn "S3 Transfer Acceleration is not available in GovCloud regions or when AWS_USE_FIPS_ENDPOINT=true. Disabling acceleration."
-                  @uploader.fog_aws_accelerate = false
                 end
 
                 if use_virtual_hosted_style

--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -35,6 +35,7 @@ module CarrierWave
         add_config :fog_authenticated_url_expiration
         add_config :fog_use_ssl_for_aws
         add_config :fog_aws_accelerate
+        add_config :fog_aws_fips
 
         # Mounting
         add_config :ignore_integrity_errors
@@ -197,6 +198,7 @@ module CarrierWave
             config.fog_authenticated_url_expiration = 600
             config.fog_use_ssl_for_aws = true
             config.fog_aws_accelerate = false
+            config.fog_aws_fips = false
             config.store_dir = 'uploads'
             config.cache_dir = 'uploads/tmp'
             config.delete_tmp_file_after_storage = true


### PR DESCRIPTION
S3 endpoints even when ENV['AWS_USE_FIPS_ENDPOINT']=='true'. When FIPS is called for, and we are in a region where FIPS endpoints are available, this method should return the FIPS endpoint.

Furthermore, when S3 Transfer Acceleration (S3TA) is requested by configuration, the above endpoint gets overridden to select the S3TA endpoint. However, S3TA is not avaialble in GovCloud, and has no FIPS endpoint equivalents. In this instance, if the region is a GovCloud region, or if FIPS mode is called for, do not override the endpoint to use S3TA.

This is functionally equivalent to an issue submitted to the fog-aws project.  https://github.com/fog/fog-aws/issues/729