### PR TITLE
Fix Lint/Void warning in storage method

### DIFF
--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -88,7 +88,7 @@ module CarrierWave
               raise CarrierWave::UnknownStorageError, "Unknown storage: #{storage}"
             end
           when nil
-            storage
+            # no-op: return current storage via _storage below
           else
             self._storage = storage
           end


### PR DESCRIPTION
The `storage` variable in the `when nil` branch was used in void context since the return value comes from `_storage` at the end of the method.