### PR TITLE
Support test matchers with only Vips

### DIFF
--- a/lib/carrierwave/test/matchers.rb
+++ b/lib/carrierwave/test/matchers.rb
@@ -336,6 +336,8 @@ module CarrierWave
         def self.load_image(filename)
           if defined? ::MiniMagick
             MiniMagickWrapper.new(filename)
+          elsif defined? ::Vips
+            VipsWrapper.new(filename)
           else
             unless defined? ::Magick
               begin
@@ -390,6 +392,28 @@ module CarrierWave
 
         def initialize(filename)
           @image = ::MiniMagick::Image.open(filename)
+        end
+      end
+
+      class VipsWrapper # :nodoc:
+        attr_reader :image
+
+        def width
+          image.width
+        end
+
+        def height
+          image.height
+        end
+
+        def format
+          # This returns the name of the vips loader (e.g. pngload) as Vips
+          # doesn't do content detection.
+          image.get("vips-loader").delete_suffix("load")
+        end
+
+        def initialize(filename)
+          @image = ::Vips::Image.new_from_file(filename)
         end
       end
 


### PR DESCRIPTION
This adds support for using the test matchers when using Vips and neither MiniMagick or Magick are installed. In our case it was falling back to Magick since MiniMagick wasn't available. I didn't see any tests for the matchers and I'm not sure if there is even a good way to test the switching logic. That said, I've tested these changes against our application and they fixed the issue we were seeing.

The one idiosyncrasy is that there isn't a clean way to get the format like with the Magick libraries. The best Vips can do is to tell which loader was used (e.g. `"pngload"`) which I'm guessing is based on the extension. 