### PR TITLE
Fix broken CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,12 +33,9 @@ jobs:
           - ruby: ruby-head
             gemfile: gemfiles/rails-8-0.gemfile
             experimental: false
-          - ruby: jruby
+          - ruby: jruby-10.0.5.0
             gemfile: gemfiles/rails-7-2.gemfile
             experimental: false
-          - ruby: jruby-head
-            gemfile: gemfiles/rails-7-2.gemfile
-            experimental: true
     runs-on: ubuntu-24.04
     continue-on-error: ${{ matrix.experimental }}
     env:

--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -88,7 +88,7 @@ module CarrierWave
               raise CarrierWave::UnknownStorageError, "Unknown storage: #{storage}"
             end
           when nil
-            storage
+            # noop
           else
             self._storage = storage
           end


### PR DESCRIPTION
It seems that the CI is breaking now. This PR tries to fix it. This PR includes the following fixes.

* Fix Rubocop warning(`Lint/Void: Variable storage used in void context.`)
  * https://github.com/carrierwaveuploader/carrierwave/actions/runs/25036403218/job/73329023531?pr=2815
  * The current logic does nothing. So just add a comment to fix it.
* Fix broken CI with JRuby
  * https://github.com/carrierwaveuploader/carrierwave/actions/runs/25036403218/job/73329023625?pr=2815
  * To be honest, I'm not sure of the root cause. But, it seems that `activerecord-jdbc-adapter ` gem doesn't work with the latest JRuby(10.1.x). So I have locked a version with 10.0.x.