### PR TITLE
Fix a `Lint/Void` offense in `Uploader::Configuration#storage` that causes CI to fail.

### DIFF
--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -88,7 +88,7 @@ module CarrierWave
               raise CarrierWave::UnknownStorageError, "Unknown storage: #{storage}"
             end
           when nil
-            storage
+            # getter: return _storage below
           else
             self._storage = storage
           end


### PR DESCRIPTION
## Problem

The `.storage` method uses a `case/when` to distinguish getter vs setter calls:

```ruby
def storage(storage = nil)
  case storage
  when Symbol
    # ... set storage engine
  when nil
    storage  # ← Lint/Void: variable used in void context
  else
    self._storage = storage
  end
  _storage
end
```

The `when nil` branch evaluated the `storage` parameter (always `nil` at that point), but the result was discarded since the method unconditionally returns `_storage` at the end. This was harmless but flagged as `Lint/Void`.

## Fix

Replace the void expression with a comment explaining the getter intent:

```ruby
when nil
  # getter: return _storage below
```

No behavioral change — the method's return value is always `_storage` regardless.