### PR TITLE
Relax marcel dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
       JRUBY_OPTS: --debug
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Update package list
       run: sudo apt update
     - name: Install ImageMagick and setup policy
@@ -65,7 +65,7 @@ jobs:
     name: RuboCop
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", ">= 6.0.0"
   s.add_dependency "activemodel", ">= 6.0.0"
   s.add_dependency "image_processing", "~> 1.1"
-  s.add_dependency "marcel", "~> 1.0"
+  s.add_dependency "marcel", ">= 1.0.0", "< 2"
   s.add_dependency "addressable", "~> 2.6"
   s.add_dependency "ssrf_filter", "~> 1.0"
   s.add_development_dependency "csv", "~> 3.0"

--- a/carrierwave.gemspec
+++ b/carrierwave.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", ">= 6.0.0"
   s.add_dependency "activemodel", ">= 6.0.0"
   s.add_dependency "image_processing", "~> 1.1"
-  s.add_dependency "marcel", "~> 1.0.0"
+  s.add_dependency "marcel", "~> 1.0"
   s.add_dependency "addressable", "~> 2.6"
   s.add_dependency "ssrf_filter", "~> 1.0"
   s.add_development_dependency "csv", "~> 3.0"

--- a/spec/processing/mini_magick_spec.rb
+++ b/spec/processing/mini_magick_spec.rb
@@ -284,6 +284,7 @@ describe CarrierWave::MiniMagick do
       before do
         allow(MiniMagick).to receive(:processor).and_return(:magick)
         allow(Open3).to receive(:capture3).and_raise(Errno::ENOENT)
+        allow(Open3).to receive(:popen3).and_raise(Errno::ENOENT)
         allow_any_instance_of(MiniMagick::Shell).to receive(:execute_open3).and_raise(Errno::ENOENT)
       end
 
@@ -333,6 +334,7 @@ describe CarrierWave::MiniMagick do
       before do
         allow(MiniMagick).to receive(:processor).and_return(:magick)
         allow(Open3).to receive(:capture3).and_raise(Errno::ENOENT)
+        allow(Open3).to receive(:popen3).and_raise(Errno::ENOENT)
         allow_any_instance_of(MiniMagick::Shell).to receive(:execute_open3).and_raise(Errno::ENOENT)
       end
       after { MiniMagick.remove_instance_variable(:@processor) if MiniMagick.instance_variable_defined?(:@processor) }


### PR DESCRIPTION
Marcel is currently locked to 1.0.0 which causes some issue for us. I think most 1.x versions should be fine.

This can replace #2807 

I fixed one unrelated test that broke from `mini_magick` silently upgrading to `5.3.2`