### PR TITLE
Add content_type_allowlist example to uploader template

### DIFF
--- a/lib/generators/templates/uploader.rb.erb
+++ b/lib/generators/templates/uploader.rb.erb
@@ -40,6 +40,14 @@ class <%= class_name %>Uploader < CarrierWave::Uploader::Base
   #   %w(jpg jpeg gif png)
   # end
 
+  # Add a content_type_allowlist to restrict uploads by MIME type.
+  # Without it, a user could upload a harmful file
+  # with a safe extension (content-type spoofing).
+  # For the previous extension_allowlist you might use something like this:
+  # def content_type_allowlist
+  #   /image\//
+  # end
+
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.
   # def filename


### PR DESCRIPTION
When developers add CarrierWave for the first time they usually follow the docs and generate an uploader with the provided generator.  At the moment, that generator does not include a `content_type_allowlist` example, which can leave newcomers vulnerable to content-type spoofing if they overlook the documentation.

This PR adds a commented `content_type_allowlist` example, in the same style as the existing `extension_allowlist` and other examples in the template.
