### PR TITLE
Fix #dup with custom serialisation

### DIFF
--- a/lib/carrierwave/orm/activerecord.rb
+++ b/lib/carrierwave/orm/activerecord.rb
@@ -51,7 +51,7 @@ module CarrierWave
           super
           @_mounters[:"#{column}"] = nil
           # The attribute needs to be cleared to prevent it from picked up as identifier
-          write_attribute(_mounter(:#{column}).serialization_column, nil)
+          write_uploader(_mounter(:#{column}).serialization_column, nil)
           _mounter(:"#{column}").cache(old_uploaders)
         end
 


### PR DESCRIPTION
While `write_uploader` is [aliased by default](https://github.com/carrierwaveuploader/carrierwave/blob/f0620919d00dbd74d31e6b48f62346d6090e88f7/lib/carrierwave/orm/activerecord.rb#L15) to `write_attribute`, it may be overridden in the model (see example below).

```ruby
class SomeModel < ActiveRecord::Base
  store :settings, accessors: [:logo] # virtual column logo

  mount_uploader :logo, LogoUploader

  def write_uploader(column, identifier)
    settings[column.to_sym] = identifier
  end

  def read_uploader(column)
    settings[column.to_sym]
  end
end
```
However duplicating such a model fails with the following error.
```ruby
[1] pry(main)> SomeModel.new.dup
ActiveModel::MissingAttributeError: can't write unknown attribute `logo
````

This change ensures that on duplication, the override `write_uploader` method is called when clearing the attribute.