### PR TITLE
Don't call s3 multiple times when the file doesn't exist

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", ">= 6.0.0"
 gem "activemodel-serializers-xml"
-gem "sqlite3", "~> 1.0", platforms: :ruby
+gem "sqlite3", "~> 2.0", platforms: :ruby
 gem "activerecord-jdbcsqlite3-adapter", platform: [:jruby, :truffleruby]
 # See https://github.com/fog/fog-google/issues/535 for this restriction.
 gem "fog-google", "~> 1.13.0" if RUBY_VERSION.to_f < 2.7

--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -257,7 +257,7 @@ module CarrierWave
         def delete
           # avoid a get by just using local reference
           directory.files.new(:key => path).destroy.tap do |result|
-            @file = nil if result
+            remove_instance_variable(:@file) if result && defined?(@file)
           end
         end
 
@@ -296,7 +296,7 @@ module CarrierWave
           return read_source_file if ::File.exist?(file_body.path)
 
           # If the source file doesn't exist, the remote content is read
-          @file = nil
+          remove_instance_variable(:@file) if defined?(@file)
           file.body
         end
 
@@ -512,7 +512,9 @@ module CarrierWave
         # [Fog::#{provider}::File] file data from remote service
         #
         def file
-          @file ||= directory.files.head(path)
+          return @file if defined?(@file)
+
+          @file = directory.files.head(path)
         end
 
         def copy_options


### PR DESCRIPTION
When s3 returns a 404, the file is not cached, so every access will re-attempt to fetch the file. Instead, cache the result of the request, even when it returns a 404.