### PR TITLE
Raise `ProcessingError` when all frames are filtered out `in manipulate!`

### DIFF
--- a/lib/carrierwave/locale/en.yml
+++ b/lib/carrierwave/locale/en.yml
@@ -9,6 +9,7 @@ en:
       content_type_allowlist_error: "You are not allowed to upload %{content_type} files, allowed types: %{allowed_types}"
       content_type_denylist_error: "You are not allowed to upload %{content_type} files"
       processing_error: "Failed to manipulate, maybe it is not an image?"
+      unsupported_image_format_error: "Failed to manipulate, file format is not supported"
       min_size_error: "File size should be greater than %{min_size}"
       max_size_error: "File size should be less than %{max_size}"
       min_width_error: "Image width should be greater than %{min_width}px"

--- a/lib/carrierwave/processing/rmagick.rb
+++ b/lib/carrierwave/processing/rmagick.rb
@@ -383,6 +383,11 @@ module CarrierWave
         frame = yield(*[frame, index, options].take(block.arity)) if block_given?
         frames << frame if frame
       end
+
+      if frames.none?
+        raise CarrierWave::ProcessingError, I18n.translate(:"errors.messages.unsupported_image_format_error")
+      end
+
       frames.append(true) if block_given?
 
       write_block = create_info_block(options[:write])

--- a/spec/processing/rmagick_spec.rb
+++ b/spec/processing/rmagick_spec.rb
@@ -257,6 +257,13 @@ describe CarrierWave::RMagick, :rmagick => true do
         }
       end.to raise_error NoMethodError, /private method .foo=. called/
     end
+
+    it 'raises a ProcessingError when all frames are filtered out by the block' do
+      allow(::Magick::Image).to receive_messages(:read => image)
+      expect do
+        instance.manipulate! { |frame, index| nil }
+      end.to raise_error(CarrierWave::ProcessingError, /file format is not supported/)
+    end
   end
 
   describe "#width and #height" do


### PR DESCRIPTION

Previously, when `manipulate!` was called with a block that returned nil for every frame, the resulting empty frames array caused an `ArgumentError` in `frames.append(true)`. This is because RMagick's `ImageList#append` does not accept a bare true value on an empty list.

https://github.com/rmagick/rmagick/blob/9788a6d43b3aebb5a1ad72013f1fe0b3affa300f/ext/RMagick/rmilist.cpp#L143 https://github.com/rmagick/rmagick/blob/9788a6d43b3aebb5a1ad72013f1fe0b3affa300f/ext/RMagick/rmilist.cpp#L877

This made the error hard to diagnose since the root cause (unsupported format or a block that always returns nil) was not surfaced.

It looks like this happens when an image file isn't supported by ImageMagick.(In our case, this happens with HEIC files with unsupported compatible brands)

So this changed to check frames and if it's empty, raises an appropriate error.