### PR TITLE
Remove use of deprecated mb_chars method

### DIFF
--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -1,5 +1,4 @@
 require 'pathname'
-require 'active_support/core_ext/string/multibyte'
 require 'marcel'
 
 module CarrierWave

--- a/lib/carrierwave/sanitized_file.rb
+++ b/lib/carrierwave/sanitized_file.rb
@@ -312,7 +312,7 @@ module CarrierWave
       name = name.gsub(sanitize_regexp, "_")
       name = "_#{name}" if name =~ /\A\.+\z/
       name = "unnamed" if name.size.zero?
-      name.mb_chars.to_s
+      name.to_s
     end
 
     def declared_content_type


### PR DESCRIPTION
mb_chars has been deprecated. and can be replaced by simply removing the method.

cf : https://github.com/rails/rails/pull/54081