### PR TITLE
upgrade marcel gem currently locked to '~> 1.0.0', lock to '~> 1.0'

### DIFF
--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", ">= 6.0.0"
   s.add_dependency "activemodel", ">= 6.0.0"
   s.add_dependency "image_processing", "~> 1.1"
-  s.add_dependency "marcel", "~> 1.0.0"
+  s.add_dependency "marcel", "~> 1.0"
   s.add_dependency "addressable", "~> 2.6"
   s.add_dependency "ssrf_filter", "~> 1.0"
   s.add_development_dependency "csv", "~> 3.0"


### PR DESCRIPTION
`marcel` is currently locked to `~>1.0.0` this PR updates the lock it to `~> 1.0` so that we can drag `marcel` up to the most recent version.