### PR TITLE
Fix/sanitized file deprecation

### DIFF
--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", ">= 6.0.0"
   s.add_dependency "activemodel", ">= 6.0.0"
-  s.add_dependency "image_processing", "~> 1.1"
+  s.add_dependency "image_processing", ">= 1.1"
   s.add_dependency "marcel", "~> 1.0.0"
   s.add_dependency "addressable", "~> 2.6"
   s.add_dependency "ssrf_filter", "~> 1.0"

--- a/lib/carrierwave.rb
+++ b/lib/carrierwave.rb
@@ -3,6 +3,7 @@ require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/object/try'
 require 'active_support/core_ext/class/attribute'
 require 'active_support/concern'
+require 'active_support/deprecation'
 
 module CarrierWave
 
@@ -20,6 +21,10 @@ module CarrierWave
 
     def tmp_path
       @tmp_path ||= File.expand_path(File.join('..', 'tmp'), root)
+    end
+
+    def deprecator
+      @deprecator ||= ActiveSupport::Deprecation.new("#{CarrierWave::VERSION.split('.')[0].to_i + 1}.0", "CarrierWave")
     end
   end
 
@@ -62,6 +67,10 @@ elsif defined?(Rails)
         ActiveSupport.on_load :active_record do
           require 'carrierwave/orm/activerecord'
         end
+      end
+
+      initializer "carrierwave.deprecator" do |app|
+        app.deprecators[:carrierwave] = CarrierWave.deprecator
       end
 
       config.before_eager_load do

