### PR TITLE
Relax dependency on image_processing to allow updates to `~> 2.0`

### DIFF
--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", ">= 7.0.0"
   s.add_dependency "activemodel", ">= 7.0.0"
-  s.add_dependency "image_processing", "~> 1.1"
+  s.add_dependency "image_processing", [">= 1.1", "< 3"]
   s.add_dependency "marcel", ">= 1.0.0", "< 2"
   s.add_dependency "addressable", "~> 2.6"
   s.add_dependency "ssrf_filter", "~> 1.0"
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "fog-google", ["~> 1.7", "!= 1.12.1"]
   s.add_development_dependency "fog-local"
   s.add_development_dependency "mini_magick"
+  s.add_development_dependency "ruby-vips"
 
   if RUBY_ENGINE != 'jruby' && ENV['GITHUB_JOB'] != 'rubocop'
     s.add_development_dependency "rmagick", ">= 2.16"

--- a/spec/processing/mini_magick_spec.rb
+++ b/spec/processing/mini_magick_spec.rb
@@ -283,9 +283,7 @@ describe CarrierWave::MiniMagick do
     context "of being configured to use ImageMagick but failing to execute" do
       before do
         allow(MiniMagick).to receive(:processor).and_return(:magick)
-        allow(Open3).to receive(:capture3).and_raise(Errno::ENOENT)
         allow(Open3).to receive(:popen3).and_raise(Errno::ENOENT)
-        allow_any_instance_of(MiniMagick::Shell).to receive(:execute_open3).and_raise(Errno::ENOENT)
       end
 
       it "raises MiniMagick::Error" do
@@ -333,9 +331,7 @@ describe CarrierWave::MiniMagick do
     context "on being configured to use ImageMagick but failing to execute" do
       before do
         allow(MiniMagick).to receive(:processor).and_return(:magick)
-        allow(Open3).to receive(:capture3).and_raise(Errno::ENOENT)
         allow(Open3).to receive(:popen3).and_raise(Errno::ENOENT)
-        allow_any_instance_of(MiniMagick::Shell).to receive(:execute_open3).and_raise(Errno::ENOENT)
       end
       after { MiniMagick.remove_instance_variable(:@processor) if MiniMagick.instance_variable_defined?(:@processor) }
 


### PR DESCRIPTION
Fixes #2825.

Related past work: #2824, #2820