### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/carrierwave

### DIFF
--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -46,4 +46,6 @@ Gem::Specification.new do |s|
   if RUBY_ENGINE != 'jruby'
     s.add_development_dependency "pry-byebug"
   end
+
+  s.metadata["changelog_uri"] = s.homepage + "/blob/master/CHANGELOG.md"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/carrierwave which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/#metadata