### PR TITLE
Fix Firebase Storage URL decoding (%2F)

### DIFF
--- a/lib/carrierwave/downloader/base.rb
+++ b/lib/carrierwave/downloader/base.rb
@@ -67,12 +67,41 @@ module CarrierWave
         uri = Addressable::URI.parse(source)
         uri.host = uri.normalized_host
         # Perform decode first, as the path is likely to be already encoded
-        uri.path = encode_path(decode_uri(uri.path)) if uri.path =~ CarrierWave::Utilities::Uri::PATH_UNSAFE
+        # Skip decode/encode for hosts that use encoded slashes as part of object identifiers (e.g. Firebase Storage)
+        if uri.path =~ CarrierWave::Utilities::Uri::PATH_UNSAFE && !preserve_path_encoding?(uri.host)
+          uri.path = encode_path(decode_uri(uri.path))
+        end
         uri.query = encode_non_ascii(uri.query) if uri.query
         uri.fragment = encode_non_ascii(uri.fragment) if uri.fragment
         URI.parse(uri.to_s)
       rescue URI::InvalidURIError, Addressable::URI::InvalidURIError
         raise CarrierWave::DownloadError, "couldn't parse URL: #{source}"
+      end
+
+      ##
+      # Returns true if the path encoding should be preserved for the given host.
+      # Override this method to add custom hosts that require preserved path encoding.
+      #
+      # Firebase Storage uses encoded slashes (%2F) as part of object identifiers.
+      # Decoding these breaks the URL.
+      #
+      # === Parameters
+      #
+      # [host (String)] The hostname from the URL
+      #
+      # === Examples
+      #
+      #     # To add additional hosts:
+      #     class MyDownloader < CarrierWave::Downloader::Base
+      #       def preserve_path_encoding?(host)
+      #         super || host == 'my-custom-storage.com'
+      #       end
+      #     end
+      #
+      def preserve_path_encoding?(host)
+        return false unless host
+
+        host.downcase == 'firebasestorage.googleapis.com'
       end
 
       ##

--- a/spec/downloader/base_spec.rb
+++ b/spec/downloader/base_spec.rb
@@ -264,6 +264,38 @@ describe CarrierWave::Downloader::Base do
       uri = '~http:'
       expect { subject.process_uri(uri) }.to raise_error(CarrierWave::DownloadError)
     end
+
+    context "with Firebase Storage URLs" do
+      it "preserves %2F encoding in path for firebasestorage.googleapis.com" do
+        uri = 'https://firebasestorage.googleapis.com/v0/b/my-app.appspot.com/o/images%2Fsubfolder%2Fphoto.jpg?alt=media&token=abc123'
+        processed = subject.process_uri(uri)
+        expect(processed.path).to include('%2F')
+        expect(processed.path).not_to include('images/subfolder')
+        expect(processed.query).to include('alt=media')
+      end
+    end
+
+    context "with non-Firebase URLs" do
+      it "still decodes %2F for regular hosts" do
+        uri = 'http://example.com/path%2Fto%2Ffile.jpg'
+        processed = subject.process_uri(uri)
+        expect(processed.path).to eq('/path/to/file.jpg')
+      end
+    end
+  end
+
+  describe "#preserve_path_encoding?" do
+    it "returns true for firebasestorage.googleapis.com" do
+      expect(subject.preserve_path_encoding?('firebasestorage.googleapis.com')).to be true
+    end
+
+    it "returns false for regular hosts" do
+      expect(subject.preserve_path_encoding?('example.com')).to be false
+    end
+
+    it "returns false for nil host" do
+      expect(subject.preserve_path_encoding?(nil)).to be false
+    end
   end
 
   describe "#skip_ssrf_protection?" do


### PR DESCRIPTION
 #### Description:

  #### Problem

  Firebase Storage URLs use `%2F` (encoded slash) as part of object identifiers.
  `process_uri` currently decodes `%2F` → `/`, which breaks these URLs.

  - Before (original URL): `/o/images%2Fsubfolder%2Fphoto.jpg` ✅
  - After `process_uri`: `/o/images/subfolder/photo.jpg` ❌ 400

  #### Solution

  Added `preserve_path_encoding?(host)` to skip path decode/encode for Firebase Storage URLs. The hook can be overridden for custom hosts.

  #### Changes

  - Preserve %2F encoding in path for firebasestorage.googleapis.co
  - Case-insensitive host matching
  - Added tests for Firebase URLs
  - Behavior for non-Firebase URLs remains unchanged