### PR TITLE
CI against Ruby 4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.2', '3.3', '3.4' ]
+        ruby: [ '3.2', '3.3', '3.4', '4.0' ]
         gemfile: [ gemfiles/rails-8-0.gemfile ]
         experimental: [ false ]
         include:


### PR DESCRIPTION
Ruby 4.0 has been released. This PR adds it to CI to ensure Carrierwave works with it.