### PR TITLE
Raise MiniMagick::Error if ImageMagick is missing delegates needed for image formats

### DIFF
--- a/lib/carrierwave/processing/mini_magick.rb
+++ b/lib/carrierwave/processing/mini_magick.rb
@@ -293,7 +293,7 @@ module CarrierWave
 
       ::MiniMagick::Image.new(current_path).identify
     rescue ::MiniMagick::Error, ::MiniMagick::Invalid => e
-      raise e if e.message =~ /(You must have .+ installed|is not installed|executable not found)/
+      raise e if e.message =~ /(You must have .+ installed|is not installed|executable not found|delegate failed)/
       message = I18n.translate(:"errors.messages.processing_error")
       raise CarrierWave::ProcessingError, message
     ensure


### PR DESCRIPTION
Fixes #2732

Starting in Alpine Linux 3.19, installing the `imagemagick` package no longer includes support for JPG, SVG, and other image formats. Additional packages must be installed to support each image format[1].

This means upgrading Alpine linux on a server can cause Carrierwave to start failing with `CarrierWave::ProcessingError` when uploading images.

The root cause isn't obvious from this error.

However when ImageMagick is not installed, Carrierwave raises `MiniMagick::Error` instead of `CarrierWave::ProcessingError`, and includes the detailed error message.

This PR also raises `MiniMagick::Error` if ImageMagick is installed but is missing the delegates required for the image format being manipulated. This will make it easier to debug when uploads are failing.

I see there was a previous attempted fix at #2733 and agree that following #2499 we do not want any end-user unfriendly text in `CarrierWave::ProcessingError#message`. As a result I have taken a different approach in this PR. 

[1] https://maxsmolens.org/posts/imagemagick-packaging-change-on-alpine-linux/