### PR TITLE
Add ssrf_filter_options configuration to pass options to SsrfFilter to use a static IPv4 address

### DIFF
--- a/lib/carrierwave/downloader/base.rb
+++ b/lib/carrierwave/downloader/base.rb
@@ -32,12 +32,13 @@ module CarrierWave
             response = OpenURI.open_uri(process_uri(url.to_s), headers)
           else
             request = nil
+            ssrf_options = @uploader.ssrf_filter_options || {}
             if ::SsrfFilter::VERSION.to_f < 1.1
-              response = SsrfFilter.get(uri, headers: headers) do |req|
+              response = SsrfFilter.get(uri, headers: headers, **ssrf_options) do |req|
                 request = req
               end
             else
-              response = SsrfFilter.get(uri, headers: headers, request_proc: ->(req) { request = req }) do |res|
+              response = SsrfFilter.get(uri, headers: headers, request_proc: ->(req) { request = req }, **ssrf_options) do |res|
                 res.body # ensure to read body
               end
             end

--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -49,6 +49,7 @@ module CarrierWave
         add_config :download_retry_count
         add_config :download_retry_wait_time
         add_config :skip_ssrf_protection
+        add_config :ssrf_filter_options
 
         # set default values
         reset_config
@@ -220,6 +221,7 @@ module CarrierWave
             config.download_retry_count = 0
             config.download_retry_wait_time = 5
             config.skip_ssrf_protection = false
+            config.ssrf_filter_options = {}
           end
         end
       end

--- a/spec/downloader/base_spec.rb
+++ b/spec/downloader/base_spec.rb
@@ -266,6 +266,43 @@ describe CarrierWave::Downloader::Base do
     end
   end
 
+  describe '#ssrf_filter_options' do
+    it 'defaults to empty hash' do
+      expect(uploader.ssrf_filter_options).to eq({})
+    end
+
+    context 'when custom resolver is provided' do
+      let(:custom_resolver) { proc { |hostname| [IPAddr.new('1.2.3.4')] } }
+      before do
+        uploader.ssrf_filter_options = { resolver: custom_resolver }
+      end
+
+      it 'passes resolver option to SsrfFilter' do
+        stub_request(:get, //).to_return(body: file)
+        expect(SsrfFilter).to receive(:get).with(
+          anything,
+          hash_including(resolver: custom_resolver)
+        ).and_call_original
+        subject.download(uri)
+      end
+    end
+
+    context 'when http_options are provided' do
+      before do
+        uploader.ssrf_filter_options = { http_options: { open_timeout: 5 } }
+        stub_request(:get, uri).to_return(body: file)
+      end
+
+      it 'passes http_options to SsrfFilter' do
+        expect(SsrfFilter).to receive(:get).with(
+          anything,
+          hash_including(http_options: { open_timeout: 5 })
+        ).and_call_original
+        subject.download(uri)
+      end
+    end
+  end
+
   describe "#skip_ssrf_protection?" do
     context "when ssrf_protection is skipped" do
       let(:uri) { 'http://localhost/test.jpg' }


### PR DESCRIPTION
CarrierWave uses SsrfFilter for SSRF protection when downloading remote files, but does not expose SsrfFilter's options (such as `resolver`, `http_options`, etc.) to users.

This is problematic when SsrfFilter resolves a hostname that returns both IPv4 and IPv6 addresses. SsrfFilter randomly picks one via `.sample`, and if IPv6 is selected but unreachable on the server, the download fails with a network error. Users have no way to control DNS resolution (e.g., to prefer IPv4) without monkey-patching.

https://github.com/arkadiyt/ssrf_filter/blob/b87b175f955743c8abee4b37053d92fe3da512c9/lib/ssrf_filter/ssrf_filter.rb#L159

This commit adds `ssrf_filter_options` configuration that passes through any options to `SsrfFilter.get`, allowing users to customize behavior such as providing a custom resolver.

Example usage:

    CarrierWave.configure do |config|
      config.ssrf_filter_options = {
        resolver: proc { |hostname|
          Resolv.getaddresses(hostname)
            .map { |ip| IPAddr.new(ip) }
            .select(&:ipv4?)
        }
      }
    end