### PR TITLE
Fix process_uri rewriting literal + in URL paths to %2B (#2800)

### DIFF
--- a/lib/carrierwave/downloader/base.rb
+++ b/lib/carrierwave/downloader/base.rb
@@ -66,8 +66,7 @@ module CarrierWave
       def process_uri(source)
         uri = Addressable::URI.parse(source)
         uri.host = uri.normalized_host
-        # Perform decode first, as the path is likely to be already encoded
-        uri.path = encode_path(decode_uri(uri.path)) if uri.path =~ CarrierWave::Utilities::Uri::PATH_UNSAFE
+        uri.path = encode_path_preserving_encoding(uri.path, PATH_UNSAFE_WITH_PLUS) if uri.path =~ PATH_UNSAFE_WITH_PLUS
         uri.query = encode_non_ascii(uri.query) if uri.query
         uri.fragment = encode_non_ascii(uri.fragment) if uri.fragment
         URI.parse(uri.to_s)

--- a/lib/carrierwave/utilities/uri.rb
+++ b/lib/carrierwave/utilities/uri.rb
@@ -6,6 +6,8 @@ module CarrierWave
       # based on Ruby < 2.0's URI.encode
       PATH_SAFE = URI::RFC2396_REGEXP::PATTERN::UNRESERVED + '\/'
       PATH_UNSAFE = Regexp.new("[^#{PATH_SAFE}]", false)
+      PATH_SAFE_WITH_PLUS = PATH_SAFE + '\+'
+      PATH_UNSAFE_WITH_PLUS = Regexp.new("[^#{PATH_SAFE_WITH_PLUS}]", false)
       NON_ASCII = /[^[:ascii:]]/.freeze
 
     private
@@ -18,8 +20,10 @@ module CarrierWave
         URI::DEFAULT_PARSER.escape(str, NON_ASCII)
       end
 
-      def decode_uri(str)
-        URI::DEFAULT_PARSER.unescape(str)
+      def encode_path_preserving_encoding(path, unsafe = PATH_UNSAFE)
+        path.gsub(/(%[0-9a-fA-F]{2})|(#{unsafe})/) do
+          $1 || $2.bytes.map { |byte| "%%%02X" % byte }.join
+        end
       end
     end # Uri
   end # Utilities

--- a/spec/downloader/base_spec.rb
+++ b/spec/downloader/base_spec.rb
@@ -124,6 +124,19 @@ describe CarrierWave::Downloader::Base do
     end
   end
 
+  context "with a url that contains a plus sign in the path" do
+    let(:filename) { "my+test.jpg" }
+    let(:uri) { "http://www.example.com/#{filename}" }
+
+    before do
+      stub_request(:get, uri).to_return(body: file)
+    end
+
+    it "does not rewrite the plus sign before downloading" do
+      expect(subject.download(uri).file.read).to eq file
+    end
+  end
+
   context "with redirects" do
     let(:another_uri) { 'http://example.com/redirected.jpg' }
     before do
@@ -263,6 +276,48 @@ describe CarrierWave::Downloader::Base do
     it "throws an exception on bad uris" do
       uri = '~http:'
       expect { subject.process_uri(uri) }.to raise_error(CarrierWave::DownloadError)
+    end
+
+    it "preserves percent-encoded reserved characters in path" do
+      uri = 'http://example.com/path%2Fto/file.jpg'
+      processed = subject.process_uri(uri)
+      expect(processed.to_s).to eq(uri)
+    end
+
+    it "preserves percent-encoded plus signs in path" do
+      uri = 'http://example.com/file%2Bname.jpg'
+      processed = subject.process_uri(uri)
+      expect(processed.to_s).to eq(uri)
+    end
+
+    it "preserves literal plus signs in path" do
+      uri = 'http://example.com/file+name.jpg'
+      processed = subject.process_uri(uri)
+      expect(processed.to_s).to eq(uri)
+    end
+
+    it "preserves percent-encoded characters in presigned URLs" do
+      uri = 'https://d111111abcdef8.cloudfront.net/images%2Fphoto%2Balbum/image%2B1.jpg?Expires=1234567890&Signature=abc'
+      processed = subject.process_uri(uri)
+      expect(processed.to_s).to eq(uri)
+    end
+
+    it "encodes incomplete percent sequences" do
+      uri = 'http://example.com/file%ZZname.jpg'
+      processed = subject.process_uri(uri)
+      expect(processed.to_s).to eq('http://example.com/file%25ZZname.jpg')
+    end
+
+    it "preserves multiple plus signs in path" do
+      uri = 'http://example.com/a+b+c+d.jpg'
+      processed = subject.process_uri(uri)
+      expect(processed.to_s).to eq(uri)
+    end
+
+    it "encodes a trailing percent sign" do
+      uri = 'http://example.com/file%.jpg'
+      processed = subject.process_uri(uri)
+      expect(processed.to_s).to eq('http://example.com/file%25.jpg')
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes #2800

`process_uri` was converting literal `+` signs in URL paths to `%2B`
before issuing the HTTP request, causing 404 errors on servers that use
`+` as a valid path character (e.g. `/my+test.jpg`)

## Root Cause

The old implementation used a decode-then-re-encode strategy:

```ruby
# Before
uri.path = encode_path(decode_uri(uri.path)) if uri.path =~ PATH_UNSAFE
```

`decode_uri` unconditionally decoded all `%XX` sequences, turning `%2B`
into `+`. Then `encode_path` re-encoded everything with `PATH_UNSAFE`,
which treated `+` as unsafe — converting all `+` (both originally
literal and originally `%2B`) to `%2B`. This made it impossible to
distinguish between a literal `+` and an intentionally encoded `%2B`.

## Solution

Replace the decode-then-re-encode strategy with a **single-pass
encoding** that skips existing `%XX` sequences:

```ruby
# After
uri.path = encode_path_preserving_encoding(uri.path, PATH_UNSAFE_WITH_PLUS) if uri.path =~ PATH_UNSAFE_WITH_PLUS
```

- `encode_path_preserving_encoding` uses a regex alternation
  `(%[0-9a-fA-F]{2})|(unsafe_char)` to match the path: existing
  percent-encoded sequences are passed through untouched (`$1`), while
  truly unsafe characters are percent-encoded byte-by-byte (`$2`).
- `PATH_UNSAFE_WITH_PLUS` extends `PATH_UNSAFE` to treat `+` as a safe
  character, per RFC 3986 §3.3 which permits `+` as a literal in paths.

## CI Notes

The failing checks are reproducible on the current base and are not introduced by this PR.

Observed unrelated failures:
- RuboCop: `lib/carrierwave/uploader/configuration.rb` (`Lint/Void`)
- `jruby-head`: experimental/dependency-level instability