### PR TITLE
Ensure ruby 4 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.2', '3.3', '3.4' ]
+        ruby: [ '3.2', '3.3', '3.4', '4.0' ]
         gemfile: [ gemfiles/rails-8-0.gemfile ]
         experimental: [ false ]
         include:
@@ -28,6 +28,9 @@ jobs:
             gemfile: gemfiles/rails-7-2.gemfile
             experimental: false
           - ruby: '3.4'
+            gemfile: gemfiles/rails-main.gemfile
+            experimental: true
+          - ruby: '4.0'
             gemfile: gemfiles/rails-main.gemfile
             experimental: true
           - ruby: ruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", ">= 6.0.0"
 gem "activemodel-serializers-xml"
-gem "sqlite3", "~> 1.0", platforms: :ruby
+gem "sqlite3", platforms: :ruby
 gem "activerecord-jdbcsqlite3-adapter", platform: [:jruby, :truffleruby]
 # See https://github.com/fog/fog-google/issues/535 for this restriction.
 gem "fog-google", "~> 1.13.0" if RUBY_VERSION.to_f < 2.7

--- a/spec/orm/activerecord_spec.rb
+++ b/spec/orm/activerecord_spec.rb
@@ -2268,8 +2268,8 @@ describe CarrierWave::ActiveRecord do
         Event.class_eval do
           attribute :called_write_uploader_with, :json, default: {}
           def write_uploader(*args)
-            self.called_write_uploader_with[args] ||= 0
-            self.called_write_uploader_with[args] += 1
+            self.called_write_uploader_with[args.to_s] ||= 0
+            self.called_write_uploader_with[args.to_s] += 1
             write_attribute(*args)
           end
         end


### PR DESCRIPTION
I added ruby 4.0 to the CI test matrix.
I fixed a test that already failed before.
And I needed to remove the pinning of the sqlite3 gem.