--- a/lib/carrierwave/processing/rmagick.rb
+++ b/lib/carrierwave/processing/rmagick.rb
@@ -381,7 +381,7 @@ module CarrierWave
       proc do |img|
         options.each do |k, v|
           if v.is_a?(String) && (matches = v.match(/^["'](.+)["']/))
-            ActiveSupport::Deprecation.warn "Passing quoted strings like #{v} to #manipulate! is deprecated, pass them without quoting."
+            CarrierWave.deprecator.warn "Passing quoted strings like #{v} to #manipulate! is deprecated, pass them without quoting."
             v = matches[1]
           end
           img.public_send(:"#{k}=", v)

--- a/lib/carrierwave/uploader/cache.rb
+++ b/lib/carrierwave/uploader/cache.rb
@@ -90,9 +90,9 @@ module CarrierWave
       end
 
       def sanitized_file
-        ActiveSupport::Deprecation.warn('#sanitized_file is deprecated, use #file instead.')
         file
       end
+      CarrierWave.deprecator.warn('#sanitized_file is deprecated, use #file instead.')
 
       ##
       # Returns a String which uniquely identifies the currently cached file for later retrieval

--- a/lib/carrierwave/uploader/cache.rb
+++ b/lib/carrierwave/uploader/cache.rb
@@ -92,7 +92,9 @@ module CarrierWave
       def sanitized_file
         file
       end
-      CarrierWave.deprecator.warn('#sanitized_file is deprecated, use #file instead.')
+
+      # NOTE: this emits a deprecation warning only when `sanitized_file` is actually called.
+      CarrierWave.deprecator.deprecate_methods(self, sanitized_file: :file)
 
       ##
       # Returns a String which uniquely identifies the currently cached file for later retrieval

--- a/lib/carrierwave/uploader/configuration.rb
+++ b/lib/carrierwave/uploader/configuration.rb
@@ -154,19 +154,19 @@ module CarrierWave
         def add_deprecated_config(name)
           class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def self.#{name}(value=nil)
-              ActiveSupport::Deprecation.warn "##{name} is deprecated and has no effect"
+              CarrierWave.deprecator.warn "##{name} is deprecated and has no effect"
             end
 
             def self.#{name}=(value)
-              ActiveSupport::Deprecation.warn "##{name} is deprecated and has no effect"
+              CarrierWave.deprecator.warn "##{name} is deprecated and has no effect"
             end
 
             def #{name}=(value)
-              ActiveSupport::Deprecation.warn "##{name} is deprecated and has no effect"
+              CarrierWave.deprecator.warn "##{name} is deprecated and has no effect"
             end
 
             def #{name}
-              ActiveSupport::Deprecation.warn "##{name} is deprecated and has no effect"
+              CarrierWave.deprecator.warn "##{name} is deprecated and has no effect"
             end
           RUBY
         end

--- a/lib/carrierwave/uploader/content_type_allowlist.rb
+++ b/lib/carrierwave/uploader/content_type_allowlist.rb
@@ -36,7 +36,7 @@ module CarrierWave
       def check_content_type_allowlist!(new_file)
         allowlist = content_type_allowlist
         if !allowlist && respond_to?(:content_type_whitelist) && content_type_whitelist
-          ActiveSupport::Deprecation.warn "#content_type_whitelist is deprecated, use #content_type_allowlist instead." unless instance_variable_defined?(:@content_type_whitelist_warned)
+          CarrierWave.deprecator.warn "#content_type_whitelist is deprecated, use #content_type_allowlist instead." unless instance_variable_defined?(:@content_type_whitelist_warned)
           @content_type_whitelist_warned = true
           allowlist = content_type_whitelist
         end

--- a/lib/carrierwave/uploader/content_type_denylist.rb
+++ b/lib/carrierwave/uploader/content_type_denylist.rb
@@ -36,14 +36,14 @@ module CarrierWave
       def check_content_type_denylist!(new_file)
         denylist = content_type_denylist
         if !denylist && respond_to?(:content_type_blacklist) && content_type_blacklist
-          ActiveSupport::Deprecation.warn "#content_type_blacklist is deprecated, use #content_type_denylist instead." unless instance_variable_defined?(:@content_type_blacklist_warned)
+          CarrierWave.deprecator.warn "#content_type_blacklist is deprecated, use #content_type_denylist instead." unless instance_variable_defined?(:@content_type_blacklist_warned)
           @content_type_blacklist_warned = true
           denylist = content_type_blacklist
         end
 
         return unless denylist
 
-        ActiveSupport::Deprecation.warn "Use of #content_type_denylist is deprecated for the security reason, use #content_type_allowlist instead to explicitly state what are safe to accept" unless instance_variable_defined?(:@content_type_denylist_warned)
+        CarrierWave.deprecator.warn "Use of #content_type_denylist is deprecated for the security reason, use #content_type_allowlist instead to explicitly state what are safe to accept" unless instance_variable_defined?(:@content_type_denylist_warned)
         @content_type_denylist_warned = true
 
         content_type = new_file.content_type

--- a/lib/carrierwave/uploader/extension_allowlist.rb
+++ b/lib/carrierwave/uploader/extension_allowlist.rb
@@ -39,7 +39,7 @@ module CarrierWave
       def check_extension_allowlist!(new_file)
         allowlist = extension_allowlist
         if !allowlist && respond_to?(:extension_whitelist) && extension_whitelist
-          ActiveSupport::Deprecation.warn "#extension_whitelist is deprecated, use #extension_allowlist instead." unless instance_variable_defined?(:@extension_whitelist_warned)
+          CarrierWave.deprecator.warn "#extension_whitelist is deprecated, use #extension_allowlist instead." unless instance_variable_defined?(:@extension_whitelist_warned)
           @extension_whitelist_warned = true
           allowlist = extension_whitelist
         end

--- a/lib/carrierwave/uploader/extension_denylist.rb
+++ b/lib/carrierwave/uploader/extension_denylist.rb
@@ -39,14 +39,14 @@ module CarrierWave
       def check_extension_denylist!(new_file)
         denylist = extension_denylist
         if !denylist && respond_to?(:extension_blacklist) && extension_blacklist
-          ActiveSupport::Deprecation.warn "#extension_blacklist is deprecated, use #extension_denylist instead." unless instance_variable_defined?(:@extension_blacklist_warned)
+          CarrierWave.deprecator.warn "#extension_blacklist is deprecated, use #extension_denylist instead." unless instance_variable_defined?(:@extension_blacklist_warned)
           @extension_blacklist_warned = true
           denylist = extension_blacklist
         end
 
         return unless denylist
 
-        ActiveSupport::Deprecation.warn "Use of #extension_denylist is deprecated for the security reason, use #extension_allowlist instead to explicitly state what are safe to accept" unless instance_variable_defined?(:@extension_denylist_warned)
+        CarrierWave.deprecator.warn "Use of #extension_denylist is deprecated for the security reason, use #extension_allowlist instead to explicitly state what are safe to accept" unless instance_variable_defined?(:@extension_denylist_warned)
         @extension_denylist_warned = true
 
         extension = new_file.extension.to_s

--- a/lib/carrierwave/version.rb
+++ b/lib/carrierwave/version.rb
@@ -1,3 +1,3 @@
 module CarrierWave
-  VERSION = "3.0.0.alpha"
+  VERSION = "3.0.1.alpha"
 end


### PR DESCRIPTION
Fix CarrierWave `sanitized_file` deprecation warning on boot rails server
this change only emits a deprecation warning only when `sanitized_file` is actually called.