### PR TITLE
docs: add note on store_dir override for standalone uploader

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ class AvatarUploader < CarrierWave::Uploader::Base
 end
 ```
 
+Since the default `#store_dir` depends on a model, override it when using an uploader stand-alone to avoid NoMethodErroron model.id.
+
+```ruby
+def store_dir
+  "upload/avatars"
+end
+```
+
 You can use your uploader class to store and retrieve files like this:
 
 ```ruby


### PR DESCRIPTION
Hi!
I realized the default `store_dir` depends on `model.id`. 
Adding a brief note about this requirement will help other developers avoid the same pitfall when using uploaders directly.

### Summary
Adds a note in the README explaining that standalone uploaders must override `store_dir`.

### Context & Motivation
When trying to use CarrierWave stand-alone (without mounting to a model), I ran into `NoMethodError: undefined method 'id' for nil` and got stuck troubleshooting for a while. 

Many Thanks!🙏