### PR TITLE
Allow to configure how carrierwave recognizes file existance on fog storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,6 +741,14 @@ following lines
 config.fog_credentials = { ... } # Provider specific credentials
 ```
 
+## How Carrierwave checks file existance
+
+Before 3.10.0, if you tried to check file existance (i.e. `file?`, `present?`, or even `validate :file, presence: true`), Carrierwave was just checking identifier existance. After 3.10.0 it makes HEAD request to fog storage. If you want to use legacy method of existance recongnition, please set:
+
+```ruby
+config.fog_emptiness_check_method = :local # default is :remote
+```
+
 ## Using Amazon S3
 
 [Fog AWS](http://github.com/fog/fog-aws) is used to support Amazon S3. Ensure you have it in your Gemfile:

--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -317,6 +317,8 @@ module CarrierWave
         # [Boolean] whether the file is non-existent or empty
         #
         def empty?
+          return path.blank? if CarrierWave::Uploader::Base.fog_emptiness_check_method == :local
+
           !exists? || size.zero?
         end
 

--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -36,6 +36,7 @@ module CarrierWave
         add_config :fog_use_ssl_for_aws
         add_config :fog_aws_accelerate
         add_config :fog_aws_fips
+        add_config :fog_emptiness_check_method
 
         # Mounting
         add_config :ignore_integrity_errors
@@ -199,6 +200,7 @@ module CarrierWave
             config.fog_use_ssl_for_aws = true
             config.fog_aws_accelerate = false
             config.fog_aws_fips = false
+            config.fog_emptiness_check_method = :remote
             config.store_dir = 'uploads'
             config.cache_dir = 'uploads/tmp'
             config.delete_tmp_file_after_storage = true

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -780,6 +780,18 @@ shared_examples "Fog storage" do |fog_credentials|
           it "returns true" do
             expect(@fog_file.empty?).to be true
           end
+
+          context "when fog_emptiness_check_method is set to :local" do
+            before do
+              CarrierWave.configure do |config|
+                config.fog_emptiness_check_method = :local
+              end
+            end
+
+            it "returns false" do
+              expect(@fog_file.empty?).to be false
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Hey guys, thank you for your work on this gem,

in 3.1.0 you've introduce new method `CarrierWave::Storage::Fog::File#empty?` that makes HEAD requests to storage to check file size.
This leads to performance issues on production - each check makes request to storage.
https://github.com/carrierwaveuploader/carrierwave/issues/2802

On our production we monkey patched it with `CarrierWave::Storage::Fog::File.undef_method(:empty?)`.

In this PR I try to allow to configure method how to check existence.
Any critic appreciated!